### PR TITLE
Add reading window anchor metrics

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -162,6 +162,38 @@ When updating this file:
 - Repository-wide `npm run lint` still reports pre-existing React hook lint errors in `src/components/app-shell.tsx` and `src/components/settings-preferences.tsx`, which are unrelated to this PRD work.
 - Public/demo mode still lacks a localStorage-backed continuity implementation; live/authenticated mode is the completed path in this branch.
 
+### [2026-04-16 00:11] — PRD 6 Reading Window Anchor
+
+**Agent:**
+- Codex
+
+**Problem addressed:**
+- The dashboard showed a raw reading window string, but not as a behavioral anchor. Users could not clearly see daily load, completion progress, or how today compared with yesterday.
+
+**Root cause:**
+- Reading time existed only as per-item `estimatedMinutes` and a simple briefing-level string.
+- There was no shared metric layer converting PRD 5 read state into a progress-oriented reading window model.
+
+**Change made:**
+- Added a shared `reading-window` helper that deterministically computes per-event reading time from content length with a stable fallback, aggregates total/completed/remaining minutes, calculates progress ratio, parses prior reading-window history, and interprets day load as `Light`, `Normal`, or `Heavy` using configurable constants.
+- Wired the dashboard data layer to compute reading metrics from existing PRD 5 `read` state and compare the current briefing against the latest prior saved briefing without introducing any new tracking system.
+- Updated the dashboard UI so reading time is shown as a top anchor metric with total minutes, delta vs yesterday, day intensity, progress text, and a progress bar, while leaving PRD 5 completion messaging unchanged.
+- Extended the refresh card to echo progress in the compact reading-window module.
+- Added unit tests for deterministic time calculation, progress aggregation, delta formatting, parsing, and intensity thresholds.
+
+**Files modified:**
+- `src/lib/types.ts`
+- `src/lib/reading-window.ts`
+- `src/lib/reading-window.test.ts`
+- `src/lib/data.ts`
+- `src/app/dashboard/page.tsx`
+- `src/components/dashboard/manual-refresh-trigger.tsx`
+- `PROJECT.md`
+
+**Remaining risks / next steps:**
+- Public/demo mode compares against sample history only; live accuracy for day-over-day comparison still depends on users having at least one prior saved briefing.
+- Repository-wide `npm run lint` still includes unrelated pre-existing React hook lint errors outside this PRD scope.
+
 ---
 
 ## 8. NEXT ACTION (FOCUS)

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { Panel } from "@/components/ui/panel";
 import { getDisplayStateLabel, getDisplayStateTone } from "@/lib/habit-loop";
 import { getDashboardData, getViewerAccount } from "@/lib/data";
 import { isAiConfigured } from "@/lib/env";
+import { formatReadingDelta, formatReadingWindow } from "@/lib/reading-window";
 import { formatBriefingDate } from "@/lib/utils";
 
 export const metadata: Metadata = {
@@ -48,6 +49,7 @@ export default async function DashboardPage({
   const canTrackProgress = data.mode === "live" && trackableItems.length > 0;
   const isCaughtUp = canTrackProgress && trackableItems.every((item) => item.read);
   const sessionSummary = data.briefing.sessionSummary;
+  const readingMetrics = data.briefing.readingMetrics;
   const serializedEventStates = JSON.stringify(
     trackableItems.map((item) => ({
       eventKey: item.continuityKey,
@@ -66,6 +68,7 @@ export default async function DashboardPage({
           aside={
             <ManualRefreshTrigger
               readingWindow={data.briefing.readingWindow}
+              readingMetrics={readingMetrics}
               isAiConfigured={isAiConfigured}
             />
           }
@@ -81,6 +84,51 @@ export default async function DashboardPage({
           <div className="rounded-[22px] border border-[var(--line)] bg-white/70 px-5 py-4 text-sm font-medium text-[var(--foreground)]">
             All events marked as read.
           </div>
+        ) : null}
+
+        {readingMetrics ? (
+          <Panel className="p-5">
+            <div className="flex flex-col gap-5 xl:flex-row xl:items-center xl:justify-between">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
+                  Reading window
+                </p>
+                <div className="mt-2 flex flex-wrap items-end gap-3">
+                  <h2 className="text-4xl font-semibold tracking-tight text-[var(--foreground)]">
+                    {formatReadingWindow(readingMetrics.totalMinutes)}
+                  </h2>
+                  <p className="pb-1 text-sm font-medium text-[var(--muted)]">
+                    today
+                  </p>
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  <Badge>{formatReadingDelta(readingMetrics.deltaVsYesterday)}</Badge>
+                  <Badge>{readingMetrics.intensity} day</Badge>
+                </div>
+              </div>
+              <div className="min-w-0 xl:w-[360px]">
+                <div className="flex items-center justify-between gap-3 text-sm">
+                  <p className="font-medium text-[var(--foreground)]">
+                    {readingMetrics.progressLabel}
+                  </p>
+                  <p className="text-[var(--muted)]">
+                    {Math.round(readingMetrics.progressRatio * 100)}%
+                  </p>
+                </div>
+                <div className="mt-3 h-3 overflow-hidden rounded-full bg-[rgba(31,79,70,0.08)]">
+                  <div
+                    className="h-full rounded-full bg-[var(--accent)] transition-[width] duration-300"
+                    style={{ width: `${Math.round(readingMetrics.progressRatio * 100)}%` }}
+                  />
+                </div>
+                <p className="mt-2 text-sm text-[var(--muted)]">
+                  {readingMetrics.remainingMinutes === 0
+                    ? "All reading minutes for today are complete."
+                    : `${readingMetrics.remainingMinutes} min remaining in today’s scan.`}
+                </p>
+              </div>
+            </div>
+          </Panel>
         ) : null}
 
         {sessionSummary ? (

--- a/src/components/dashboard/manual-refresh-trigger.tsx
+++ b/src/components/dashboard/manual-refresh-trigger.tsx
@@ -6,13 +6,16 @@ import { useFormStatus } from "react-dom";
 
 import { generateBriefingAction } from "@/app/actions";
 import { Button } from "@/components/ui/button";
+import type { ReadingWindowMetrics } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 export function ManualRefreshTrigger({
   readingWindow,
+  readingMetrics,
   isAiConfigured,
 }: {
   readingWindow: string;
+  readingMetrics?: ReadingWindowMetrics;
   isAiConfigured: boolean;
 }) {
   return (
@@ -24,6 +27,11 @@ export function ManualRefreshTrigger({
         <p className="mt-1 text-xl font-semibold text-[var(--foreground)]">
           {readingWindow}
         </p>
+        {readingMetrics ? (
+          <p className="mt-1 text-xs font-medium text-[var(--muted)]">
+            {readingMetrics.progressLabel}
+          </p>
+        ) : null}
       </div>
       {isAiConfigured ? (
         <form action={generateBriefingAction}>

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/habit-loop";
 import { countSourcesByHomepageCategory } from "@/lib/homepage-taxonomy";
 import { logServerEvent } from "@/lib/observability";
+import { calculateReadingWindow, formatReadingWindow, parseReadingWindowMinutes } from "@/lib/reading-window";
 import { selectRelatedCoverage } from "@/lib/related-coverage";
 import { rankNewsClusters } from "@/lib/ranking";
 import { clusterArticles, fetchFeedArticles, type FeedArticle } from "@/lib/rss";
@@ -77,12 +78,14 @@ type UserEventStateRow = {
 };
 
 function createEmptyBriefing(): DailyBriefing {
+  const readingMetrics = calculateReadingWindow([]);
+
   return {
     id: `generated-empty-${Date.now()}`,
     briefingDate: formatISO(new Date()),
     title: "Today's Briefing",
     intro: "No clustered events yet for your current topics. Try adjusting keywords or refreshing your briefing.",
-    readingWindow: "0 minutes",
+    readingWindow: formatReadingWindow(readingMetrics.totalMinutes),
     items: [],
     sessionSummary: {
       reviewedCount: 0,
@@ -90,6 +93,7 @@ function createEmptyBriefing(): DailyBriefing {
       changedCount: 0,
       escalatedCount: 0,
     },
+    readingMetrics,
   };
 }
 
@@ -214,6 +218,9 @@ export async function getDashboardData(): Promise<DashboardData> {
   await syncEventClusters(supabase, user.id, topics, sources);
 
   const briefing = await buildMatchedBriefing(supabase, user.id, topics, sources);
+  const priorReadingWindow = await getPreviousReadingWindow(supabase, user.id, briefing.briefingDate);
+  briefing.readingMetrics = calculateReadingWindow(briefing.items, priorReadingWindow);
+  briefing.readingWindow = formatReadingWindow(briefing.readingMetrics.totalMinutes);
   const homepageDiagnostics = await buildHomepageDiagnostics(supabase, user.id, sources);
 
   return {
@@ -227,6 +234,12 @@ export async function getDashboardData(): Promise<DashboardData> {
 
 async function getPublicDashboardData(): Promise<DashboardData> {
   const briefing = await generateDailyBriefing(demoTopics, demoSources);
+  const yesterday = demoHistory.find((entry) => entry.id === "briefing-yesterday") ?? demoHistory[1];
+  briefing.readingMetrics = calculateReadingWindow(
+    briefing.items,
+    parseReadingWindowMinutes(yesterday?.readingWindow),
+  );
+  briefing.readingWindow = formatReadingWindow(briefing.readingMetrics.totalMinutes);
 
   return {
     mode: "public",
@@ -283,33 +296,38 @@ export async function getHistory() {
 
   return data.map(
     (briefing): DailyBriefing => ({
+      ...(function () {
+        const items =
+          briefing.briefing_items?.map((item) => ({
+            id: item.id,
+            topicId: item.topic_id,
+            topicName: item.topic_name,
+            title: item.title,
+            whatHappened: item.what_happened,
+            keyPoints: item.key_points as [string, string, string],
+            whyItMatters: item.why_it_matters,
+            sources: (item.sources as Array<{ title: string; url: string }>) ?? [],
+            sourceCount: ((item.sources as Array<{ title: string; url: string }>) ?? []).length,
+            estimatedMinutes: item.estimated_minutes,
+            read: item.is_read,
+            priority: item.priority,
+            matchedKeywords: extractMatchedKeywords(item.key_points as string[]),
+            importanceScore: undefined,
+            importanceLabel: undefined,
+            rankingSignals: [],
+          })) ?? [];
+        const readingMetrics = calculateReadingWindow(items);
+
+        return {
+          items,
+          readingMetrics,
+          readingWindow: formatReadingWindow(readingMetrics.totalMinutes),
+        };
+      })(),
       id: briefing.id,
       briefingDate: briefing.briefing_date,
       title: briefing.title,
       intro: briefing.intro,
-      items:
-        briefing.briefing_items?.map((item) => ({
-          id: item.id,
-          topicId: item.topic_id,
-          topicName: item.topic_name,
-          title: item.title,
-          whatHappened: item.what_happened,
-          keyPoints: item.key_points as [string, string, string],
-          whyItMatters: item.why_it_matters,
-          sources: (item.sources as Array<{ title: string; url: string }>) ?? [],
-          sourceCount: ((item.sources as Array<{ title: string; url: string }>) ?? []).length,
-          estimatedMinutes: item.estimated_minutes,
-          read: item.is_read,
-          priority: item.priority,
-          matchedKeywords: extractMatchedKeywords(item.key_points as string[]),
-          importanceScore: undefined,
-          importanceLabel: undefined,
-          rankingSignals: [],
-        })) ?? [],
-      readingWindow: deriveReadingWindow(
-        briefing.briefing_items?.map((item) => item.estimated_minutes) ?? [],
-        briefing.reading_window,
-      ),
     }),
   );
 }
@@ -390,15 +408,16 @@ export async function generateDailyBriefing(
       : createEmptyBriefing();
   }
 
-  const totalMinutes = validItems.reduce((sum, item) => sum + item.estimatedMinutes, 0);
+  const readingMetrics = calculateReadingWindow(validItems);
 
   return {
     id: `generated-${Date.now()}`,
     briefingDate: formatISO(new Date()),
     title: "Daily Executive Briefing",
     intro: "A concise scan of the events most likely to affect decisions today.",
-    readingWindow: `${totalMinutes} minutes`,
+    readingWindow: formatReadingWindow(readingMetrics.totalMinutes),
     items: validItems,
+    readingMetrics,
   };
 }
 
@@ -809,15 +828,46 @@ export async function buildMatchedBriefing(
     };
   });
 
+  const readingMetrics = calculateReadingWindow(items);
+
   return {
     id: `generated-${Date.now()}`,
     briefingDate: formatISO(new Date()),
     title: "Today's Briefing",
     intro: "Related reporting is clustered into events so you can scan developments instead of isolated articles.",
-    readingWindow: `${items.reduce((sum, item) => sum + item.estimatedMinutes, 0)} minutes`,
+    readingWindow: formatReadingWindow(readingMetrics.totalMinutes),
     items,
     sessionSummary: summarizeSessionStates(items),
+    readingMetrics,
   };
+}
+
+async function getPreviousReadingWindow(
+  supabase: SupabaseServerClient,
+  userId: string,
+  briefingDate: string,
+) {
+  const currentDate = briefingDate.slice(0, 10);
+  const result = await supabase
+    .from("daily_briefings")
+    .select("reading_window, briefing_date")
+    .eq("user_id", userId)
+    .lt("briefing_date", currentDate)
+    .order("briefing_date", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (result.error) {
+    logServerEvent("warn", "Previous reading window lookup failed", {
+      route: "/dashboard",
+      userId,
+      briefingDate: currentDate,
+      errorMessage: result.error.message,
+    });
+    return null;
+  }
+
+  return parseReadingWindowMinutes(result.data?.reading_window);
 }
 
 export async function persistRawArticles(
@@ -1247,9 +1297,4 @@ function createArticleDedupeKey(title: string, url: string) {
   return createHash("sha256")
     .update(`${title.trim().toLowerCase()}::${url.trim().toLowerCase()}`)
     .digest("hex");
-}
-
-function deriveReadingWindow(estimatedMinutes: number[], fallback: string) {
-  const totalMinutes = estimatedMinutes.reduce((sum, minutes) => sum + minutes, 0);
-  return totalMinutes > 0 ? `${totalMinutes} minutes` : fallback;
 }

--- a/src/lib/reading-window.test.ts
+++ b/src/lib/reading-window.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  calculateReadingTime,
+  calculateReadingWindow,
+  formatReadingDelta,
+  formatReadingWindow,
+  interpretReadingWindow,
+  parseReadingWindowMinutes,
+} from "@/lib/reading-window";
+import type { BriefingItem } from "@/lib/types";
+
+describe("reading window helpers", () => {
+  it("calculates deterministic reading time from event content", () => {
+    const item = createItem({
+      title: "A".repeat(20),
+      whatHappened: "word ".repeat(120),
+      whyItMatters: "impact ".repeat(90),
+    });
+
+    expect(calculateReadingTime(item)).toBeGreaterThanOrEqual(2);
+  });
+
+  it("computes total and completed progress from existing read state", () => {
+    const unread = createItem({
+      title: "Market update",
+      whatHappened: "word ".repeat(120),
+      whyItMatters: "impact ".repeat(60),
+      read: false,
+    });
+    const read = createItem({
+      title: "Policy shift",
+      whatHappened: "word ".repeat(140),
+      whyItMatters: "impact ".repeat(80),
+      read: true,
+    });
+
+    const metrics = calculateReadingWindow([unread, read], 3);
+
+    expect(metrics.totalMinutes).toBeGreaterThan(metrics.completedMinutes);
+    expect(metrics.completedMinutes).toBeGreaterThan(0);
+    expect(metrics.progressLabel).toContain("min completed");
+    expect(metrics.deltaVsYesterday).toBe(metrics.totalMinutes - 3);
+  });
+
+  it("interprets day intensity from configurable thresholds", () => {
+    expect(interpretReadingWindow(6)).toBe("Light");
+    expect(interpretReadingWindow(18)).toBe("Normal");
+    expect(interpretReadingWindow(32)).toBe("Heavy");
+  });
+
+  it("parses historical reading window strings", () => {
+    expect(parseReadingWindowMinutes("18 min")).toBe(18);
+    expect(parseReadingWindowMinutes("34 minutes")).toBe(34);
+    expect(parseReadingWindowMinutes("")).toBeNull();
+  });
+
+  it("formats reading window and delta copy", () => {
+    expect(formatReadingWindow(18)).toBe("18 min");
+    expect(formatReadingDelta(5)).toBe("+5 min vs yesterday");
+    expect(formatReadingDelta(0)).toBe("No change vs yesterday");
+    expect(formatReadingDelta(null)).toBe("First tracked day");
+  });
+});
+
+function createItem(overrides: Partial<BriefingItem>): BriefingItem {
+  return {
+    id: overrides.id ?? "item-1",
+    topicId: overrides.topicId ?? "topic-1",
+    topicName: overrides.topicName ?? "Finance",
+    title: overrides.title ?? "Generic event",
+    whatHappened: overrides.whatHappened ?? "A generic development happened.",
+    keyPoints: overrides.keyPoints ?? ["Point one", "Point two", "Point three"],
+    whyItMatters: overrides.whyItMatters ?? "It matters because it changes expectations.",
+    sources: overrides.sources ?? [{ title: "Reuters", url: "https://example.com" }],
+    estimatedMinutes: overrides.estimatedMinutes ?? 4,
+    read: overrides.read ?? false,
+    priority: overrides.priority ?? "normal",
+  };
+}

--- a/src/lib/reading-window.ts
+++ b/src/lib/reading-window.ts
@@ -1,0 +1,94 @@
+import type { BriefingItem, ReadingWindowIntensity, ReadingWindowMetrics } from "@/lib/types";
+
+const WORDS_PER_MINUTE = 140;
+const DEFAULT_READING_TIME_MINUTES = 4;
+const LIGHT_DAY_MAX_MINUTES = 9;
+const NORMAL_DAY_MAX_MINUTES = 25;
+
+export function calculateReadingTime(item: Pick<
+  BriefingItem,
+  "title" | "whatHappened" | "keyPoints" | "whyItMatters" | "estimatedMinutes"
+>) {
+  const content = [item.title, item.whatHappened, ...(item.keyPoints ?? []), item.whyItMatters]
+    .filter(Boolean)
+    .join(" ");
+  const wordCount = countWords(content);
+
+  if (wordCount > 0) {
+    return Math.max(1, Math.ceil(wordCount / WORDS_PER_MINUTE));
+  }
+
+  return Math.max(1, Math.round(item.estimatedMinutes ?? DEFAULT_READING_TIME_MINUTES));
+}
+
+export function calculateReadingWindow(
+  items: BriefingItem[],
+  previousTotalMinutes: number | null = null,
+): ReadingWindowMetrics {
+  const totalMinutes = items.reduce((sum, item) => sum + calculateReadingTime(item), 0);
+  const completedMinutes = items
+    .filter((item) => item.read)
+    .reduce((sum, item) => sum + calculateReadingTime(item), 0);
+  const remainingMinutes = Math.max(0, totalMinutes - completedMinutes);
+  const progressRatio = totalMinutes === 0 ? 0 : completedMinutes / totalMinutes;
+
+  return {
+    totalMinutes,
+    completedMinutes,
+    remainingMinutes,
+    progressRatio,
+    progressLabel: `${completedMinutes} / ${totalMinutes} min completed`,
+    deltaVsYesterday:
+      previousTotalMinutes === null ? null : totalMinutes - previousTotalMinutes,
+    intensity: interpretReadingWindow(totalMinutes),
+  };
+}
+
+export function interpretReadingWindow(totalMinutes: number): ReadingWindowIntensity {
+  if (totalMinutes <= LIGHT_DAY_MAX_MINUTES) {
+    return "Light";
+  }
+
+  if (totalMinutes <= NORMAL_DAY_MAX_MINUTES) {
+    return "Normal";
+  }
+
+  return "Heavy";
+}
+
+export function formatReadingWindow(totalMinutes: number) {
+  return `${totalMinutes} min`;
+}
+
+export function formatReadingDelta(deltaVsYesterday: number | null) {
+  if (deltaVsYesterday === null) {
+    return "First tracked day";
+  }
+
+  if (deltaVsYesterday === 0) {
+    return "No change vs yesterday";
+  }
+
+  return `${deltaVsYesterday > 0 ? "+" : ""}${deltaVsYesterday} min vs yesterday`;
+}
+
+export function parseReadingWindowMinutes(value: string | null | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  const match = value.match(/-?\d+/);
+  if (!match) {
+    return null;
+  }
+
+  const parsed = Number(match[0]);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function countWords(value: string) {
+  return value
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean).length;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -79,6 +79,19 @@ export type DailyBriefing = {
     changedCount: number;
     escalatedCount: number;
   };
+  readingMetrics?: ReadingWindowMetrics;
+};
+
+export type ReadingWindowIntensity = "Light" | "Normal" | "Heavy";
+
+export type ReadingWindowMetrics = {
+  totalMinutes: number;
+  completedMinutes: number;
+  remainingMinutes: number;
+  progressRatio: number;
+  progressLabel: string;
+  deltaVsYesterday: number | null;
+  intensity: ReadingWindowIntensity;
 };
 
 export type DashboardData = {


### PR DESCRIPTION
## Summary
- add shared reading-window metric helpers for total, completed, remaining, delta, and intensity
- compute dashboard reading metrics from existing PRD 5 read state and prior briefing history
- surface the reading window as a top dashboard anchor without duplicating PRD 5 behavior

## Testing
- npm test
- npm run build