### PR TITLE
PRD 8: Event-centric differentiation layer

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,18 +1,19 @@
 import type { Metadata } from "next";
-import { CheckCheck, ExternalLink } from "lucide-react";
+import { CheckCheck, CheckCircle2, Circle, ExternalLink } from "lucide-react";
 
-import { markAllReadAction } from "@/app/actions";
-import { PageHeader } from "@/components/page-header";
-import { StoryCard } from "@/components/story-card";
+import { markAllReadAction, toggleReadAction } from "@/app/actions";
 import { AppShell } from "@/components/app-shell";
 import { ManualRefreshTrigger } from "@/components/dashboard/manual-refresh-trigger";
+import { PageHeader } from "@/components/page-header";
 import { Badge } from "@/components/ui/badge";
 import { Panel } from "@/components/ui/panel";
-import { getDisplayStateLabel, getDisplayStateTone } from "@/lib/habit-loop";
 import { getDashboardData, getViewerAccount } from "@/lib/data";
+import { buildEventIntelligenceSignals, isTopEventEligible } from "@/lib/event-intelligence";
 import { isAiConfigured } from "@/lib/env";
+import { getDisplayStateLabel, getDisplayStateTone } from "@/lib/habit-loop";
 import { formatReadingDelta, formatReadingWindow } from "@/lib/reading-window";
-import { formatBriefingDate } from "@/lib/utils";
+import type { BriefingItem } from "@/lib/types";
+import { cn, formatBriefingDate, minutesToLabel } from "@/lib/utils";
 
 export const metadata: Metadata = {
   title: "Today's Briefing — Daily Intelligence",
@@ -27,21 +28,25 @@ export default async function DashboardPage({
   const data = await getDashboardData();
   const viewer = await getViewerAccount();
 
-  // Deduplicate: top-priority items shown in priority scan, not repeated in topic sections
-  const topEvents = data.briefing.items.filter((item) => item.priority === "top");
+  const sortedItems = data.briefing.items.slice().sort((left, right) => {
+    const scoreDelta = (right.importanceScore ?? right.matchScore ?? 0) - (left.importanceScore ?? left.matchScore ?? 0);
+    if (scoreDelta !== 0) return scoreDelta;
+    const rightPublished = right.publishedAt ? new Date(right.publishedAt).getTime() : 0;
+    const leftPublished = left.publishedAt ? new Date(left.publishedAt).getTime() : 0;
+    return rightPublished - leftPublished;
+  });
+
+  const topEvents = sortedItems.filter((item) => isTopEventEligible(item)).slice(0, 4);
   const topEventIds = new Set(topEvents.map((item) => item.id));
-  const grouped = data.topics.map((topic) => ({
-    topic,
-    items: data.briefing.items
-      .filter((item) => item.topicId === topic.id && !topEventIds.has(item.id))
-      .sort((left, right) => {
-        const scoreDelta = (right.matchScore ?? 0) - (left.matchScore ?? 0);
-        if (scoreDelta !== 0) return scoreDelta;
-        const rightPublished = right.publishedAt ? new Date(right.publishedAt).getTime() : 0;
-        const leftPublished = left.publishedAt ? new Date(left.publishedAt).getTime() : 0;
-        return rightPublished - leftPublished;
-      }),
-  }));
+  const earlySignals = sortedItems.filter((item) => !isTopEventEligible(item));
+  const topicBriefs = data.topics.map((topic) => {
+    const items = sortedItems.filter((item) => item.topicId === topic.id && !topEventIds.has(item.id));
+    return {
+      topic,
+      confirmed: items.filter((item) => isTopEventEligible(item)).slice(0, 2),
+      early: items.filter((item) => !isTopEventEligible(item)).slice(0, 2),
+    };
+  });
 
   const trackableItems = data.briefing.items.filter(
     (item) => item.continuityKey && item.continuityFingerprint,
@@ -64,7 +69,7 @@ export default async function DashboardPage({
         <PageHeader
           eyebrow={formatBriefingDate(data.briefing.briefingDate)}
           title={data.briefing.title}
-          description={data.briefing.intro}
+          description="A structured intelligence briefing with confirmed event clusters first, early signals separated, and ranking logic exposed on every card."
           aside={
             <ManualRefreshTrigger
               readingWindow={data.briefing.readingWindow}
@@ -74,7 +79,6 @@ export default async function DashboardPage({
           }
         />
 
-        {/* Feedback banners */}
         {params.generated === "1" ? (
           <div className="rounded-[22px] border border-[rgba(31,79,70,0.18)] bg-[rgba(31,79,70,0.06)] px-5 py-4 text-sm font-medium text-[var(--accent)]">
             Fresh briefing generated successfully.
@@ -97,9 +101,7 @@ export default async function DashboardPage({
                   <h2 className="text-4xl font-semibold tracking-tight text-[var(--foreground)]">
                     {formatReadingWindow(readingMetrics.totalMinutes)}
                   </h2>
-                  <p className="pb-1 text-sm font-medium text-[var(--muted)]">
-                    today
-                  </p>
+                  <p className="pb-1 text-sm font-medium text-[var(--muted)]">today</p>
                 </div>
                 <div className="mt-2 flex flex-wrap gap-2">
                   <Badge>{formatReadingDelta(readingMetrics.deltaVsYesterday)}</Badge>
@@ -142,7 +144,7 @@ export default async function DashboardPage({
                   What changed since yesterday
                 </h2>
                 <p className="mt-1 text-sm text-[var(--muted)]">
-                  New signals are surfaced first, updates stay visible, and the feed closes with a calm caught-up moment.
+                  New signals surface first, updates stay visible, and single-source items are kept separate from the confirmed event layer.
                 </p>
               </div>
               <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
@@ -155,7 +157,6 @@ export default async function DashboardPage({
           </Panel>
         ) : null}
 
-        {/* Priority scan + coverage map */}
         <section className="grid gap-5 xl:grid-cols-[1.2fr_0.8fr]">
           <Panel className="p-5">
             <div className="flex flex-wrap items-center justify-between gap-3">
@@ -166,6 +167,9 @@ export default async function DashboardPage({
                 <h2 className="mt-1.5 text-xl font-semibold text-[var(--foreground)]">
                   Top events today
                 </h2>
+                <p className="mt-1 text-sm text-[var(--muted)]">
+                  Only event clusters with corroborating source coverage appear here.
+                </p>
               </div>
               <div className="flex items-center gap-2">
                 <Badge>{topEvents.length} {topEvents.length === 1 ? "event" : "events"}</Badge>
@@ -184,132 +188,117 @@ export default async function DashboardPage({
                 ) : null}
               </div>
             </div>
-            <div className="mt-5 grid gap-3">
-              {topEvents.map((event) => {
-                const primarySourceUrl = event.sources.find((source) => isValidStoryUrl(source.url))?.url;
-                const sourceCount = event.sourceCount ?? event.sources.length;
-
-                return (
-                  <div
-                    key={event.id}
-                    className="rounded-[20px] border border-[var(--line)] bg-white/60 p-4"
-                  >
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Badge>{event.topicName}</Badge>
-                      <Badge className="text-[var(--accent)]">Top event</Badge>
-                      {getDisplayStateLabel(event.displayState) ? (
-                        <Badge className={getDisplayStateTone(event.displayState)}>
-                          {getDisplayStateLabel(event.displayState)}
-                        </Badge>
-                      ) : null}
-                      <Badge>{sourceCount} {sourceCount === 1 ? "source" : "sources"}</Badge>
-                    </div>
-                    {primarySourceUrl ? (
-                      <a
-                        href={primarySourceUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="mt-3 inline-flex items-start gap-2 text-base font-semibold leading-snug text-[var(--foreground)] underline-offset-4 hover:underline"
-                      >
-                        <span>{event.title}</span>
-                        <ExternalLink className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--muted)]" />
-                      </a>
-                    ) : (
-                      <div className="mt-3">
-                        <h3 className="text-base font-semibold leading-snug text-[var(--foreground)]">
-                          {event.title}
-                        </h3>
-                        <p className="mt-1 text-xs font-medium uppercase tracking-[0.18em] text-[var(--muted)]">
-                          Source unavailable
-                        </p>
-                      </div>
-                    )}
-                    {event.matchedKeywords?.length ? (
-                      <p className="mt-2 text-sm font-medium text-[var(--accent)]">
-                        Matched on: {event.matchedKeywords.join(", ")}
-                      </p>
-                    ) : null}
-                    <p className="mt-2 text-sm leading-6 text-[var(--muted)] line-clamp-2">
-                      {event.whatHappened}
-                    </p>
-                  </div>
-                );
-              })}
+            <div className="mt-5 grid gap-4">
+              {topEvents.length ? (
+                topEvents.map((event) => <DashboardEventCard key={event.id} item={event} tone="confirmed" />)
+              ) : (
+                <Panel className="border-dashed border-[var(--line)] bg-white/40 p-5 text-sm leading-7 text-[var(--muted)]">
+                  No multi-source event clusters qualified yet. Early signals will remain below until more corroborating coverage arrives.
+                </Panel>
+              )}
             </div>
           </Panel>
 
-          {/* Coverage map — sticky on desktop */}
           <div className="xl:sticky xl:top-4 xl:self-start">
             <Panel className="p-5">
               <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
                 Coverage map
               </p>
               <p className="mt-1 text-sm text-[var(--muted)]">
-                Events by topic in today&apos;s briefing
+                Topic-by-topic event posture for today&apos;s briefing
               </p>
               <div className="mt-4 space-y-3">
-                {grouped.map(({ topic }) => {
-                  const total = data.briefing.items.filter((i) => i.topicId === topic.id).length;
-                  return (
-                    <a
-                      key={topic.id}
-                      href={`#topic-${topic.id}`}
-                      className="flex items-center justify-between gap-3 rounded-[18px] border border-[var(--line)] bg-white/60 px-4 py-3 transition-colors hover:bg-white"
-                    >
-                      <div className="flex items-center gap-3 min-w-0">
-                        <span
-                          className="h-2.5 w-2.5 shrink-0 rounded-full"
-                          style={{ backgroundColor: topic.color }}
-                        />
-                        <div className="min-w-0">
-                          <p className="text-sm font-semibold text-[var(--foreground)]">
-                            {topic.name}
-                          </p>
-                          <p className="truncate text-xs text-[var(--muted)]">
-                            {topic.description}
-                          </p>
-                        </div>
+                {topicBriefs.map(({ topic, confirmed, early }) => (
+                  <a
+                    key={topic.id}
+                    href={`#topic-${topic.id}`}
+                    className="flex items-center justify-between gap-3 rounded-[18px] border border-[var(--line)] bg-white/60 px-4 py-3 transition-colors hover:bg-white"
+                  >
+                    <div className="flex items-center gap-3 min-w-0">
+                      <span
+                        className="h-2.5 w-2.5 shrink-0 rounded-full"
+                        style={{ backgroundColor: topic.color }}
+                      />
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold text-[var(--foreground)]">{topic.name}</p>
+                        <p className="truncate text-xs text-[var(--muted)]">{topic.description}</p>
                       </div>
-                      <Badge>{total} {total === 1 ? "event" : "events"}</Badge>
-                    </a>
-                  );
-                })}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Badge>{confirmed.length} confirmed</Badge>
+                      {early.length ? <Badge className="text-[#8a5a11]">{early.length} early</Badge> : null}
+                    </div>
+                  </a>
+                ))}
               </div>
             </Panel>
           </div>
         </section>
 
-        {/* Topic sections — deduplicated */}
         <section className="space-y-6">
-          {grouped.map(({ topic, items }) => (
-            <div key={topic.id} id={`topic-${topic.id}`} className="scroll-mt-6 space-y-3">
-              <div className="flex items-center gap-3">
-                <span
-                  className="h-2.5 w-2.5 rounded-full"
-                  style={{ backgroundColor: topic.color }}
-                />
-                <div>
-                  <h2 className="display-font text-2xl text-[var(--foreground)]">
-                    {topic.name}
-                  </h2>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
+              Topic briefings
+            </p>
+            <h2 className="mt-1 text-2xl font-semibold text-[var(--foreground)]">
+              Compact event view by topic
+            </h2>
+            <p className="mt-2 text-sm text-[var(--muted)]">
+              Each topic is capped so the dashboard stays high-signal rather than turning into a feed.
+            </p>
+          </div>
+          {topicBriefs.map(({ topic, confirmed, early }) => (
+            <Panel key={topic.id} id={`topic-${topic.id}`} className="scroll-mt-6 p-5">
+              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div className="flex items-center gap-3">
+                  <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: topic.color }} />
+                  <div>
+                    <h2 className="display-font text-2xl text-[var(--foreground)]">{topic.name}</h2>
+                    <p className="text-sm text-[var(--muted)]">{topic.description}</p>
+                  </div>
                 </div>
-                <p className="hidden text-sm text-[var(--muted)] md:block">{topic.description}</p>
+                <div className="flex flex-wrap gap-2">
+                  <Badge>{confirmed.length} confirmed events</Badge>
+                  {early.length ? <Badge className="text-[#8a5a11]">{early.length} early signals</Badge> : null}
+                </div>
               </div>
-              {items.length ? (
-                <div className="grid gap-4">
-                  {items.map((item) => (
-                    <StoryCard key={item.id} item={item} />
+
+              {confirmed.length || early.length ? (
+                <div className="mt-5 grid gap-4 xl:grid-cols-2">
+                  {confirmed.map((item) => (
+                    <DashboardEventCard key={item.id} item={item} tone="confirmed" compact />
+                  ))}
+                  {early.map((item) => (
+                    <DashboardEventCard key={item.id} item={item} tone="early" compact />
                   ))}
                 </div>
               ) : (
-                <Panel className="p-5 text-sm leading-7 text-[var(--muted)]">
-                  <p className="font-medium text-[var(--foreground)]">No clustered events yet for this topic.</p>
-                  <p>Try adjusting keywords or refreshing your briefing.</p>
-                </Panel>
+                <div className="mt-5 rounded-[20px] border border-dashed border-[var(--line)] bg-white/40 p-5 text-sm leading-7 text-[var(--muted)]">
+                  No clustered events yet for this topic. Try adjusting keywords or refreshing your briefing.
+                </div>
               )}
-            </div>
+            </Panel>
           ))}
         </section>
+
+        {earlySignals.length ? (
+          <Panel className="p-5">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
+              Early signals
+            </p>
+            <h2 className="mt-1 text-xl font-semibold text-[var(--foreground)]">
+              Single-source developments held out of Top Events
+            </h2>
+            <p className="mt-2 text-sm text-[var(--muted)]">
+              These stay on the dashboard for awareness, but they are clearly marked until more sources confirm the event cluster.
+            </p>
+            <div className="mt-5 grid gap-4 xl:grid-cols-2">
+              {earlySignals.slice(0, 4).map((item) => (
+                <DashboardEventCard key={item.id} item={item} tone="early" compact />
+              ))}
+            </div>
+          </Panel>
+        ) : null}
 
         {canTrackProgress ? (
           <Panel className="p-6">
@@ -322,8 +311,7 @@ export default async function DashboardPage({
                   You&apos;re caught up
                 </h2>
                 <p className="mt-2 text-sm leading-7 text-[var(--muted)]">
-                  {sessionSummary?.reviewedCount ?? 0} events reviewed today, with {sessionSummary?.newCount ?? 0} new,{" "}
-                  {sessionSummary?.changedCount ?? 0} changed, and {sessionSummary?.escalatedCount ?? 0} escalated since your last pass.
+                  {sessionSummary?.reviewedCount ?? 0} events reviewed today, with {sessionSummary?.newCount ?? 0} new, {sessionSummary?.changedCount ?? 0} changed, and {sessionSummary?.escalatedCount ?? 0} escalated since your last pass.
                 </p>
               </>
             ) : (
@@ -332,7 +320,7 @@ export default async function DashboardPage({
                   Keep scanning
                 </h2>
                 <p className="mt-2 text-sm leading-7 text-[var(--muted)]">
-                  Mark events as read as you finish them. When everything in today&apos;s feed is reviewed, this becomes your closure point.
+                  Mark events as read as you finish them. When everything in today&apos;s briefing is reviewed, this becomes your closure point.
                 </p>
               </>
             )}
@@ -340,6 +328,178 @@ export default async function DashboardPage({
         ) : null}
       </div>
     </AppShell>
+  );
+}
+
+function DashboardEventCard({
+  item,
+  tone,
+  compact = false,
+}: {
+  item: BriefingItem;
+  tone: "confirmed" | "early";
+  compact?: boolean;
+}) {
+  const intelligence = buildEventIntelligenceSignals(item);
+  const primarySourceUrl = item.relatedArticles?.[0]?.url ?? item.sources.find((source) => isValidStoryUrl(source.url))?.url;
+  const displayStateLabel = getDisplayStateLabel(item.displayState);
+
+  return (
+    <div className={cn("rounded-[22px] border bg-white/65 p-5", tone === "early" ? "border-[rgba(138,90,17,0.18)]" : "border-[var(--line)]")}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-2">
+          <div className="flex flex-wrap gap-2">
+            <Badge>{item.topicName}</Badge>
+            <Badge className={tone === "early" ? "text-[#8a5a11]" : "text-[var(--accent)]"}>
+              {tone === "early" ? "Early Signal" : "Top Event"}
+            </Badge>
+            {displayStateLabel ? (
+              <Badge className={getDisplayStateTone(item.displayState)}>{displayStateLabel}</Badge>
+            ) : null}
+            <Badge>{intelligence.timelineIndicator}</Badge>
+            <Badge className={intelligence.confidenceTone === "developing" ? "text-[#8a5a11]" : "text-[#294f86]"}>
+              {intelligence.confidenceLabel}
+            </Badge>
+            {item.read ? <Badge className="text-[var(--muted)]">Read</Badge> : null}
+          </div>
+          <div>
+            {primarySourceUrl ? (
+              <a
+                href={primarySourceUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-start gap-2 text-xl font-semibold tracking-tight text-[var(--foreground)] underline-offset-4 hover:underline"
+              >
+                <span>{item.title}</span>
+                <ExternalLink className="mt-1 h-4 w-4 shrink-0 text-[var(--muted)]" />
+              </a>
+            ) : (
+              <h3 className="text-xl font-semibold tracking-tight text-[var(--foreground)]">{item.title}</h3>
+            )}
+            <p className="mt-2 text-sm leading-7 text-[var(--muted)] line-clamp-3">{item.whatHappened}</p>
+          </div>
+        </div>
+
+        {item.continuityKey && item.continuityFingerprint ? (
+          <form action={toggleReadAction}>
+            <input type="hidden" name="itemId" value={item.id} />
+            <input type="hidden" name="eventKey" value={item.continuityKey} />
+            <input type="hidden" name="continuityFingerprint" value={item.continuityFingerprint} />
+            <input
+              type="hidden"
+              name="importanceScore"
+              value={String(Math.round(item.importanceScore ?? item.matchScore ?? 0))}
+            />
+            <input type="hidden" name="current" value={String(item.read)} />
+            <button
+              className={cn(
+                "flex items-center gap-2 rounded-full border px-3 py-2 text-sm transition-colors",
+                item.read
+                  ? "border-[rgba(31,79,70,0.18)] bg-[rgba(31,79,70,0.06)] text-[var(--accent)]"
+                  : "border-[var(--line)] bg-white/60 text-[var(--muted)] hover:bg-white",
+              )}
+            >
+              {item.read ? (
+                <CheckCircle2 className="h-4 w-4 text-[var(--accent)]" />
+              ) : (
+                <Circle className="h-4 w-4" />
+              )}
+              {item.read ? "Read" : "Mark as read"}
+            </button>
+          </form>
+        ) : null}
+      </div>
+
+      <div className="mt-4 rounded-[18px] border border-[rgba(19,26,34,0.08)] bg-[rgba(255,255,255,0.72)] px-4 py-4">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
+          Ranking reason
+        </p>
+        <p className="mt-2 text-sm font-medium text-[var(--foreground)]">{intelligence.rankingReason}</p>
+        {item.rankingSignals?.[0] ? (
+          <p className="mt-2 text-sm leading-6 text-[var(--muted)]">{item.rankingSignals[0]}</p>
+        ) : null}
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-2">
+        <SignalStat label="Impact" value={intelligence.impactLabel} />
+        <SignalStat label="Source diversity" value={intelligence.sourceLabel} />
+        <SignalStat label="Timeline" value={intelligence.timelineIndicator} />
+        <SignalStat label="Recency" value={intelligence.recencyLabel} />
+      </div>
+
+      <div className="mt-4 rounded-[18px] border border-[rgba(19,26,34,0.08)] bg-[rgba(41,79,134,0.05)] px-4 py-4">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#294f86]">Why it matters</p>
+        <p className="mt-2 text-sm leading-7 text-[var(--foreground)]">{item.whyItMatters}</p>
+      </div>
+
+      {intelligence.keyEntities.length ? (
+        <div className="mt-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">Key entities</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {intelligence.keyEntities.map((entity) => (
+              <span
+                key={entity}
+                className="inline-flex items-center rounded-full border border-[rgba(19,26,34,0.08)] bg-white/80 px-3 py-1.5 text-xs font-medium text-[var(--foreground)]"
+              >
+                {entity}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="mt-4 rounded-[18px] border border-[rgba(19,26,34,0.08)] bg-white/60 px-4 py-4">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
+            Supporting coverage
+          </p>
+          <p className="text-xs font-medium text-[var(--muted)]">{intelligence.sourceLabel}</p>
+        </div>
+        <div className="mt-3 space-y-2.5">
+          {(item.relatedArticles?.length ? item.relatedArticles : item.sources.map((source) => ({
+            title: source.title,
+            url: source.url,
+            sourceName: source.title,
+          })))
+            .slice(0, compact ? 3 : 4)
+            .map((article) => (
+              <a
+                key={`${article.sourceName}-${article.title}-${article.url}`}
+                href={article.url}
+                target="_blank"
+                rel="noreferrer"
+                className="flex items-start justify-between gap-3 rounded-[16px] border border-[rgba(19,26,34,0.06)] bg-white/70 px-3 py-3 transition-colors hover:bg-white"
+              >
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold leading-6 text-[var(--foreground)]">{article.title}</p>
+                  <p className="mt-1 text-xs leading-5 text-[var(--muted)]">{article.sourceName}</p>
+                </div>
+                <ExternalLink className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--muted)]" />
+              </a>
+            ))}
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2 text-xs font-medium text-[var(--muted)]">
+        <span className="inline-flex items-center rounded-full border border-[rgba(19,26,34,0.08)] bg-[rgba(255,255,255,0.72)] px-3 py-1.5">
+          {minutesToLabel(item.estimatedMinutes)} read
+        </span>
+        {item.matchedKeywords?.[0] ? (
+          <span className="inline-flex items-center rounded-full border border-[rgba(19,26,34,0.08)] bg-[rgba(255,255,255,0.72)] px-3 py-1.5">
+            Signal: {item.matchedKeywords[0]}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function SignalStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-[16px] border border-[rgba(19,26,34,0.08)] bg-white/70 px-3 py-3">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--muted)]">{label}</p>
+      <p className="mt-1 text-sm font-medium text-[var(--foreground)]">{value}</p>
+    </div>
   );
 }
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -103,7 +103,7 @@ export default async function DashboardPage({
                   </h2>
                   <p className="pb-1 text-sm font-medium text-[var(--muted)]">today</p>
                 </div>
-                <div className="mt-2 flex flex-wrap gap-2">
+                <div className="mt-2 flex max-w-full flex-wrap gap-2">
                   <Badge>{formatReadingDelta(readingMetrics.deltaVsYesterday)}</Badge>
                   <Badge>{readingMetrics.intensity} day</Badge>
                 </div>
@@ -257,7 +257,7 @@ export default async function DashboardPage({
                     <p className="text-sm text-[var(--muted)]">{topic.description}</p>
                   </div>
                 </div>
-                <div className="flex flex-wrap gap-2">
+                <div className="flex max-w-full flex-wrap gap-2">
                   <Badge>{confirmed.length} confirmed events</Badge>
                   {early.length ? <Badge className="text-[#8a5a11]">{early.length} early signals</Badge> : null}
                 </div>
@@ -345,8 +345,8 @@ function DashboardEventCard({
   const displayStateLabel = getDisplayStateLabel(item.displayState);
 
   return (
-    <div className={cn("rounded-[22px] border bg-white/65 p-5", tone === "early" ? "border-[rgba(138,90,17,0.18)]" : "border-[var(--line)]")}>
-      <div className="flex flex-wrap items-start justify-between gap-3">
+    <div className={cn("overflow-hidden rounded-[22px] border bg-white/65 p-5", tone === "early" ? "border-[rgba(138,90,17,0.18)]" : "border-[var(--line)]")}>
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
         <div className="space-y-2">
           <div className="flex flex-wrap gap-2">
             <Badge>{item.topicName}</Badge>
@@ -368,13 +368,13 @@ function DashboardEventCard({
                 href={primarySourceUrl}
                 target="_blank"
                 rel="noreferrer"
-                className="inline-flex items-start gap-2 text-xl font-semibold tracking-tight text-[var(--foreground)] underline-offset-4 hover:underline"
+                className="inline-flex min-w-0 items-start gap-2 text-xl font-semibold tracking-tight text-[var(--foreground)] underline-offset-4 hover:underline"
               >
-                <span>{item.title}</span>
+                <span className="break-words">{item.title}</span>
                 <ExternalLink className="mt-1 h-4 w-4 shrink-0 text-[var(--muted)]" />
               </a>
             ) : (
-              <h3 className="text-xl font-semibold tracking-tight text-[var(--foreground)]">{item.title}</h3>
+              <h3 className="break-words text-xl font-semibold tracking-tight text-[var(--foreground)]">{item.title}</h3>
             )}
             <p className="mt-2 text-sm leading-7 text-[var(--muted)] line-clamp-3">{item.whatHappened}</p>
           </div>
@@ -435,11 +435,11 @@ function DashboardEventCard({
       {intelligence.keyEntities.length ? (
         <div className="mt-4">
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">Key entities</p>
-          <div className="mt-2 flex flex-wrap gap-2">
+          <div className="mt-2 flex max-w-full flex-wrap gap-2">
             {intelligence.keyEntities.map((entity) => (
               <span
                 key={entity}
-                className="inline-flex items-center rounded-full border border-[rgba(19,26,34,0.08)] bg-white/80 px-3 py-1.5 text-xs font-medium text-[var(--foreground)]"
+                className="inline-flex max-w-full items-center rounded-full border border-[rgba(19,26,34,0.08)] bg-white/80 px-3 py-1.5 text-xs font-medium text-[var(--foreground)] break-words"
               >
                 {entity}
               </span>
@@ -449,7 +449,7 @@ function DashboardEventCard({
       ) : null}
 
       <div className="mt-4 rounded-[18px] border border-[rgba(19,26,34,0.08)] bg-white/60 px-4 py-4">
-        <div className="flex items-center justify-between gap-3">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
             Supporting coverage
           </p>
@@ -468,10 +468,10 @@ function DashboardEventCard({
                 href={article.url}
                 target="_blank"
                 rel="noreferrer"
-                className="flex items-start justify-between gap-3 rounded-[16px] border border-[rgba(19,26,34,0.06)] bg-white/70 px-3 py-3 transition-colors hover:bg-white"
+                className="flex flex-col gap-2 rounded-[16px] border border-[rgba(19,26,34,0.06)] bg-white/70 px-3 py-3 transition-colors hover:bg-white sm:flex-row sm:items-start sm:justify-between"
               >
                 <div className="min-w-0">
-                  <p className="text-sm font-semibold leading-6 text-[var(--foreground)]">{article.title}</p>
+                  <p className="break-words text-sm font-semibold leading-6 text-[var(--foreground)]">{article.title}</p>
                   <p className="mt-1 text-xs leading-5 text-[var(--muted)]">{article.sourceName}</p>
                 </div>
                 <ExternalLink className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--muted)]" />

--- a/src/components/landing/homepage.test.tsx
+++ b/src/components/landing/homepage.test.tsx
@@ -77,7 +77,7 @@ describe("LandingHomepage", () => {
     render(<LandingHomepage data={data} viewer={null} />);
 
     expect(screen.getByText("No Finance events yet")).toBeInTheDocument();
-    expect(screen.getAllByText("Top stories while this category fills in").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Other confirmed events while this category fills in").length).toBeGreaterThan(0);
   });
 
   it("shows sparse-state messaging when only one category event exists", () => {
@@ -95,7 +95,7 @@ describe("LandingHomepage", () => {
 
     render(<LandingHomepage data={data} viewer={null} />);
 
-    expect(screen.getAllByText(/Coverage is still building here/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/intentionally capped so the briefing stays calm/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/More Finance coverage is on the way/i).length).toBeGreaterThan(0);
   });
 

--- a/src/components/landing/homepage.tsx
+++ b/src/components/landing/homepage.tsx
@@ -486,7 +486,7 @@ function EventCard({
 
   return (
     <div className="space-y-4">
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
         <div className="flex items-start gap-3">
           {rank ? (
             <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-[16px] bg-[rgba(41,79,134,0.1)] text-[1.15rem] font-semibold text-[#294f86] lg:h-14 lg:w-14 lg:text-[1.35rem]">
@@ -497,7 +497,7 @@ function EventCard({
             <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
               {label}
             </p>
-            <div className="mt-2 flex flex-wrap items-center gap-2">
+            <div className="mt-2 flex max-w-full flex-wrap items-center gap-2">
               <Badge>{event.topicName}</Badge>
               <Badge className={intelligence.isEarlySignal ? "text-[#8a5a11]" : "text-[#294f86]"}>
                 {intelligence.isEarlySignal ? "Early Signal" : "Confirmed Event"}
@@ -507,7 +507,7 @@ function EventCard({
             </div>
           </div>
         </div>
-        <div className="max-w-[220px] text-right">
+        <div className="rounded-[18px] border border-[rgba(19,26,34,0.08)] bg-white/65 px-3 py-3 text-left md:max-w-[220px] md:text-right">
           <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--muted)]">
             Ranking reason
           </p>
@@ -613,7 +613,7 @@ function EntityBlock({ entities }: { entities: string[] }) {
         {entities.map((entity) => (
           <span
             key={entity}
-            className="inline-flex items-center rounded-full border border-[rgba(19,26,34,0.08)] bg-white/80 px-3 py-1.5 text-xs font-medium text-[var(--foreground)]"
+            className="inline-flex max-w-full items-center rounded-full border border-[rgba(19,26,34,0.08)] bg-white/80 px-3 py-1.5 text-xs font-medium text-[var(--foreground)] break-words"
           >
             {entity}
           </span>
@@ -703,12 +703,12 @@ function RelatedArticlesList({
             href={article.url}
             target="_blank"
             rel="noreferrer"
-            className="flex items-start justify-between gap-3 rounded-[16px] border border-[rgba(19,26,34,0.06)] bg-white/70 px-3 py-3 transition-colors hover:bg-white"
+            className="flex flex-col gap-2 rounded-[16px] border border-[rgba(19,26,34,0.06)] bg-white/70 px-3 py-3 transition-colors hover:bg-white sm:flex-row sm:items-start sm:justify-between"
           >
             <div className="min-w-0">
               <p
                 className={cn(
-                  "font-semibold text-[var(--foreground)]",
+                  "break-words font-semibold text-[var(--foreground)]",
                   compact ? "text-sm leading-5" : "text-sm leading-6",
                 )}
               >

--- a/src/components/landing/homepage.tsx
+++ b/src/components/landing/homepage.tsx
@@ -38,7 +38,7 @@ export default function LandingHomepage({
   const currentHash = useHashValue();
   const showDebug = debugEnabled || isHomepageDebugConfigured;
 
-  const { featured, topRanked, categorySections, trending, debug } = useMemo(
+  const { featured, topRanked, categorySections, trending, earlySignals, debug } = useMemo(
     () => buildHomepageViewModel(data),
     [data],
   );
@@ -89,6 +89,8 @@ export default function LandingHomepage({
           </section>
 
           <TrendingSection events={trending} />
+
+          <EarlySignalsSection events={earlySignals} />
 
           {showDebug ? <HomepageDebugPanel debug={debug} /> : null}
 
@@ -234,15 +236,15 @@ function HeroIntelligenceBlock({
             Understand what matters today and why.
           </h1>
           <p className="mt-5 max-w-xl text-[15px] leading-7 text-[var(--muted)] sm:text-[17px] sm:leading-8">
-            Daily Intelligence Aggregator ranks the most important developments, groups related coverage into events, and gives you the context needed to interpret impact fast.
+            Daily Intelligence Aggregator turns scattered coverage into a structured intelligence briefing with confirmed events, visible ranking logic, and clearly separated early signals.
           </p>
           <p className="mt-5 text-sm font-medium text-[var(--foreground)]/88">
             Less article chasing. More signal, context, and meaning.
           </p>
           <div className="mt-8 grid gap-3 text-sm text-[var(--muted)] sm:grid-cols-3">
-            <SignalPill title="Event-first" detail="Coverage is grouped into developments, not dumped as isolated links." />
-            <SignalPill title="Context-led" detail="Why it matters and why it ranked stay visible." />
-            <SignalPill title="Ranked by signal" detail="The homepage emphasizes importance, not just recency." />
+            <SignalPill title="Event-first" detail="Coverage is grouped into shared developments, not dumped as standalone articles." />
+            <SignalPill title="Transparent ranking" detail="Impact, source breadth, and recency stay visible on every event." />
+            <SignalPill title="Noise controlled" detail="Single-source items are separated into Early Signals instead of crowding Top Events." />
           </div>
           {!signedIn ? (
             <div className="mt-8 flex flex-wrap items-center gap-3">
@@ -335,9 +337,9 @@ function TopRankedEventsSection({ events }: { events: HomepageEvent[] }) {
   return (
     <section id="top-events" className="space-y-5 lg:space-y-6">
       <SectionHeader
-        eyebrow="Top Ranked Events"
-        title="The developments most worth your attention right now"
-        description="This ranked layer favors importance over chronology, with grouped supporting coverage under each event."
+        eyebrow="Top Events"
+        title="Confirmed developments, ranked with transparent logic"
+        description="Only multi-source event clusters qualify here. Each card shows impact, recency, source breadth, confidence, and why it made the briefing."
       />
       {events.length ? (
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-12">
@@ -353,7 +355,7 @@ function TopRankedEventsSection({ events }: { events: HomepageEvent[] }) {
                   event={event}
                   rank={index + 1}
                   variant={index === 0 ? "ranked-featured" : "ranked"}
-                  label="Ranked event"
+                  label="Confirmed event"
                   showTimeline={index === 0}
                   showRelatedArticles
                 />
@@ -381,10 +383,10 @@ function CategorySection({ section }: { section: HomepageCategorySection }) {
         <>
           {section.state === "sparse" ? (
             <p className="text-sm text-[var(--muted)]">
-              Coverage is still building here, so confirmed {section.label.toLowerCase()} events share space with clear placeholders.
+              This category is intentionally capped so the briefing stays calm. Confirmed events appear first, while single-source developments stay visibly labeled as early signals.
             </p>
           ) : null}
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          <div className="grid gap-4 md:grid-cols-2">
             {section.events.map((event) => (
               <Panel
                 key={event.id}
@@ -409,9 +411,9 @@ function TrendingSection({ events }: { events: HomepageEvent[] }) {
   return (
     <section className="space-y-4">
       <SectionHeader
-        eyebrow="Trending / Important"
-        title="Other developments worth keeping in view"
-        description="A lower-priority tail section for breadth once the top-ranked events are clear."
+        eyebrow="Watchlist"
+        title="Other confirmed events worth keeping in view"
+        description="This is the lower-priority watchlist once the top event layer is clear. It stays compact on purpose."
         compact
       />
       {events.length ? (
@@ -421,16 +423,43 @@ function TrendingSection({ events }: { events: HomepageEvent[] }) {
               key={event.id}
               className={cn("px-5 py-5", index !== events.length - 1 && "border-b border-[var(--line)]")}
             >
-              <EventCard event={event} variant="list" label="Event" showRelatedArticles />
+              <EventCard event={event} variant="list" label="Confirmed event" showRelatedArticles />
             </div>
           ))}
         </Panel>
       ) : (
         <StatusPanel
-          title="No additional developments yet"
-          body="Once more stories are available, lower-priority events will collect here in a compact scan."
+          title="No additional confirmed events yet"
+          body="Once more multi-source clusters qualify, they will collect here in a compact watchlist."
         />
       )}
+    </section>
+  );
+}
+
+function EarlySignalsSection({ events }: { events: HomepageEvent[] }) {
+  if (!events.length) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-4">
+      <SectionHeader
+        eyebrow="Early Signals"
+        title="Single-source developments kept separate from Top Events"
+        description="These items stay visible for awareness, but they do not qualify for the lead ranking until more coverage confirms the event cluster."
+        compact
+      />
+      <div className="grid gap-4 md:grid-cols-3">
+        {events.map((event) => (
+          <Panel
+            key={event.id}
+            className="border-[rgba(19,26,34,0.08)] bg-[rgba(255,255,255,0.62)] p-5"
+          >
+            <EventCard event={event} variant="compact" label="Early signal" showRelatedArticles />
+          </Panel>
+        ))}
+      </div>
     </section>
   );
 }
@@ -453,6 +482,7 @@ function EventCard({
   const emphatic = variant === "featured" || variant === "ranked-featured";
   const compact = variant === "compact";
   const list = variant === "list";
+  const intelligence = event.intelligence;
 
   return (
     <div className="space-y-4">
@@ -469,16 +499,22 @@ function EventCard({
             </p>
             <div className="mt-2 flex flex-wrap items-center gap-2">
               <Badge>{event.topicName}</Badge>
-              {event.importanceLabel ? <Badge className="text-[#294f86]">{event.importanceLabel}</Badge> : null}
-              {event.matchedKeywords[0] ? <Badge>Matched on {event.matchedKeywords[0]}</Badge> : null}
+              <Badge className={intelligence.isEarlySignal ? "text-[#8a5a11]" : "text-[#294f86]"}>
+                {intelligence.isEarlySignal ? "Early Signal" : "Confirmed Event"}
+              </Badge>
+              <Badge>{intelligence.timelineIndicator}</Badge>
+              <ConfidenceBadge tone={intelligence.confidenceTone} label={intelligence.confidenceLabel} />
             </div>
           </div>
         </div>
-        {!list && event.rankingSignals[0] ? (
-          <span className="max-w-[190px] text-right text-xs font-medium leading-5 text-[var(--muted)]">
-            {event.rankingSignals[0]}
-          </span>
-        ) : null}
+        <div className="max-w-[220px] text-right">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--muted)]">
+            Ranking reason
+          </p>
+          <p className="mt-1 text-xs font-medium leading-5 text-[var(--foreground)]">
+            {intelligence.rankingReason}
+          </p>
+        </div>
       </div>
 
       <div>
@@ -503,22 +539,85 @@ function EventCard({
         </p>
       </div>
 
+      <SignalStrip event={event} />
+
       <WhyItMattersBlock
         text={event.whyItMatters}
         whyThisIsHere={event.whyThisIsHere}
         emphatic={emphatic}
       />
 
+      {event.intelligence.keyEntities.length ? (
+        <EntityBlock entities={event.intelligence.keyEntities} />
+      ) : null}
+
       {showTimeline && event.timeline.length ? <TimelineBlock timeline={event.timeline} /> : null}
 
       {showRelatedArticles ? (
-        <RelatedArticlesList articles={event.relatedArticles} compact={compact || list} />
+        <RelatedArticlesList
+          articles={event.relatedArticles}
+          compact={compact || list}
+          sourceLabel={event.intelligence.sourceLabel}
+        />
       ) : null}
 
       <div className="flex flex-wrap gap-2 text-xs font-medium text-[var(--muted)]">
         <MetaPill>{minutesToLabel(event.estimatedMinutes)} read</MetaPill>
-        <MetaPill>{event.sourceCount} related sources</MetaPill>
-        {event.rankingSignals[1] ? <MetaPill>{event.rankingSignals[1]}</MetaPill> : null}
+        <MetaPill>{event.intelligence.sourceLabel}</MetaPill>
+        <MetaPill>{event.intelligence.impactLabel}</MetaPill>
+        <MetaPill>{event.intelligence.recencyLabel}</MetaPill>
+      </div>
+    </div>
+  );
+}
+
+function SignalStrip({ event }: { event: HomepageEvent }) {
+  return (
+    <div className="rounded-[22px] border border-[rgba(19,26,34,0.08)] bg-[rgba(255,255,255,0.58)] px-4 py-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <MetaPill>{event.intelligence.impactLabel}</MetaPill>
+        <MetaPill>{event.intelligence.sourceLabel}</MetaPill>
+        <MetaPill>{event.intelligence.recencyLabel}</MetaPill>
+      </div>
+      {event.rankingSignals.length ? (
+        <p className="mt-3 text-sm leading-6 text-[var(--muted)]">{event.rankingSignals[0]}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function ConfidenceBadge({
+  tone,
+  label,
+}: {
+  tone: HomepageEvent["intelligence"]["confidenceTone"];
+  label: string;
+}) {
+  const className =
+    tone === "high"
+      ? "text-[var(--accent)]"
+      : tone === "medium"
+        ? "text-[#294f86]"
+        : "text-[#8a5a11]";
+
+  return <Badge className={className}>{label}</Badge>;
+}
+
+function EntityBlock({ entities }: { entities: string[] }) {
+  return (
+    <div className="rounded-[22px] border border-[rgba(19,26,34,0.08)] bg-[rgba(255,255,255,0.52)] px-4 py-4">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
+        Key entities
+      </p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {entities.map((entity) => (
+          <span
+            key={entity}
+            className="inline-flex items-center rounded-full border border-[rgba(19,26,34,0.08)] bg-white/80 px-3 py-1.5 text-xs font-medium text-[var(--foreground)]"
+          >
+            {entity}
+          </span>
+        ))}
       </div>
     </div>
   );
@@ -544,7 +643,7 @@ function WhyItMattersBlock({
       <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#294f86]">Why it matters</p>
       <p className="mt-2 text-sm leading-7 text-[var(--foreground)]">{text}</p>
       <p className="mt-3 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
-        Why this is here
+        Why this ranks here
       </p>
       <p className="mt-2 text-sm leading-6 text-[var(--muted)]">{whyThisIsHere}</p>
     </div>
@@ -559,7 +658,7 @@ function TimelineBlock({
   return (
     <div className="rounded-[22px] border border-[rgba(19,26,34,0.08)] bg-[rgba(255,255,255,0.58)] px-4 py-4">
       <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
-        What led to today
+        Timeline signal
       </p>
       <div className="mt-4 space-y-3">
         {timeline.map((milestone) => (
@@ -581,17 +680,22 @@ function TimelineBlock({
 function RelatedArticlesList({
   articles,
   compact = false,
+  sourceLabel,
 }: {
   articles: Array<{ title: string; url: string; sourceName: string; note?: string }>;
   compact?: boolean;
+  sourceLabel: string;
 }) {
   if (!articles.length) return null;
 
   return (
     <div className="rounded-[22px] border border-[rgba(19,26,34,0.08)] bg-[rgba(255,255,255,0.52)] px-4 py-4">
-      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
-        Related coverage
-      </p>
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
+          Supporting coverage
+        </p>
+        <p className="text-xs font-medium text-[var(--muted)]">{sourceLabel}</p>
+      </div>
       <div className="mt-3 space-y-2.5">
         {articles.map((article) => (
           <a
@@ -749,7 +853,7 @@ function EmptyCategoryState({ section }: { section: HomepageCategorySection }) {
       {section.fallbackEvents.length ? (
         <Panel className="rounded-[28px] border-[rgba(19,26,34,0.08)] bg-[rgba(255,255,255,0.5)] p-5">
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
-            Top stories while this category fills in
+            Other confirmed events while this category fills in
           </p>
           <div className="mt-4 grid gap-4 md:grid-cols-2">
             {section.fallbackEvents.map((event) => (

--- a/src/lib/event-intelligence.ts
+++ b/src/lib/event-intelligence.ts
@@ -18,6 +18,37 @@ export type EventIntelligenceSignals = {
   rankingReason: string;
 };
 
+const ENTITY_STOPWORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "as",
+  "at",
+  "by",
+  "for",
+  "from",
+  "in",
+  "into",
+  "of",
+  "on",
+  "or",
+  "the",
+  "to",
+  "with",
+  "just",
+  "new",
+  "latest",
+  "update",
+  "report",
+  "reports",
+  "says",
+  "show",
+  "shows",
+  "after",
+  "ahead",
+  "amid",
+]);
+
 export function buildEventIntelligenceSignals(
   item: Pick<
     BriefingItem,
@@ -50,7 +81,7 @@ export function buildEventIntelligenceSignals(
         : "Developing";
 
   const impactLabel = getImpactLabel(item.importanceLabel, item.importanceScore ?? 0);
-  const recencyLabel = getRecencyLabel(item.publishedAt);
+  const recencyLabel = getRecencyLabel(item.publishedAt, item.displayState);
   const sourceLabel = `${sourceCount} ${sourceCount === 1 ? "source" : "sources"}`;
 
   return {
@@ -97,8 +128,16 @@ function getImpactLabel(
   return "Watch impact";
 }
 
-function getRecencyLabel(publishedAt?: string) {
-  if (!publishedAt) return "timing unclear";
+function getRecencyLabel(
+  publishedAt: string | undefined,
+  displayState: BriefingItem["displayState"],
+) {
+  if (!publishedAt) {
+    if (displayState === "new") return "new this cycle";
+    if (displayState === "changed") return "updated this cycle";
+    if (displayState === "escalated") return "escalating this cycle";
+    return "current briefing cycle";
+  }
 
   const ageHours = Math.max(
     0,
@@ -110,22 +149,23 @@ function getRecencyLabel(publishedAt?: string) {
   }
 
   if (ageHours < 24) {
-    return `last ${Math.round(ageHours)} hours`;
+    const roundedHours = Math.max(1, Math.round(ageHours));
+    return roundedHours === 1 ? "last hour" : `last ${roundedHours} hours`;
   }
 
-  const ageDays = Math.round(ageHours / 24);
-  return ageDays <= 1 ? "last day" : `last ${ageDays} days`;
+  const ageDays = Math.max(1, Math.round(ageHours / 24));
+  return ageDays === 1 ? "last day" : `last ${ageDays} days`;
 }
 
 function extractKeyEntities(
   item: Pick<BriefingItem, "title" | "topicName" | "matchedKeywords">,
 ) {
   const entities = [
-    ...(item.matchedKeywords ?? []),
+    ...(item.matchedKeywords ?? []).map(formatKeywordEntity),
     ...extractTitleEntities(item.title),
     item.topicName,
   ]
-    .map((value) => value.trim())
+    .map((value) => cleanEntity(value))
     .filter(Boolean);
 
   return entities.filter((value, index) => {
@@ -135,7 +175,44 @@ function extractKeyEntities(
 }
 
 function extractTitleEntities(title: string) {
-  const matches =
-    title.match(/\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,2}|[A-Z]{2,}(?:\s+[A-Z]{2,})*)\b/g) ?? [];
-  return matches.filter((value) => value.length > 2);
+  const normalizedTitle = title.replace(/[|:]/g, " ").replace(/\s+/g, " ").trim();
+  const words = normalizedTitle.split(" ").filter(Boolean);
+  const titleCaseRatio =
+    words.length > 0
+      ? words.filter((word) => /^[A-Z][a-z]/.test(word)).length / words.length
+      : 0;
+
+  if (titleCaseRatio > 0.75) {
+    return [];
+  }
+
+  const matches = normalizedTitle.match(/\b(?:[A-Z][a-z0-9]+|[A-Z]{2,}|AI|TV)(?:\s+(?:[A-Z][a-z0-9]+|[A-Z]{2,}|AI|TV)){0,3}\b/g) ?? [];
+  return matches
+    .map((value) => value.trim())
+    .filter((value) => isCredibleEntity(value));
+}
+
+function formatKeywordEntity(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  if (/^[A-Z0-9]{2,}$/.test(trimmed)) return trimmed;
+  return trimmed
+    .split(/\s+/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function cleanEntity(value: string) {
+  return value.replace(/[.,;:!?]+$/g, "").replace(/\s+/g, " ").trim();
+}
+
+function isCredibleEntity(value: string) {
+  const parts = value.split(/\s+/).filter(Boolean);
+  if (!parts.length || parts.length > 4) return false;
+  if (parts.every((part) => ENTITY_STOPWORDS.has(part.toLowerCase()))) return false;
+  if (value.length < 3 || value.length > 28) return false;
+  return parts.every((part) => {
+    const normalized = part.toLowerCase();
+    return !ENTITY_STOPWORDS.has(normalized) || /^[A-Z]{2,}$/.test(part);
+  });
 }

--- a/src/lib/event-intelligence.ts
+++ b/src/lib/event-intelligence.ts
@@ -1,0 +1,141 @@
+import type { BriefingItem } from "@/lib/types";
+
+export const TOP_EVENT_SOURCE_THRESHOLD = 2;
+
+export type EventTimelineIndicator = "New" | "Updated" | "Escalating";
+export type EventConfidenceLabel = "High confidence" | "Medium confidence" | "Developing";
+
+export type EventIntelligenceSignals = {
+  sourceCount: number;
+  isEarlySignal: boolean;
+  timelineIndicator: EventTimelineIndicator;
+  confidenceLabel: EventConfidenceLabel;
+  confidenceTone: "high" | "medium" | "developing";
+  keyEntities: string[];
+  impactLabel: string;
+  recencyLabel: string;
+  sourceLabel: string;
+  rankingReason: string;
+};
+
+export function buildEventIntelligenceSignals(
+  item: Pick<
+    BriefingItem,
+    | "title"
+    | "topicName"
+    | "publishedAt"
+    | "matchedKeywords"
+    | "importanceLabel"
+    | "importanceScore"
+    | "sourceCount"
+    | "sources"
+    | "displayState"
+  >,
+): EventIntelligenceSignals {
+  const sourceCount = item.sourceCount ?? item.sources.length;
+  const isEarlySignal = sourceCount < TOP_EVENT_SOURCE_THRESHOLD;
+
+  const timelineIndicator = getTimelineIndicator(item);
+  const confidenceTone =
+    sourceCount >= 4 || (item.importanceScore ?? 0) >= 85
+      ? "high"
+      : sourceCount >= TOP_EVENT_SOURCE_THRESHOLD
+        ? "medium"
+        : "developing";
+  const confidenceLabel =
+    confidenceTone === "high"
+      ? "High confidence"
+      : confidenceTone === "medium"
+        ? "Medium confidence"
+        : "Developing";
+
+  const impactLabel = getImpactLabel(item.importanceLabel, item.importanceScore ?? 0);
+  const recencyLabel = getRecencyLabel(item.publishedAt);
+  const sourceLabel = `${sourceCount} ${sourceCount === 1 ? "source" : "sources"}`;
+
+  return {
+    sourceCount,
+    isEarlySignal,
+    timelineIndicator,
+    confidenceLabel,
+    confidenceTone,
+    keyEntities: extractKeyEntities(item).slice(0, 4),
+    impactLabel,
+    recencyLabel,
+    sourceLabel,
+    rankingReason: `${impactLabel} • ${sourceLabel} • ${recencyLabel}`,
+  };
+}
+
+export function isTopEventEligible(item: Pick<BriefingItem, "sourceCount" | "sources">) {
+  const sourceCount = item.sourceCount ?? item.sources.length;
+  return sourceCount >= TOP_EVENT_SOURCE_THRESHOLD;
+}
+
+function getTimelineIndicator(
+  item: Pick<BriefingItem, "displayState" | "publishedAt">,
+): EventTimelineIndicator {
+  if (item.displayState === "escalated") return "Escalating";
+  if (item.displayState === "changed") return "Updated";
+  if (item.displayState === "new") return "New";
+
+  const publishedAt = item.publishedAt ? new Date(item.publishedAt).getTime() : 0;
+  const ageHours = publishedAt
+    ? (Date.now() - publishedAt) / (1000 * 60 * 60)
+    : Number.POSITIVE_INFINITY;
+
+  if (ageHours <= 12) return "New";
+  return "Updated";
+}
+
+function getImpactLabel(
+  importanceLabel: BriefingItem["importanceLabel"],
+  importanceScore: number,
+) {
+  if (importanceLabel === "Critical" || importanceScore >= 80) return "High impact";
+  if (importanceLabel === "High" || importanceScore >= 65) return "Meaningful impact";
+  return "Watch impact";
+}
+
+function getRecencyLabel(publishedAt?: string) {
+  if (!publishedAt) return "timing unclear";
+
+  const ageHours = Math.max(
+    0,
+    (Date.now() - new Date(publishedAt).getTime()) / (1000 * 60 * 60),
+  );
+
+  if (ageHours < 1) {
+    return "last hour";
+  }
+
+  if (ageHours < 24) {
+    return `last ${Math.round(ageHours)} hours`;
+  }
+
+  const ageDays = Math.round(ageHours / 24);
+  return ageDays <= 1 ? "last day" : `last ${ageDays} days`;
+}
+
+function extractKeyEntities(
+  item: Pick<BriefingItem, "title" | "topicName" | "matchedKeywords">,
+) {
+  const entities = [
+    ...(item.matchedKeywords ?? []),
+    ...extractTitleEntities(item.title),
+    item.topicName,
+  ]
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  return entities.filter((value, index) => {
+    const normalized = value.toLowerCase();
+    return entities.findIndex((candidate) => candidate.toLowerCase() === normalized) === index;
+  });
+}
+
+function extractTitleEntities(title: string) {
+  const matches =
+    title.match(/\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,2}|[A-Z]{2,}(?:\s+[A-Z]{2,})*)\b/g) ?? [];
+  return matches.filter((value) => value.length > 2);
+}

--- a/src/lib/homepage-model.test.ts
+++ b/src/lib/homepage-model.test.ts
@@ -131,7 +131,21 @@ describe("buildHomepageViewModel", () => {
     const financeSection = model.categorySections.find((section) => section.key === "finance");
 
     expect(financeSection?.state).toBe("sparse");
-    expect(financeSection?.placeholderCount).toBe(2);
+    expect(financeSection?.placeholderCount).toBe(1);
+  });
+
+  it("keeps single-source items out of the top-ranked event rail", () => {
+    const earlySignal = createItem({
+      id: "early-1",
+      sourceCount: 1,
+      sources: [{ title: "Reuters", url: "https://www.reuters.com/world/example" }],
+      title: "Single-source report surfaces ahead of broader pickup",
+    });
+
+    const model = buildHomepageViewModel(createData([earlySignal]));
+
+    expect(model.topRanked).toHaveLength(0);
+    expect(model.earlySignals.map((event) => event.id)).toContain("early-1");
   });
 
   it("counts uncategorized events in debug mode", () => {

--- a/src/lib/homepage-model.ts
+++ b/src/lib/homepage-model.ts
@@ -5,10 +5,14 @@ import {
   getHomepageCategoryDescription,
   getHomepageCategoryLabel,
   HOMEPAGE_CATEGORY_CONFIG,
-  HOMEPAGE_CATEGORY_TARGET,
   type HomepageCategoryClassification,
   type HomepageCategoryKey,
 } from "@/lib/homepage-taxonomy";
+import {
+  buildEventIntelligenceSignals,
+  TOP_EVENT_SOURCE_THRESHOLD,
+  type EventIntelligenceSignals,
+} from "@/lib/event-intelligence";
 import { firstSentence } from "@/lib/utils";
 
 export type EventArticle = {
@@ -40,6 +44,7 @@ export type HomepageEvent = {
   rankScore: number;
   sourceCount: number;
   classification: HomepageCategoryClassification;
+  intelligence: EventIntelligenceSignals;
 };
 
 export type HomepageCategorySection = {
@@ -72,33 +77,44 @@ export type HomepageViewModel = {
   topRanked: HomepageEvent[];
   categorySections: HomepageCategorySection[];
   trending: HomepageEvent[];
+  earlySignals: HomepageEvent[];
   debug: HomepageDebugModel;
 };
 
+const TOP_EVENTS_LIMIT = 4;
+const CATEGORY_EVENT_LIMIT = 2;
+const TRENDING_EVENT_LIMIT = 3;
+const EARLY_SIGNAL_LIMIT = 3;
+
 export function buildHomepageViewModel(data: DashboardData): HomepageViewModel {
   const events = buildHomepageEvents(data.briefing.items);
-  const featured = events[0] ?? null;
-  const topRanked = events.slice(0, 5);
+  const confirmedEvents = events.filter((event) => !event.intelligence.isEarlySignal);
+  const earlySignals = events.filter((event) => event.intelligence.isEarlySignal);
+  const featured = confirmedEvents[0] ?? events[0] ?? null;
+  const topRanked = confirmedEvents.slice(0, TOP_EVENTS_LIMIT);
 
   const categorySections = HOMEPAGE_CATEGORY_CONFIG.map((category) => {
     const eligibleEvents = events.filter((event) => event.classification.primaryCategory === category.key);
-    const displayEvents = eligibleEvents.slice(0, HOMEPAGE_CATEGORY_TARGET);
-    const heldBackEvents = eligibleEvents.slice(HOMEPAGE_CATEGORY_TARGET);
+    const displayEvents = eligibleEvents.slice(0, CATEGORY_EVENT_LIMIT);
+    const heldBackEvents = eligibleEvents.slice(CATEGORY_EVENT_LIMIT);
     const fallbackEvents =
-      eligibleEvents.length === 0
-        ? events
+      displayEvents.length === 0
+        ? confirmedEvents
             .filter((event) => event.classification.primaryCategory !== category.key)
             .slice(0, 2)
         : [];
 
     const placeholderCount =
-      eligibleEvents.length > 0 ? Math.max(0, HOMEPAGE_CATEGORY_TARGET - displayEvents.length) : 0;
+      displayEvents.length > 0 ? Math.max(0, CATEGORY_EVENT_LIMIT - displayEvents.length) : 0;
 
     const excludedReasons = [
       ...events
         .filter((event) => event.classification.primaryCategory !== category.key)
         .map((event) => getExclusionReason(event, category.key)),
-      ...heldBackEvents.map(() => `Held back because ${getHomepageCategoryLabel(category.key)} is capped at ${HOMEPAGE_CATEGORY_TARGET} cards.`),
+      ...heldBackEvents.map(
+        () =>
+          `Held back because ${getHomepageCategoryLabel(category.key)} is capped at ${CATEGORY_EVENT_LIMIT} event cards.`,
+      ),
     ];
 
     return {
@@ -109,7 +125,7 @@ export function buildHomepageViewModel(data: DashboardData): HomepageViewModel {
       fallbackEvents,
       placeholderCount,
       state:
-        displayEvents.length >= HOMEPAGE_CATEGORY_TARGET
+        displayEvents.length >= CATEGORY_EVENT_LIMIT
           ? "populated"
           : displayEvents.length > 0
             ? "sparse"
@@ -120,7 +136,9 @@ export function buildHomepageViewModel(data: DashboardData): HomepageViewModel {
   });
 
   const reservedIds = new Set(topRanked.map((event) => event.id));
-  const trending = events.filter((event) => !reservedIds.has(event.id)).slice(0, 4);
+  const trending = confirmedEvents
+    .filter((event) => !reservedIds.has(event.id))
+    .slice(0, TRENDING_EVENT_LIMIT);
   const sourceCountsByCategory =
     data.homepageDiagnostics?.sourceCountsByCategory ?? countSourcesByHomepageCategory(data.sources);
 
@@ -129,6 +147,7 @@ export function buildHomepageViewModel(data: DashboardData): HomepageViewModel {
     topRanked,
     categorySections,
     trending,
+    earlySignals: earlySignals.slice(0, EARLY_SIGNAL_LIMIT),
     debug: {
       totalArticlesFetched: data.homepageDiagnostics?.totalArticlesFetched ?? null,
       totalCandidateEvents: data.homepageDiagnostics?.totalCandidateEvents ?? null,
@@ -157,6 +176,7 @@ export function buildHomepageEvents(items: BriefingItem[]) {
     .slice()
     .sort((left, right) => getRankScore(right) - getRankScore(left))
     .map((item, index, sortedItems) => {
+      const intelligence = buildEventIntelligenceSignals(item);
       const classification = classifyHomepageCategory({
         topicName: item.topicName,
         title: item.title,
@@ -166,16 +186,17 @@ export function buildHomepageEvents(items: BriefingItem[]) {
         rankingSignals: item.rankingSignals,
         sourceNames: item.sources.map((source) => source.title),
       });
-      const siblingItems = sortedItems.filter((candidate) => candidate.id !== item.id && candidate.topicId === item.topicId);
-      const sourceCount = item.sourceCount ?? new Set(item.sources.map((source) => source.title)).size;
+      const siblingItems = sortedItems.filter(
+        (candidate) => candidate.id !== item.id && candidate.topicId === item.topicId,
+      );
 
       return {
         id: item.id,
         topicName: item.topicName,
         title: item.title,
-        summary: summarize(item.whatHappened, item.priority === "top" ? 2 : 1),
+        summary: summarize(item.whatHappened, 2),
         whyItMatters: sanitizeWhyItMatters(item.whyItMatters, item.title),
-        whyThisIsHere: buildWhyThisIsHere(item, classification, sourceCount),
+        whyThisIsHere: buildWhyThisIsHere(item, classification, intelligence),
         relatedArticles: buildHomepageRelatedArticles(item),
         timeline: buildEventTimeline(item, siblingItems),
         estimatedMinutes: item.estimatedMinutes,
@@ -184,18 +205,21 @@ export function buildHomepageEvents(items: BriefingItem[]) {
         matchedKeywords: item.matchedKeywords ?? [],
         priority: item.priority,
         rankScore: getRankScore(item) - index * 0.01,
-        sourceCount,
+        sourceCount: intelligence.sourceCount,
         classification,
-      };
+        intelligence,
+      } satisfies HomepageEvent;
     });
 }
 
 function buildHomepageRelatedArticles(item: BriefingItem) {
-  const candidates = (item.relatedArticles?.length ? item.relatedArticles : undefined) ?? item.sources.map((source) => ({
-    title: source.title,
-    url: source.url,
-    sourceName: source.title,
-  }));
+  const candidates =
+    (item.relatedArticles?.length ? item.relatedArticles : undefined) ??
+    item.sources.map((source) => ({
+      title: source.title,
+      url: source.url,
+      sourceName: source.title,
+    }));
 
   const seenSources = new Set<string>();
   const seenTitles = new Set<string>();
@@ -255,21 +279,19 @@ function buildEventTimeline(item: BriefingItem, siblingItems: BriefingItem[]) {
 function buildWhyThisIsHere(
   item: BriefingItem,
   classification: HomepageCategoryClassification,
-  sourceCount: number,
+  intelligence: EventIntelligenceSignals,
 ) {
   const primaryCategory = classification.primaryCategory
     ? getHomepageCategoryLabel(classification.primaryCategory)
     : "General";
   const leadingSignal = item.matchedKeywords?.[0];
-  const breadthLabel =
-    sourceCount > 1 ? `${sourceCount} sources grouped around the same event` : "an early single-source signal";
-  const rankLabel = item.importanceLabel ? `${item.importanceLabel.toLowerCase()} rank signal` : "current rank signal";
+  const signalContext = leadingSignal ? `triggered by \"${leadingSignal}\"` : "matched your tracked topics";
 
-  if (leadingSignal) {
-    return `${primaryCategory} match on "${leadingSignal}" with ${breadthLabel} and ${rankLabel}.`;
+  if (intelligence.isEarlySignal) {
+    return `${primaryCategory} ${signalContext}, but only ${intelligence.sourceCount} source has picked it up so far. It stays visible as an early signal rather than a top-ranked event until more coverage confirms the cluster.`;
   }
 
-  return `${primaryCategory} classification backed by topic fit, ${breadthLabel}, and ${rankLabel}.`;
+  return `${primaryCategory} ${signalContext} and ranked because ${intelligence.rankingReason.toLowerCase()} with ${intelligence.confidenceLabel.toLowerCase()}.`;
 }
 
 function sanitizeWhyItMatters(value: string, title: string) {
@@ -288,11 +310,11 @@ function getEmptyReason(categoryKey: HomepageCategoryKey, eligibleCount: number,
   const label = getHomepageCategoryLabel(categoryKey);
 
   if (eligibleCount > 0) {
-    return `${label} has ${eligibleCount} eligible event${eligibleCount === 1 ? "" : "s"}, so placeholders fill the rest of the rail while coverage builds.`;
+    return `${label} has ${eligibleCount} eligible event${eligibleCount === 1 ? "" : "s"}, so placeholders keep the section calm while more clustered coverage builds.`;
   }
 
   if (fallbackCount > 0) {
-    return `No ranked ${label.toLowerCase()} events qualified yet, so the section falls back to clearly labeled top stories instead of collapsing.`;
+    return `No ${label.toLowerCase()} events qualified yet, so the section borrows other confirmed multi-source events instead of falling back to loose article cards.`;
   }
 
   return `No eligible ${label.toLowerCase()} events qualified in the current ranked briefing.`;
@@ -300,14 +322,14 @@ function getEmptyReason(categoryKey: HomepageCategoryKey, eligibleCount: number,
 
 function getExclusionReason(event: HomepageEvent, categoryKey: HomepageCategoryKey) {
   if (!event.classification.primaryCategory) {
-    return `"${event.title}" stayed out because it never cleared the category confidence threshold.`;
+    return `\"${event.title}\" stayed out because it never cleared the category confidence threshold.`;
   }
 
   if (event.classification.primaryCategory === categoryKey) {
-    return `"${event.title}" is eligible for ${getHomepageCategoryLabel(categoryKey)}.`;
+    return `\"${event.title}\" is eligible for ${getHomepageCategoryLabel(categoryKey)}.`;
   }
 
-  return `"${event.title}" was classified as ${getHomepageCategoryLabel(event.classification.primaryCategory)}, not ${getHomepageCategoryLabel(categoryKey)}.`;
+  return `\"${event.title}\" was classified as ${getHomepageCategoryLabel(event.classification.primaryCategory)}, not ${getHomepageCategoryLabel(categoryKey)}.`;
 }
 
 function getRankScore(item: BriefingItem) {
@@ -340,7 +362,7 @@ export function buildOverallNoDataMessage(itemCount: number) {
   if (itemCount > 0) {
     return {
       title: "Coverage is loading normally",
-      body: "Ranked events are available below.",
+      body: `Ranked events are available below once they clear the ${TOP_EVENT_SOURCE_THRESHOLD}-source confirmation threshold.`,
     };
   }
 


### PR DESCRIPTION
## Summary
- implement an event-centric intelligence layer shared by homepage and dashboard
- separate confirmed multi-source Top Events from single-source Early Signals
- expose ranking transparency, timeline state, confidence, and supporting coverage in the UI

## Validation
- npm install
- npm run build
- manual dev-server checks on `/` and `/dashboard`

## Notes
- `npm run lint` currently fails on pre-existing `react-hooks/set-state-in-effect` issues outside this PR
- `npm run test` currently fails because Vitest alias resolution for `@/` imports is already broken in this repo