### PR TITLE
test: add Playwright E2E foundation and starter coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # next.js
 /.next/

--- a/docs/engineering/engineering-protocol.md
+++ b/docs/engineering/engineering-protocol.md
@@ -54,6 +54,7 @@
 ## 6. Validation Sequence
 - Validation order is `Local -> Vercel Preview -> Production`.
 - Local is for code correctness, rendering checks, and fast debugging.
+- Playwright is the default automated E2E and functional testing layer for UI flows, smoke coverage, and regression coverage.
 - Preview is the real deployment-like truth layer.
 - Production is for final sanity checks only.
 - If auth, cookies, redirects, SSR, or environment logic has not been tested in preview, it is not validated.
@@ -66,11 +67,13 @@
 - `npm run build`
 - the Dev Server Rule
 - `npm run dev`
+- `npx playwright test` when UI, routing, SSR, or auth-adjacent flows are affected and local execution is technically possible
 - basic smoke validation
 - a concise test report
 - a repo-safe docs update
 - Build failure is blocking.
 - Lint and test failures must be reported explicitly.
+- Codex must report the exact commands run, pass/fail status, and remaining human-only validation.
 
 ## 8. Human Validation Requirements
 - The user must validate in preview when relevant:
@@ -81,6 +84,8 @@
 - SSR behavior
 - env-dependent behavior
 - After merge to `main`, the user must perform a concise production sanity check.
+- Preview remains the source of truth for auth, cookies, redirects, SSR, and environment-specific behavior.
+- Production is not a debugging ground.
 
 ## 9. Git and Branch Discipline
 - One feature or fix per branch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1535,6 +1536,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -6733,6 +6750,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@supabase/ssr": "^0.10.0",
@@ -25,6 +28,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = 3000;
+const baseURL = `http://localhost:${port}`;
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [
+    ["list"],
+    ["html", { open: "never" }],
+  ],
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  webServer: process.env.PLAYWRIGHT_MANAGED_WEBSERVER
+    ? {
+        command: "npm run dev",
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      }
+    : undefined,
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+  ],
+});

--- a/tests/dashboard.spec.ts
+++ b/tests/dashboard.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("dashboard", () => {
+  test("renders the signed-out dashboard smoke state", async ({ page }) => {
+    await page.goto("/dashboard");
+
+    await expect(page).toHaveTitle(/today's briefing/i);
+    await expect(page.getByRole("heading", { name: /today's public briefing/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /what signing in unlocks/i })).toBeVisible();
+    await expect(page.getByText(/preview the ranked public briefing here, then sign in/i)).toBeVisible();
+  });
+});

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("homepage", () => {
+  test("renders the public briefing smoke flow", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page).toHaveTitle(/Daily Intelligence/i);
+    await expect(
+      page.getByRole("heading", {
+        name: /preview a structured intelligence briefing before you unlock the full workspace/i,
+      }),
+    ).toBeVisible();
+    await expect(page.getByRole("link", { name: /daily intelligence/i })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /confirmed developments, ranked with transparent logic/i }),
+    ).toBeVisible();
+  });
+
+  test("opens the sign-in entry flow for signed-out visitors", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("button", { name: /personalize briefing/i }).click();
+
+    await expect(
+      page.getByRole("heading", { name: /continue to daily intelligence/i }),
+    ).toBeVisible();
+    await expect(page.getByLabel(/email/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: /sign in with email/i })).toBeVisible();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
+    exclude: ["tests/**", "node_modules/**", "dist/**", ".next/**"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add Playwright as the local end-to-end automation foundation
- add starter homepage and dashboard smoke/auth-entry tests
- update engineering protocol to treat Playwright as the default local E2E layer for UI flows

## Verified locally
- `npm install`
- `npx playwright --version`
- `npx playwright install`
- `npm run build`
- `npm run dev`
- `npx playwright test` → passed
- `npx playwright test --project=chromium` → passed
- `npx playwright show-report --host 127.0.0.1 --port 9323` → passed
- `npm run test || true` → passed
- `npm run lint || true` → pre-existing failure in `src/components/app-shell.tsx:56` and `:67`

## Still requires preview / human validation
- auth cookies and session persistence
- OAuth redirect correctness
- SSR / env-sensitive behavior
- preview-host callback behavior
- real signed-in journey with live data
- final production sanity after merge

## Notes
- no Playwright GitHub Actions workflow was added
- this PR is local-first foundation work, not CI/CD automation
- Node `v25.9.0` worked locally, but is a non-LTS baseline
