### PR TITLE
docs: add Playwright post-coding testing SOP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,15 +28,35 @@ Before ANY substantial implementation work, you MUST read:
 - Verify the app loads.
 - If build fails, stop.
 
-## 5. Human Validation Required
+## 5. Playwright Post-Coding Execution Rule
+- For any UI-affecting, auth-affecting, routing-affecting, SSR-affecting, dashboard-affecting, or data-rendering change, Codex must evaluate whether Playwright coverage must be added or updated.
+- After implementation is complete, Codex must run the local Playwright workflow when technically possible.
+- Minimum default local flow:
+- `npm install`
+- `npm run lint || true`
+- `npm run test || true`
+- `npm run build`
+- the Dev Server Rule
+- `npm run dev`
+- `npx playwright test --project=chromium`
+- If the feature affects broader UI behavior, Codex should run `npx playwright test`.
+- Codex must report:
+- exact commands run
+- exact Local URL
+- Playwright pass/fail results
+- remaining preview-required checks
+- remaining human-only checks
+- Codex must not claim preview or production validation from local Playwright results alone.
+
+## 6. Human Validation Required
 - Request user validation for OAuth or login flows.
 - Request user validation for session persistence.
 - Request user validation for preview environment behavior.
 - Request user validation for auth, SSR, or env-sensitive changes.
 
-## 6. Documentation & Security
+## 7. Documentation & Security
 - Update repo-safe documentation for every serious feature or fix.
 - Never commit or expose API keys, tokens, secrets, auth vulnerabilities, exploit steps, cookies, headers, or sensitive logs.
 
-## 7. Merge Conditions
+## 8. Merge Conditions
 - Do not recommend merge unless build passes, local validation is complete, preview validation is confirmed, and docs are updated.

--- a/docs/engineering/engineering-protocol.md
+++ b/docs/engineering/engineering-protocol.md
@@ -66,11 +66,17 @@
 - `npm run build`
 - the Dev Server Rule
 - `npm run dev`
+- Playwright is the default local E2E and functional automation layer for UI flows.
+- After coding is complete, Codex should run the local Playwright workflow when technically possible.
+- Minimum required local Playwright path is `npx playwright test --project=chromium`.
+- Codex should broaden to `npx playwright test` when the feature scope meaningfully affects multiple UI flows.
 - basic smoke validation
 - a concise test report
 - a repo-safe docs update
 - Build failure is blocking.
 - Lint and test failures must be reported explicitly.
+- Codex must report the exact commands run, Local URL, Playwright results, preview-required checks, and human-only checks.
+- Local Playwright passing does not replace preview validation for auth, cookies, redirects, SSR, or env-sensitive behavior.
 
 ## 8. Human Validation Requirements
 - The user must validate in preview when relevant:
@@ -128,6 +134,8 @@
 ## 14. Enforcement Behavior
 - Do not recommend merge when:
 - preview validation is missing for env, auth, cookies, redirects, or SSR work
+- required Playwright local automation has not been run for the branch scope
+- required Playwright coverage is failing for the branch scope
 - scope is mixed
 - docs are missing
 - build is broken


### PR DESCRIPTION
## Summary
- require Codex to evaluate Playwright coverage for UI/auth/routing/SSR/dashboard/data-rendering changes
- require local Playwright execution after implementation when technically appropriate
- require structured reporting of commands run, Local URL, Playwright pass/fail, preview-required checks, and human-only checks
- clarify that this is workflow policy only and does not create event-triggered CI/CD automation

## Files changed
- `AGENTS.md`
- `docs/engineering/engineering-protocol.md`

## Notes
- docs-only change
- no runtime code changes
- no CI/CD or deployment hooks added
- intended to strengthen the default post-coding testing workflow with Playwright
