### PR TITLE
chore: audit and tighten PRD-23 release governance gate

### DIFF
--- a/docs/engineering/protocols/release-automation-operating-guide.md
+++ b/docs/engineering/protocols/release-automation-operating-guide.md
@@ -35,12 +35,14 @@
   - `pr-e2e-chromium`
   - `pr-summary`
   - `release-governance-gate`
+- GitHub branch protection must separately require those checks; the repo workflows alone do not make them blocking.
 - These jobs automate install, lint, build, unit/integration tests, Chromium Playwright smoke coverage, artifact upload, and PR summary generation.
 
 ### 2a. Release Governance Gate
 - Workflow: [release-governance-gate.yml](/Users/bm/Documents/daily-intelligence-aggregator-main/.github/workflows/release-governance-gate.yml)
 - Script entrypoint: `python scripts/release-governance-gate.py`
 - Reuses the feature-system CSV validator and inspects the PR diff.
+- Monitored change areas include `src/`, `supabase/`, `scripts/`, `.github/workflows/`, and key root config files such as `package.json`, `next.config.ts`, `playwright.config.ts`, and `tsconfig.json`.
 - Classification:
   - docs-only
   - trivial-code-change
@@ -49,8 +51,9 @@
 - Enforcement:
   - docs-only changes pass when CSV validation still passes
   - trivial code changes pass when CSV validation still passes
-  - material feature or system changes require at least one supporting docs update in `docs/product/briefs/`, `docs/product/prd/`, `docs/engineering/bug-fixes/`, `docs/engineering/incidents/`, `docs/engineering/change-records/`, `docs/engineering/testing/`, or `docs/engineering/protocols/`
+  - material feature or system changes require at least one supporting docs update in `docs/product/briefs/`, `docs/product/prd/`, `docs/engineering/bug-fixes/`, `docs/engineering/incidents/`, `docs/engineering/change-records/`, `docs/engineering/testing/`, `docs/engineering/protocols/`, `docs/product/documentation-rules.md`, or `AGENTS.md`
   - new feature or system changes require a canonical `PRD-XX` file in `docs/product/prd/` plus a matching `docs/product/feature-system.csv` mapping
+  - new scripts or workflow files are treated as material governance changes by default, not as new feature/system declarations by themselves
 
 ### 3. Preview Gate
 - Workflow: [preview-gate.yml](/Users/bm/Documents/daily-intelligence-aggregator-main/.github/workflows/preview-gate.yml)

--- a/scripts/release-governance-gate.py
+++ b/scripts/release-governance-gate.py
@@ -12,12 +12,25 @@ from pathlib import Path
 
 
 MONITORED_PREFIXES = (
-    "src/app/",
-    "src/components/",
-    "src/lib/",
+    "src/",
     "supabase/",
     "scripts/",
     ".github/workflows/",
+)
+MONITORED_EXACT_PATHS = (
+    "package.json",
+    "package-lock.json",
+    "next.config.ts",
+    "tsconfig.json",
+    "playwright.config.ts",
+    "vitest.config.ts",
+    "eslint.config.mjs",
+    "postcss.config.mjs",
+    "src/proxy.ts",
+)
+NEW_FEATURE_PREFIXES = (
+    "src/",
+    "supabase/",
 )
 RELEVANT_DOC_PREFIXES = (
     "docs/product/briefs/",
@@ -27,6 +40,10 @@ RELEVANT_DOC_PREFIXES = (
     "docs/engineering/change-records/",
     "docs/engineering/testing/",
     "docs/engineering/protocols/",
+)
+RELEVANT_DOC_FILES = (
+    "AGENTS.md",
+    "docs/product/documentation-rules.md",
 )
 CSV_PATH = "docs/product/feature-system.csv"
 PRD_DIR = "docs/product/prd"
@@ -122,15 +139,15 @@ def load_changes(repo_root: Path, diff_range: str) -> dict[str, Change]:
 
 
 def is_docs_file(path: str) -> bool:
-    return path.startswith("docs/")
+    return path.startswith("docs/") or path == "AGENTS.md"
 
 
 def is_monitored_file(path: str) -> bool:
-    return path.startswith(MONITORED_PREFIXES)
+    return path.startswith(MONITORED_PREFIXES) or path in MONITORED_EXACT_PATHS
 
 
 def is_relevant_doc_file(path: str) -> bool:
-    return path.startswith(RELEVANT_DOC_PREFIXES)
+    return path.startswith(RELEVANT_DOC_PREFIXES) or path in RELEVANT_DOC_FILES
 
 
 def is_test_file(path: str) -> bool:
@@ -141,17 +158,32 @@ def is_canonical_prd(path: str) -> bool:
     return path.startswith("docs/product/prd/prd-") and path.endswith(".md")
 
 
+def is_new_feature_path(path: str) -> bool:
+    return path.startswith(NEW_FEATURE_PREFIXES)
+
+
+def is_high_risk_trivial_path(path: str) -> bool:
+    return (
+        path.startswith(("src/app/", "supabase/", ".github/workflows/"))
+        or path in MONITORED_EXACT_PATHS
+        or path == "src/lib/auth.ts"
+    )
+
+
 def classify_pr(changes: dict[str, Change]) -> tuple[str, list[Change], list[Change], list[str]]:
     changed_paths = list(changes)
     monitored_changes = [change for change in changes.values() if is_monitored_file(change.path)]
     non_test_monitored = [change for change in monitored_changes if not is_test_file(change.path)]
-    added_non_test_monitored = [change for change in non_test_monitored if change.is_added]
+    added_new_feature_files = [
+        change for change in non_test_monitored if change.is_added and is_new_feature_path(change.path)
+    ]
     new_prd_files = [path for path, change in changes.items() if change.is_added and is_canonical_prd(path)]
+    relevant_doc_updates_present = any(is_relevant_doc_file(path) for path in changed_paths)
 
     if changed_paths and all(is_docs_file(path) for path in changed_paths):
         return "docs-only", monitored_changes, non_test_monitored, new_prd_files
 
-    if new_prd_files or added_non_test_monitored:
+    if new_prd_files or added_new_feature_files:
         return "new-feature-or-system", monitored_changes, non_test_monitored, new_prd_files
 
     if not monitored_changes:
@@ -161,7 +193,8 @@ def classify_pr(changes: dict[str, Change]) -> tuple[str, list[Change], list[Cha
     single_small_modification = (
         len(non_test_monitored) == 1
         and not non_test_monitored[0].is_added
-        and not non_test_monitored[0].path.startswith(("supabase/", ".github/workflows/"))
+        and not is_high_risk_trivial_path(non_test_monitored[0].path)
+        and not relevant_doc_updates_present
         and non_test_monitored[0].total_changed_lines <= TRIVIAL_MAX_CHANGED_LINES
     )
 


### PR DESCRIPTION
## Summary
- audit PRD-23 against real PR evidence and local classifier probes
- tighten `scripts/release-governance-gate.py` to reduce verified false positives/false negatives
- clarify in the operating guide that branch protection must separately require the GitHub checks

## What changed
- monitor all of `src/` plus key root config files such as `package.json`, `next.config.ts`, `playwright.config.ts`, and `tsconfig.json`
- treat new `scripts/` and `.github/workflows/` files as material governance changes by default instead of auto-classifying them as `new-feature-or-system`
- count `AGENTS.md` and `docs/product/documentation-rules.md` as supporting governance docs
- stop auto-marking high-risk routing/auth/config changes as trivial small edits

## Validation
- `python3 scripts/validate-feature-system-csv.py`
- `python3 -m py_compile scripts/release-governance-gate.py scripts/validate-feature-system-csv.py`
- replayed representative local diff probes for docs-only, tests-only, tiny route change, package.json change, new script addition, and material change with docs
- inspected real PR evidence for #31, #34, and #45, including whether `release-governance-gate` appeared in the PR checks

## Audit findings called out by this patch
- PR #31 showed `release-governance-gate` running and passing
- PR #45 showed `release-governance-gate` running and passing
- PR #34 merged even though `release-governance-gate` failed, which implies branch protection was not enforcing it or was bypassed externally