### PR TITLE
Harden release gates with WebKit browser coverage and auth smoke validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,48 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-chromium
+          path: playwright-report
+          if-no-files-found: ignore
+
+  e2e-webkit:
+    name: pr-e2e-webkit
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: test-anon-key
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: test-publishable-key
+      NEXT_PUBLIC_APP_URL: http://127.0.0.1:3000
+      SUPABASE_SERVICE_ROLE_KEY: test-service-role-key
+      OPENAI_API_KEY: test-openai-key
+      THE_NEWS_API_KEY: test-news-api-key
+      NEXT_TELEMETRY_DISABLED: 1
+      PLAYWRIGHT_MANAGED_WEBSERVER: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps webkit
+
+      - name: Run WebKit release smoke
+        run: npm run test:e2e:webkit
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-webkit
           path: playwright-report
           if-no-files-found: ignore
 
@@ -130,6 +171,7 @@ jobs:
       - unit-tests
       - build
       - e2e-chromium
+      - e2e-webkit
     if: always()
     steps:
       - name: Checkout

--- a/docs/engineering/change-records/release-gate-browser-auth-hardening.md
+++ b/docs/engineering/change-records/release-gate-browser-auth-hardening.md
@@ -1,0 +1,41 @@
+# Change Record: Release Gate Browser/Auth Hardening
+
+## Summary
+- Added a second required PR browser smoke gate for WebKit while preserving the existing Chromium gate.
+- Expanded deterministic Playwright coverage around auth-entry and session-sensitive release risk without pretending real provider OAuth is CI-safe.
+- Updated release protocol docs so merge readiness now explicitly depends on Chromium plus WebKit automation, preview verification, and the separate human auth/session gate.
+
+## Changes Made
+- `.github/workflows/ci.yml`
+  - Kept `pr-e2e-chromium`
+  - Added `pr-e2e-webkit`
+  - Updated `pr-summary` to wait for both browser jobs
+- `package.json`
+  - Added `test:e2e:webkit`
+- `scripts/release/validate-local.mjs`
+  - Local release validation now runs both Chromium and WebKit by default
+- `tests/homepage.spec.ts`
+  - Added callback-error auth-entry smoke coverage
+- `tests/dashboard.spec.ts`
+  - Added signed-out refresh truth and callback-error redirect smoke coverage
+- `docs/engineering/protocols/`
+  - Updated release guidance to document the new browser baseline and the remaining human-only auth/session checks
+
+## Browser Coverage Change
+- Before: Chromium-only PR browser enforcement
+- After: Chromium plus WebKit PR browser enforcement
+
+## Auth/Session Coverage Change
+- Newly automated:
+  - signed-out auth entry visibility
+  - signed-out dashboard truth after refresh
+  - callback-error redirect return to the homepage auth state
+- Still manual:
+  - real provider login
+  - real provider callback success path
+  - real signed-in session persistence after refresh
+  - real sign-out behavior
+  - preview-only SSR, cookies, and environment truth
+
+## Follow-up
+- GitHub branch protection or rulesets must be updated manually to require `pr-e2e-webkit` in addition to the existing required checks.

--- a/docs/engineering/change-records/release-gate-browser-auth-hardening.md
+++ b/docs/engineering/change-records/release-gate-browser-auth-hardening.md
@@ -18,6 +18,8 @@
   - Added callback-error auth-entry smoke coverage
 - `tests/dashboard.spec.ts`
   - Added signed-out refresh truth and callback-error redirect smoke coverage
+- `src/components/auth/auth-modal.tsx`
+  - Removed a server/client callback-URL text mismatch so `/?auth=callback-error` no longer throws a hydration warning while the auth modal is open
 - `docs/engineering/protocols/`
   - Updated release guidance to document the new browser baseline and the remaining human-only auth/session checks
 

--- a/docs/engineering/protocols/engineering-protocol.md
+++ b/docs/engineering/protocols/engineering-protocol.md
@@ -90,8 +90,10 @@
 - `npm run dev`
 - Playwright is the default local E2E and functional automation layer for UI flows.
 - After coding is complete, Codex should run the local Playwright workflow when technically possible.
-- Minimum required local Playwright path is `npx playwright test --project=chromium`.
+- Minimum required local Playwright paths are `npx playwright test --project=chromium` and `npx playwright test --project=webkit`.
 - Codex should broaden to `npx playwright test` when the feature scope meaningfully affects multiple UI flows.
+- Release-sensitive browser coverage should prioritize Chromium baseline correctness plus WebKit smoke coverage for Safari-class behavior.
+- Deterministic auth/session smoke should cover signed-out truth, auth entry state, and callback-error or redirect handling when those checks are safely automatable.
 - basic smoke validation
 - a concise test report
 - a repo-safe docs update

--- a/docs/engineering/protocols/human-auth-session-gate.md
+++ b/docs/engineering/protocols/human-auth-session-gate.md
@@ -2,6 +2,8 @@
 
 Use this checklist for every release that can affect auth, cookies, redirects, SSR, or session behavior.
 
+Automated Chromium and WebKit smoke may cover signed-out truth, auth entry surfaces, and callback-error handling, but they do not replace this preview gate for real provider behavior.
+
 ## Required Human Checks
 - Google OAuth sign-in succeeds from the signed-out homepage or auth modal.
 - Email/password sign-in succeeds if that flow is enabled for the release.
@@ -17,4 +19,3 @@ Use this checklist for every release that can affect auth, cookies, redirects, S
 - Date:
 - Result:
 - Notes:
-

--- a/docs/engineering/protocols/release-automation-operating-guide.md
+++ b/docs/engineering/protocols/release-automation-operating-guide.md
@@ -22,6 +22,7 @@
   - `npm run build`
   - Dev Server Rule on port `3000`
   - `npx playwright test --project=chromium`
+  - `npx playwright test --project=webkit`
   - route probes for `/` and `/dashboard`
 - Build failure is blocking.
 - Lint, unit-test, and Playwright failures are reported explicitly and still return a non-zero exit code.
@@ -45,10 +46,11 @@
   - `pr-unit-tests`
   - `pr-build`
   - `pr-e2e-chromium`
+  - `pr-e2e-webkit`
   - `pr-summary`
   - `release-governance-gate`
 - GitHub branch protection must separately require those checks; the repo workflows alone do not make them blocking.
-- These jobs automate install, lint, build, unit/integration tests, Chromium Playwright smoke coverage, artifact upload, and PR summary generation.
+- These jobs automate install, lint, build, unit/integration tests, Chromium plus WebKit Playwright smoke coverage, artifact upload, and PR summary generation.
 
 ### 2a. Release Governance Gate
 - Workflow: [release-governance-gate.yml](/Users/bm/Documents/daily-intelligence-aggregator-main/.github/workflows/release-governance-gate.yml)
@@ -78,12 +80,13 @@
   - expected signed-out markers
   - absence of obvious `500` or framework error pages
 - This gate is intended to run once the Vercel preview URL is known.
+- It remains required for merge readiness because PR CI cannot prove real preview cookies, SSR, redirects, or environment truth by itself.
 
 ### 4. Human Auth/Session Gate
 - Checklist: [human-auth-session-gate.md](/Users/bm/Documents/daily-intelligence-aggregator-main/docs/engineering/protocols/human-auth-session-gate.md)
 - Human-only truth remains required for:
   - Google OAuth/provider login
-  - callback redirect correctness
+  - real-provider callback redirect correctness
   - session persistence after refresh
   - signed-in versus signed-out truth across navigation
   - sign-out correctness
@@ -113,6 +116,8 @@
 - unit/integration tests
 - build
 - local Chromium Playwright smoke
+- local WebKit Playwright smoke
+- deterministic auth entry, signed-out refresh, and callback-error redirect smoke
 - preview route probe
 - production route probe
 - PR summary generation
@@ -121,7 +126,7 @@
 
 ### Human
 - provider/OAuth truth
-- callback truth
+- real-provider callback truth
 - session persistence after refresh
 - sign-out truth
 - final merge approval
@@ -151,6 +156,7 @@
   - `pr-unit-tests`
   - `pr-build`
   - `pr-e2e-chromium`
+  - `pr-e2e-webkit`
   - `pr-summary`
   - `release-governance-gate`
 - Confirm the rule applies to pull requests targeting `main`.

--- a/docs/engineering/protocols/release-machine.md
+++ b/docs/engineering/protocols/release-machine.md
@@ -46,7 +46,7 @@ Minimum required validation:
 - lint
 - build
 - tests
-- Playwright/e2e when technically appropriate
+- Chromium and WebKit Playwright smoke when technically appropriate
 - local smoke validation
 
 ### Gate 2 — Preview Gate
@@ -131,7 +131,7 @@ Codex must not pretend these are fully automated if they are not.
 
 Human-only checks include:
 - real provider login
-- real callback truth
+- real provider callback truth
 - real session persistence
 - real sign-out correctness
 - subjective UX judgment where appropriate

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:chromium": "playwright test --project=chromium",
+    "test:e2e:webkit": "playwright test --project=webkit",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:report": "playwright show-report",
     "release:local": "node scripts/release/validate-local.mjs",

--- a/scripts/release/validate-local.mjs
+++ b/scripts/release/validate-local.mjs
@@ -45,7 +45,10 @@ function envForAppBootstrap(baseUrl) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const installMode = args.install || "if-needed";
-  const e2eProject = args["e2e-project"] || "chromium";
+  const e2eProjects = String(args["e2e-project"] || "chromium,webkit")
+    .split(",")
+    .map((project) => project.trim())
+    .filter(Boolean);
   const baseUrl = args["base-url"] || DEFAULT_LOCAL_BASE_URL;
   const env = envForLocalRun();
   const appEnv = envForAppBootstrap(baseUrl);
@@ -55,10 +58,16 @@ async function main() {
     createStep("unit tests", { soft: true }),
     createStep("build"),
     createStep("dev server rule"),
-    createStep(`playwright (${e2eProject})`, { soft: true }),
+    ...e2eProjects.map((project) => createStep(`playwright (${project})`, { soft: true })),
     createStep("local smoke routes"),
   ];
-  const [installStep, lintStep, testStep, buildStep, devStep, playwrightStep, smokeStep] = steps;
+  const installStep = steps[0];
+  const lintStep = steps[1];
+  const testStep = steps[2];
+  const buildStep = steps[3];
+  const devStep = steps[4];
+  const playwrightSteps = steps.slice(5, 5 + e2eProjects.length);
+  const smokeStep = steps.at(-1);
   let devServer;
 
   try {
@@ -124,11 +133,13 @@ async function main() {
         ? `Freed port ${DEFAULT_PORT} from PID(s): ${portOwners.join(", ")}`
         : `Dev server ready at ${baseUrl}`;
 
-    runCommand("npx", ["playwright", "test", "--project", e2eProject], {
-      step: playwrightStep,
-      allowFailure: true,
-      env: appEnv,
-    });
+    for (const [index, project] of e2eProjects.entries()) {
+      runCommand("npx", ["playwright", "test", "--project", project], {
+        step: playwrightSteps[index],
+        allowFailure: true,
+        env: appEnv,
+      });
+    }
 
     const smokeStartedAt = Date.now();
     const smokeResults = await probeRoutes({

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 
 import PersonalizedDashboard from "@/components/dashboard/personalized-dashboard";
 import { getDashboardPageState } from "@/lib/data";
+import { isAiConfigured } from "@/lib/env";
 
 export const metadata: Metadata = {
   title: "Today's Briefing — Daily Intelligence",
@@ -22,6 +23,7 @@ export default async function DashboardPage({
       searchParams={params}
       data={pageState.data}
       viewer={pageState.viewer}
+      isAiConfigured={isAiConfigured}
     />
   );
 }

--- a/src/components/auth/auth-modal.tsx
+++ b/src/components/auth/auth-modal.tsx
@@ -14,7 +14,6 @@ type Props = {
 export default function AuthModal({ open, onClose, errorMessage }: Props) {
   const [googlePending, setGooglePending] = useState(false);
   const [googleError, setGoogleError] = useState<string | null>(null);
-  const redirectTo = useMemo(() => getGoogleRedirectTo(), []);
   const authDiagnostics = useMemo(() => getSupabasePublicEnvDiagnostics(), []);
   const authConfigured = isSupabaseConfigured;
   const configErrorMessage = authConfigured
@@ -26,6 +25,7 @@ export default function AuthModal({ open, onClose, errorMessage }: Props) {
 
   async function handleGoogleSignIn() {
     const supabase = createSupabaseBrowserClient();
+    const redirectTo = getGoogleRedirectTo();
 
     console.info("[auth] Google button clicked", {
       redirectFlow: "full-page redirect",
@@ -142,7 +142,8 @@ export default function AuthModal({ open, onClose, errorMessage }: Props) {
         <div className="space-y-3">
           <GoogleAuthButton pending={googlePending} onClick={handleGoogleSignIn} disabled={!authConfigured} />
           <p className="text-xs leading-5 text-[var(--muted)]">
-            Google uses a full-page redirect flow. Redirect target for this page: <span className="font-medium text-[var(--foreground)]">{redirectTo}</span>
+            Google uses a full-page redirect flow through{" "}
+            <span className="font-medium text-[var(--foreground)]">/auth/callback</span>.
           </p>
         </div>
 

--- a/src/components/dashboard/personalized-dashboard.tsx
+++ b/src/components/dashboard/personalized-dashboard.tsx
@@ -12,7 +12,6 @@ import { PageHeader } from "@/components/page-header";
 import { Badge } from "@/components/ui/badge";
 import { Panel } from "@/components/ui/panel";
 import { buildEventIntelligenceSignals, isTopEventEligible } from "@/lib/event-intelligence";
-import { isAiConfigured } from "@/lib/env";
 import { getDisplayStateLabel, getDisplayStateTone } from "@/lib/habit-loop";
 import {
   buildPersonalizationMatch,
@@ -33,12 +32,14 @@ type PersonalizedDashboardProps = {
   searchParams: { generated?: string; allread?: string };
   data: DashboardData;
   viewer: ViewerAccount | null;
+  isAiConfigured: boolean;
 };
 
 export default function PersonalizedDashboard({
   searchParams: params,
   data,
   viewer,
+  isAiConfigured,
 }: PersonalizedDashboardProps) {
   const isSignedIn = Boolean(viewer);
   const personalizationPayload = useSyncExternalStore(

--- a/tests/dashboard.spec.ts
+++ b/tests/dashboard.spec.ts
@@ -9,4 +9,32 @@ test.describe("dashboard", () => {
     await expect(page.getByRole("heading", { name: /what signing in unlocks/i })).toBeVisible();
     await expect(page.getByText(/preview the ranked public briefing here, then sign in/i)).toBeVisible();
   });
+
+  test("keeps the signed-out dashboard truth after refresh", async ({ page }) => {
+    await page.goto("/dashboard");
+
+    await expect(page.getByRole("heading", { name: /today's public briefing/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /what signing in unlocks/i })).toBeVisible();
+
+    await page.reload();
+
+    await expect(page).toHaveURL(/\/dashboard$/);
+    await expect(page.getByRole("heading", { name: /today's public briefing/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /what signing in unlocks/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /unlock full briefing/i })).toBeVisible();
+  });
+
+  test("returns provider callback errors to the homepage callback-error state", async ({ page }) => {
+    await page.goto(
+      "/auth/callback?error=access_denied&error_code=otp_expired&error_description=User%20denied%20access",
+    );
+
+    await expect(page).toHaveURL(/\/\?auth=callback-error$/);
+    await expect(
+      page.getByRole("heading", { name: /continue to daily intelligence/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("alert").getByText(/sign-in callback could not be completed/i),
+    ).toBeVisible();
+  });
 });

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -27,4 +27,17 @@ test.describe("homepage", () => {
     await expect(page.getByLabel(/email/i)).toBeVisible();
     await expect(page.getByRole("button", { name: /sign in with email/i })).toBeVisible();
   });
+
+  test("surfaces callback error state without losing the auth entry flow", async ({ page }) => {
+    await page.goto("/?auth=callback-error");
+
+    await expect(
+      page.getByRole("alert").getByText(/sign-in callback could not be completed/i),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /continue to daily intelligence/i }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: /continue with google/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /sign in with email/i })).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- preserve the existing Chromium PR browser gate and add a required WebKit PR browser gate
- update local release validation so Chromium and WebKit both run by default
- expand deterministic Playwright smoke coverage for auth entry, signed-out refresh truth, and callback-error redirect handling
- update release engineering docs and add a change record for the browser/auth hardening rollout
- fix hydration mismatches surfaced during hardening validation

## Validation
- npm install
- npm run lint
- npm run test
- npm run build
- npx playwright test --project=chromium
- npx playwright test --project=webkit
- npm run release:local -- --install=never

## Remaining human-only checks
- real provider login
- real successful provider callback path
- signed-in session persistence after refresh
- real sign-out behavior
- preview-only auth/cookie/SSR/env truth

## Manual follow-up
- GitHub branch protection must manually add `pr-e2e-webkit` as a required check for `main`