### PR TITLE
[codex] Require tracker closeout before task completion

### DIFF
--- a/docs/engineering/bug-fixes/templates/bug-fix-record-template.md
+++ b/docs/engineering/bug-fixes/templates/bug-fix-record-template.md
@@ -12,5 +12,9 @@
 - Automated checks:
 - Human checks:
 
+## Tracker Closeout
+- Google Sheets tracker row updated and verified:
+- Fallback tracker-sync file, if direct Sheets update was unavailable:
+
 ## Remaining Risks / Follow-up
 - 

--- a/docs/engineering/protocols/prd-template.md
+++ b/docs/engineering/protocols/prd-template.md
@@ -22,3 +22,14 @@
 ## Evidence and Confidence
 - Repo evidence used:
 - Confidence:
+
+## Closeout Checklist
+- Scope completed:
+- Tests run:
+- Local validation complete:
+- Preview validation complete, if applicable:
+- Production sanity check complete, only after preview is good:
+- PRD summary stored in repo:
+- Bug-fix report stored in repo, if applicable:
+- Google Sheets tracker updated and verified:
+- If direct Sheets update is unavailable, fallback tracker-sync file created in `docs/operations/tracker-sync/` with exact manual update payload:

--- a/docs/engineering/protocols/release-automation-operating-guide.md
+++ b/docs/engineering/protocols/release-automation-operating-guide.md
@@ -32,12 +32,14 @@
 - Script entrypoint: `node scripts/github-sheets-sync.mjs --event pr-merge --payload-file <path>`
 - Permanent rules:
   - Google Sheets workbook `Features Table` is the live feature-tracking system.
+  - Tracker update is part of Definition of Done for feature, fix, refactor, UX, and governance work.
   - `Sheet1` is the governed table for approved mapped work.
   - `Intake Queue` is the only destination for unmapped, spontaneous, or ambiguous merged work.
   - `Record ID` in `Sheet1` is immutable and may only be used as the exact-match lookup key.
   - The automation must validate the expected headers before writing and may update only approved automation-managed columns.
   - A merge to `main` may update one exact `Record ID` match to `Merged`.
   - A merge must never auto-create a new governed `Sheet1` row.
+  - Codex closeout must verify a live sheet update, or create a fallback tracker-sync markdown file in `docs/operations/tracker-sync/` with the exact manual update payload.
 
 ### 2. PR Gate
 - Workflow: [ci.yml](/Users/bm/Documents/daily-intelligence-aggregator-main/.github/workflows/ci.yml)
@@ -119,6 +121,17 @@
   - [docs/engineering/testing/templates/release-testing-report-template.md](/Users/bm/Documents/daily-intelligence-aggregator-main/docs/engineering/testing/templates/release-testing-report-template.md)
   - [docs/engineering/bug-fixes/templates/release-bug-fix-template.md](/Users/bm/Documents/daily-intelligence-aggregator-main/docs/engineering/bug-fixes/templates/release-bug-fix-template.md)
   - [docs/product/briefs/templates/release-brief-template.md](/Users/bm/Documents/daily-intelligence-aggregator-main/docs/product/briefs/templates/release-brief-template.md)
+
+### 7. Closeout Checklist
+- Scope completed.
+- Tests run and results recorded.
+- Local validation complete.
+- Preview validation complete when applicable.
+- Production sanity check run only after preview is good.
+- PRD summary stored in repo when applicable.
+- Bug-fix report stored in repo when applicable.
+- Google Sheets tracker updated and verified.
+- If direct Sheets update is unavailable, fallback tracker-sync file created in `docs/operations/tracker-sync/`.
 
 ## Automated Versus Human
 ### Automated

--- a/docs/engineering/protocols/release-machine.md
+++ b/docs/engineering/protocols/release-machine.md
@@ -86,6 +86,15 @@ Minimum production verification:
 ### Gate 6 — Documentation Gate
 For every serious feature, fix, consolidation, or release, Codex must update concise repo-safe docs.
 
+### Gate 7 — Tracker Closeout Gate
+Before a task is considered complete, Codex must update the Google Sheets workbook `Features Table`.
+
+Required tracker closeout:
+- If direct Sheets access is available, update the existing mapped row and verify the row after writing.
+- If the work is unmapped or ambiguous, route it to the appropriate review lane instead of creating a duplicate governed row.
+- If direct Sheets access is unavailable, create a concise fallback tracker-sync markdown file in `docs/operations/tracker-sync/` with the exact manual update payload.
+- Do not mark the task complete until the live sheet is verified or the fallback file exists.
+
 ---
 
 ## 4. Required Commands and Entrypoints
@@ -172,11 +181,17 @@ For serious implementation or release work, Codex should report in a structured 
 3. validation performed
 4. preview status
 5. human-only checks still needed
-6. merge decision
-7. exact git result
-8. docs updated
+6. Google Sheets tracker status or fallback tracker-sync file
+7. merge decision
+8. exact git result
+9. docs updated
 
 ---
 
-## 11. Failure Rule
+## 11. Reusable Codex Closeout Block
+Before closing this task, update the Google Sheets tracker. If direct update is unavailable, create a tracker-sync markdown file in the repo with the exact manual update payload. Do not mark the task complete until one of these two paths is done.
+
+---
+
+## 12. Failure Rule
 If Codex skips these release gates, any merge recommendation is invalid.

--- a/docs/engineering/protocols/test-checklist.md
+++ b/docs/engineering/protocols/test-checklist.md
@@ -39,9 +39,11 @@
 - `docs/product/feature-system.csv` updated if applicable.
 - Bug-fix, incident, or change-record doc created if applicable.
 - Testing note added if meaningful validation was performed.
+- Google Sheets tracker updated and verified, or fallback tracker-sync file created in `docs/operations/tracker-sync/`.
 - No sensitive information is included.
 
 ## 8. Merge Readiness
 - Build passes.
 - Preview validation is complete.
+- Tracker closeout is complete: live Google Sheets row verified or exact manual update payload recorded in repo fallback.
 - No known blockers remain.

--- a/docs/engineering/testing/templates/release-testing-report-template.md
+++ b/docs/engineering/testing/templates/release-testing-report-template.md
@@ -16,6 +16,11 @@
 - Preview gate:
 - Production verification gate:
 
+## Tracker Closeout
+- Google Sheets tracker update:
+- Verified row / item:
+- Fallback tracker-sync file, if direct Sheets update was unavailable:
+
 ## Human Auth / Session Results
 - Google OAuth:
 - Email/password:
@@ -25,4 +30,3 @@
 
 ## Remaining Risks
 - 
-

--- a/docs/operations/tracker-sync/README.md
+++ b/docs/operations/tracker-sync/README.md
@@ -1,0 +1,22 @@
+# Tracker Sync Fallbacks
+
+Use this folder only when direct Google Sheets updates are unavailable during task closeout.
+
+Each fallback file must be concise, repo-safe, and named `YYYY-MM-DD-short-title-tracker-sync.md`.
+
+Required fields:
+- Date
+- Feature or fix title
+- Type
+- Branch
+- Implementation summary
+- Testing / validation status
+- PRD summary path, if applicable
+- Bug-fix report path, if applicable
+- Exact Google Sheet fields to update
+- Exact manual values to enter
+- Remaining follow-up items or risks
+
+Closeout rule:
+- Do not mark a task complete until the Google Sheets tracker is updated and verified, or a fallback file exists here with the exact manual update payload.
+- Do not include secrets, tokens, cookies, sensitive logs, private infrastructure details, auth vulnerability details, or exploit instructions.

--- a/docs/product/briefs/templates/release-brief-template.md
+++ b/docs/product/briefs/templates/release-brief-template.md
@@ -33,3 +33,4 @@
 - `docs/product/prd/` when the release maps to numbered feature work
 - `docs/engineering/testing/`
 - `docs/engineering/bug-fixes/` when a real defect was fixed
+- Google Sheets tracker updated and verified, or fallback tracker-sync file created in `docs/operations/tracker-sync/`

--- a/docs/product/documentation-rules.md
+++ b/docs/product/documentation-rules.md
@@ -7,6 +7,7 @@ This repository uses a controlled documentation system. The goal is to keep docs
 - `Sheet1` is the governed approved feature table and `Intake Queue` is the quarantine lane for unmapped or ambiguous work.
 - `Record ID` in `Sheet1` is immutable and may only be used as the governed lookup key for automation.
 - Automation must never write formula/computed columns or silently overwrite human-managed fields in Google Sheets.
+- Tracker closeout is part of Definition of Done: update and verify the live Google Sheet, or create a fallback tracker-sync file in `docs/operations/tracker-sync/` with the exact manual update payload.
 - `docs/product/feature-system.csv` is the repo-side control layer for PRD mapping, build order, and durable governance metadata.
 - The CSV is the product control layer and its schema is locked to exactly 12 columns in this exact order:
   `Layer, Feature Name, Priority, Status, Description, Owner, Dependency, Build Order, Decision, Last Updated, prd_id, prd_file`
@@ -57,6 +58,7 @@ This repository uses a controlled documentation system. The goal is to keep docs
 7. During active branch work, set `status = In Progress`.
 8. When implementation is complete but awaiting merge or review, set `status = In Review`.
 9. After merge or explicit user acceptance, set `status = Built`, `decision = keep`, and update `last_updated`.
+10. Before closeout, verify the Google Sheets tracker row or create a fallback tracker-sync markdown file with the exact manual update payload.
 
 ## Change Control
 - Do not implement features marked `delay` or `kill`.
@@ -83,6 +85,8 @@ This repository uses a controlled documentation system. The goal is to keep docs
   Concise validation notes and test reports
 - `docs/engineering/protocols/`:
   Operating rules, templates, checklists, and governance standards
+- `docs/operations/tracker-sync/`:
+  Fallback tracker-sync payloads when direct Google Sheets updates are unavailable
 
 ## Meaningful Documentation Threshold
 - Use the smallest truthful documentation set that preserves future understanding.


### PR DESCRIPTION
## Summary
- Adds a tracker closeout gate to the release protocol and output requirements.
- Adds a reusable Codex closeout block requiring either a verified Google Sheets update or a repo fallback tracker-sync file.
- Updates PRD, bug-fix, testing, release brief, and documentation templates/checklists with tracker closeout fields.
- Adds `docs/operations/tracker-sync/README.md` for exact manual update payloads when direct Sheets access is unavailable.

## Tracker update performed
- Google Sheets workbook: `Features Table`
- Tab: `Sheet1`
- Row: `54`
- Record ID: `PRD-36`
- Status: `Merged`
- Notes include branch `feature/prd-36-signal-display-cap`, PR `#60`, and remaining preview/production checks before `Built`.

## Validation
- `npm install`
- `npm run lint || true`
- `npm run test || true`
- `python3 scripts/validate-feature-system-csv.py`
- `npm run build`
- `git diff --check`

Notes: `npm install` reported one existing high-severity audit item. CSV validation passed with the existing PRD-32 slug warning.