### PR TITLE
Add deployed runtime source audit snapshot

### DIFF
--- a/docs/engineering/change-records/runtime-source-observability.md
+++ b/docs/engineering/change-records/runtime-source-observability.md
@@ -13,8 +13,9 @@ Post-merge source audits needed a clean way to verify which source IDs were reso
 - A safe runtime source-resolution snapshot in the existing `src/lib/observability/pipeline-run.ts` module.
 - A structured server log event named `Runtime source resolution snapshot`.
 - Pipeline-run metadata carrying the same source-resolution snapshot for local and test verification.
+- A no-argument source-resolution audit snapshot attached to the existing `Dashboard data request received` server log. This invokes the no-argument resolution helper only; it does not fetch no-argument feeds and does not change the public MVP source list used for dashboard rendering.
 
-The snapshot separates:
+The snapshots separate:
 
 - MVP default public source IDs
 - donor fallback default IDs
@@ -24,7 +25,7 @@ The snapshot separates:
 
 ## Safety Boundary
 
-The snapshot is ID-only. It does not expose feed URLs, registry dumps, request headers, cookies, user identity, tokens, secrets, or provider credentials. No public route or unauthenticated debug endpoint was added.
+The snapshot is ID-only. It does not expose feed URLs, registry dumps, request headers, cookies, user identity, tokens, secrets, or provider credentials. No public route, UI, or unauthenticated debug endpoint was added.
 
 ## How To Use In Future Audits
 
@@ -38,11 +39,14 @@ Run a local, preview, or production ingestion path and inspect server logs for `
 
 For supplied public MVP sources, use the pipeline metadata or focused tests to confirm `resolution_mode` is `supplied_sources` and the resolved IDs are the `custom-*` versions of the explicit MVP public defaults.
 
+For deployed production audits where the no-argument ingestion path is not otherwise invoked, request the existing home or dashboard route and inspect the `Dashboard data request received` server log for `no_argument_runtime_source_resolution_audit`. Confirm the same no-argument fields above. This is a resolution audit only; it proves the deployed build can resolve the no-argument source set, not that those no-argument feeds were fetched on that request.
+
 ## What This Proves
 
 - Which governed source ID sets the runtime knew about at resolution time.
 - Which source IDs were resolved for the current ingestion path.
 - Whether MIT Technology Review remains the only probationary runtime source.
+- In deployed route logs, whether the no-argument runtime source resolver can resolve the governed donor defaults plus probationary runtime IDs without adding a debug route.
 
 ## What This Does Not Prove
 
@@ -50,6 +54,7 @@ For supplied public MVP sources, use the pipeline metadata or focused tests to c
 - It does not prove preview or production network health by itself.
 - It does not promote or activate any source.
 - It does not replace release preview validation or human review for source-policy changes.
+- The dashboard audit snapshot does not mean the public dashboard rendered from no-argument sources; the dashboard still renders from supplied MVP public defaults unless that behavior is changed by a separate governed PR.
 
 ## Why This Comes Before More Source Activation
 

--- a/docs/operations/tracker-sync/2026-04-19-runtime-source-auditability.md
+++ b/docs/operations/tracker-sync/2026-04-19-runtime-source-auditability.md
@@ -1,0 +1,26 @@
+# Tracker Sync — Runtime Source Auditability
+
+Date: 2026-04-19
+
+## Reason
+
+Direct live tracker access was not used in this pass. This fallback artifact records the intended tracker update for `PRD-42` so the governed row can be reconciled manually without creating duplicate feature rows.
+
+## Governed Row
+
+- PRD ID: `PRD-42`
+- PRD File: `docs/product/prd/prd-42-source-governance-and-defaults.md`
+- Work type: auditability / observability follow-up
+
+## Intended Tracker Update
+
+- Status: `In Review`
+- Decision: `keep`
+- Notes: Added an ID-only no-argument runtime source-resolution audit snapshot to the existing server-side dashboard/homepage request log. No new public endpoint, no source activation, no MVP default change, no donor fallback default change, and no source-policy boost change.
+
+## Verification Payload
+
+- MVP public defaults remain `source-verge`, `source-ars`, `source-tldr-tech`, `source-techcrunch`, and `source-ft`.
+- Donor fallback defaults remain `openclaw-the-verge`, `openclaw-ars-technica`, `horizon-reuters-world`, and `horizon-reuters-business`.
+- Probationary runtime feeds remain `mit-technology-review` only.
+- The new audit snapshot is ID-only and does not include feed URLs, credentials, cookies, request headers, user IDs, or secrets.

--- a/docs/product/prd/prd-42-source-governance-and-defaults.md
+++ b/docs/product/prd/prd-42-source-governance-and-defaults.md
@@ -40,6 +40,7 @@ The product needs a narrow high-signal source mix. If catalog additions, fallbac
 - `src/adapters/donors/registry.ts` also owns `PROBATIONARY_RUNTIME_FEED_IDS`, a separate governed runtime path for explicitly approved source trials. This is not an MVP default list and does not alter donor fallback defaults.
 - `src/lib/observability/pipeline-run.ts` builds a safe runtime source-resolution snapshot with governed source IDs only.
 - `src/lib/pipeline/ingestion/index.ts` emits an ID-only structured log for runtime source resolution and attaches the same snapshot to pipeline-run metadata for local/test inspection.
+- `src/lib/data.ts` attaches an ID-only no-argument runtime source-resolution audit snapshot to the existing server-side dashboard/homepage request log so deployed audits can verify resolution without adding a public debug route.
 - `src/app/sources/page.tsx` presents catalog state as optional/importable rather than default ingestion.
 
 ## Dependencies / Risks
@@ -55,6 +56,7 @@ The product needs a narrow high-signal source mix. If catalog additions, fallbac
 - Catalog additions do not alter default ingestion unless their IDs are explicitly promoted.
 - Probationary runtime activation is controlled by an explicit source-ID allowlist and can be evaluated or rolled back without changing MVP public defaults.
 - Runtime source observability separates MVP public defaults, donor fallback defaults, probationary runtime IDs, and resolved no-argument runtime IDs without exposing feed URLs or registry dumps.
+- Deployed route logs include an ID-only no-argument source-resolution audit snapshot while preserving the supplied MVP public source path used for dashboard rendering.
 - Source preference treatment is granted only through the shared source-policy module.
 - Tests assert exact public defaults, donor defaults, and BBC/CNBC exclusion.
 - Repo-safe documentation explains source onboarding, validation states, default promotion, and the difference between supported, importable, preferred, and active-default sources.

--- a/src/lib/data.dashboard-fallback.test.ts
+++ b/src/lib/data.dashboard-fallback.test.ts
@@ -373,6 +373,31 @@ describe("getDashboardData fallback behavior", () => {
     expect(data.sources.length).toBeGreaterThan(0);
     expect(runClusterFirstPipeline).toHaveBeenCalledTimes(1);
     expect(logServerEvent).toHaveBeenCalledWith(
+      "info",
+      "Dashboard data request received",
+      expect.objectContaining({
+        no_argument_runtime_source_resolution_audit: expect.objectContaining({
+          resolution_mode: "no_argument_runtime",
+          donor_fallback_default_ids: [
+            "openclaw-the-verge",
+            "openclaw-ars-technica",
+            "horizon-reuters-world",
+            "horizon-reuters-business",
+          ],
+          probationary_runtime_source_ids: ["mit-technology-review"],
+          resolved_runtime_source_ids: [
+            "openclaw-the-verge",
+            "openclaw-ars-technica",
+            "horizon-reuters-world",
+            "horizon-reuters-business",
+            "mit-technology-review",
+          ],
+          resolved_probationary_source_ids: ["mit-technology-review"],
+          resolved_other_source_ids: [],
+        }),
+      }),
+    );
+    expect(logServerEvent).toHaveBeenCalledWith(
       "warn",
       "Signed-in dashboard fell back to pipeline briefing",
       expect.objectContaining({

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/homepage-taxonomy";
 import { logServerEvent } from "@/lib/observability";
 import { runClusterFirstPipeline } from "@/lib/pipeline";
+import { resolveNoArgumentRuntimeSourceResolutionSnapshot } from "@/lib/pipeline/ingestion";
 import { selectRelatedCoverage } from "@/lib/related-coverage";
 import {
   compareBriefingItemsByRanking,
@@ -224,6 +225,17 @@ export async function getViewerAccount(
   return viewer;
 }
 
+function buildNoArgumentRuntimeSourceResolutionAuditContext() {
+  try {
+    return resolveNoArgumentRuntimeSourceResolutionSnapshot();
+  } catch (error) {
+    return {
+      unavailable: true,
+      errorMessage: error instanceof Error ? error.message : "No-argument runtime source resolution audit failed",
+    };
+  }
+}
+
 export async function getDashboardData(
   route = "/dashboard",
   authState?: RequestAuthState,
@@ -235,6 +247,7 @@ export async function getDashboardData(
     route: resolvedAuthState.route,
     sessionExists: Boolean(user),
     sessionCookiePresent,
+    no_argument_runtime_source_resolution_audit: buildNoArgumentRuntimeSourceResolutionAuditContext(),
   });
 
   if (!supabase || !user) {

--- a/src/lib/pipeline/ingestion/index.test.ts
+++ b/src/lib/pipeline/ingestion/index.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { getMvpDefaultPublicSources } from "@/lib/demo-data";
-import { ingestRawItems } from "@/lib/pipeline/ingestion";
+import {
+  ingestRawItems,
+  resolveNoArgumentRuntimeSourceResolutionSnapshot,
+} from "@/lib/pipeline/ingestion";
 
 vi.mock("@/lib/rss", () => ({
   fetchFeedArticles: vi.fn(async (feedUrl: string, sourceName: string) => [
@@ -103,6 +106,45 @@ describe("ingestRawItems", () => {
 
     expect(result.sources.map((source) => source.sourceId)).not.toContain("mit-technology-review");
     expect(result.sources.map((source) => source.source)).not.toContain("MIT Technology Review");
+  });
+
+  it("exposes an ID-only no-argument source-resolution audit snapshot without fetching feeds", () => {
+    const snapshot = resolveNoArgumentRuntimeSourceResolutionSnapshot();
+
+    expect(snapshot).toEqual({
+      resolution_mode: "no_argument_runtime",
+      mvp_default_public_source_ids: [
+        "source-verge",
+        "source-ars",
+        "source-tldr-tech",
+        "source-techcrunch",
+        "source-ft",
+      ],
+      donor_fallback_default_ids: [
+        "openclaw-the-verge",
+        "openclaw-ars-technica",
+        "horizon-reuters-world",
+        "horizon-reuters-business",
+      ],
+      probationary_runtime_source_ids: ["mit-technology-review"],
+      resolved_runtime_source_ids: [
+        "openclaw-the-verge",
+        "openclaw-ars-technica",
+        "horizon-reuters-world",
+        "horizon-reuters-business",
+        "mit-technology-review",
+      ],
+      resolved_default_donor_source_ids: [
+        "openclaw-the-verge",
+        "openclaw-ars-technica",
+        "horizon-reuters-world",
+        "horizon-reuters-business",
+      ],
+      resolved_probationary_source_ids: ["mit-technology-review"],
+      resolved_other_source_ids: [],
+    });
+    expect(JSON.stringify(snapshot)).not.toContain("feedUrl");
+    expect(JSON.stringify(snapshot)).not.toContain("https://");
   });
 
   it("logs a safe source-resolution snapshot without feed URLs or registry dumps", async () => {

--- a/src/lib/pipeline/ingestion/index.ts
+++ b/src/lib/pipeline/ingestion/index.ts
@@ -96,6 +96,13 @@ function resolveIngestionSources(sources?: Source[]): SourceDefinition[] {
     .map(buildCustomSourceDefinition);
 }
 
+export function resolveNoArgumentRuntimeSourceResolutionSnapshot(): RuntimeSourceResolutionSnapshot {
+  return buildRuntimeSourceResolutionSnapshot({
+    resolutionMode: "no_argument_runtime",
+    resolvedSources: resolveIngestionSources(),
+  });
+}
+
 async function fetchSourceWithAdapter(source: SourceDefinition) {
   const adapter = getIngestionAdapter(source.donor as DonorFeed["donor"]);
 


### PR DESCRIPTION
## Summary
- Adds an ID-only no-argument runtime source-resolution audit snapshot to the existing dashboard/homepage server log.
- Exports a focused no-argument resolution helper for tests and deployed auditability.
- Documents how production audits should use the snapshot safely.

## Non-Changes
- No source activation.
- No MVP default changes.
- No donor fallback default changes.
- No source-policy boost changes.
- No public debug endpoint or UI.

## Validation
- npm install
- npm run lint || true
- npm run test
- npm run build
- feature-system CSV validation
- local dev server on http://localhost:3000
- curl / and /dashboard returned 200
- Chromium Playwright passed after rerunning initial timing flakes

## Security / exposure
- Audit snapshot is ID-only.
- No feed URLs, credentials, cookies, headers, tokens, emails, user IDs, or registry dumps are exposed.

## Operational value
- Future preview/production audits can inspect `Dashboard data request received` logs and read the `no_argument_runtime_source_resolution_audit` field.
- This proves deployed no-argument source resolution, but not no-argument feed fetch success.