### PR TITLE
Add MIT probationary review automation

### DIFF
--- a/.github/workflows/mit-probationary-review.yml
+++ b/.github/workflows/mit-probationary-review.yml
@@ -1,0 +1,127 @@
+name: MIT Probationary Runtime Review
+
+on:
+  schedule:
+    - cron: "20 13 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Generate the review payload without posting an issue comment
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: mit-probationary-runtime-review-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  collect-and-comment:
+    name: collect-and-comment
+    runs-on: ubuntu-latest
+    env:
+      ISSUE_NUMBER: "70"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Collect MIT review evidence
+        run: |
+          node scripts/mit-probationary-review.mjs \
+            --output "$RUNNER_TEMP/mit-probationary-review.md" \
+            --json-output "$RUNNER_TEMP/mit-probationary-review.json"
+
+      - name: Validate issue comment payload safety
+        run: |
+          node <<'NODE'
+          const fs = require("node:fs");
+          const body = fs.readFileSync(`${process.env.RUNNER_TEMP}/mit-probationary-review.md`, "utf8");
+          const forbiddenPatterns = [
+            /https?:\/\//i,
+            /feedUrl/i,
+            /feed_url/i,
+            /credential/i,
+            /authorization/i,
+            /headers/i,
+            /cookie/i,
+            /token/i,
+            /email/i,
+            /userId/i,
+            /user_id/i,
+            /registry dump/i,
+          ];
+          const hit = forbiddenPatterns.find((pattern) => pattern.test(body));
+
+          if (hit) {
+            throw new Error(`Review comment payload matched restricted pattern: ${hit}`);
+          }
+
+          if (!body.includes("### Review entry") || !body.includes("### Decision reminder")) {
+            throw new Error("Review comment payload is missing required sections.");
+          }
+          NODE
+
+      - name: Publish dry-run summary
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}
+        run: |
+          {
+            echo "## MIT probationary runtime review dry run"
+            echo ""
+            cat "$RUNNER_TEMP/mit-probationary-review.md"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post review comment to Issue 70
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("node:fs");
+            const issue_number = Number(process.env.ISSUE_NUMBER);
+            const body = fs.readFileSync(`${process.env.RUNNER_TEMP}/mit-probationary-review.md`, "utf8");
+            const today = new Date().toISOString().slice(0, 10);
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const duplicate = comments.find(
+              (comment) =>
+                comment.user?.type === "Bot" &&
+                comment.body?.includes("### Review entry") &&
+                comment.body?.includes(`- Date/time: ${today}`),
+            );
+
+            if (duplicate) {
+              core.notice(`Issue #${issue_number} already has an automated MIT review entry for ${today}; skipping duplicate comment.`);
+              await core.summary
+                .addHeading("MIT probationary runtime review")
+                .addRaw(`Skipped duplicate issue comment for ${today}.`)
+                .write();
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body,
+            });
+            await core.summary
+              .addHeading("MIT probationary runtime review")
+              .addRaw(`Posted a new review comment to issue #${issue_number}.`)
+              .write();

--- a/docs/engineering/change-records/mit-probationary-review-automation.md
+++ b/docs/engineering/change-records/mit-probationary-review-automation.md
@@ -1,0 +1,83 @@
+# MIT Probationary Review Automation
+
+Date: 2026-04-20
+
+Governed feature: `PRD-42` (`docs/product/prd/prd-42-source-governance-and-defaults.md`)
+
+## Purpose
+
+MIT Technology Review is the only probationary runtime source. Before considering removal, promotion, or a second probationary source such as Foreign Affairs, the team needs repeated evidence entries rather than one-off manual checks.
+
+This automation collects a daily, repo-safe MIT review snapshot and posts it to GitHub Issue #70, `MIT probationary runtime review`.
+
+## Implementation
+
+- Script: `scripts/mit-probationary-review.mjs`
+- Workflow: `.github/workflows/mit-probationary-review.yml`
+- Target issue: `#70`
+- Schedule: daily GitHub Actions cron at 13:20 UTC
+- Manual trigger: `workflow_dispatch`
+
+The script reuses the existing donor registry and donor adapter files as the source of truth for:
+
+- `PROBATIONARY_RUNTIME_FEED_IDS`
+- `DEFAULT_DONOR_FEED_IDS`
+- MIT Technology Review's existing donor feed metadata
+
+It does not create a parallel donor integration path and does not change runtime source configuration.
+
+## Posted Evidence
+
+Each issue comment uses the agreed review template and includes:
+
+- UTC date/time
+- environment label
+- no-argument runtime source-resolution status from existing registry wiring
+- probationary and resolved probationary source IDs
+- MIT feed reachability
+- MIT item count observed
+- top MIT item titles
+- freshness of top items
+- conservative signal-quality judgment
+- duplication/noise notes
+- contribution usefulness
+- `insufficient evidence` as the default decision
+
+## Safety Boundary
+
+The issue comment intentionally omits feed URLs, credentials, cookies, headers, tokens, emails, user IDs, and registry dumps. The workflow validates the generated comment against restricted patterns before posting.
+
+The automation does not:
+
+- activate or deactivate sources
+- change MVP defaults
+- change donor fallback defaults
+- change source-policy boosts
+- expose a public endpoint
+- make product decisions
+
+## Human Judgment Still Required
+
+The daily comment is evidence, not a decision. A human reviewer must still decide whether MIT should remain probationary, be removed, or whether Foreign Affairs should be evaluated as a future one-source activation candidate.
+
+The script uses conservative rule-based judgment. When automatic editorial assessment is uncertain, it leaves the decision as `insufficient evidence`.
+
+## Manual Trigger
+
+After this workflow is merged to the default branch:
+
+1. Open GitHub Actions.
+2. Select `MIT Probationary Runtime Review`.
+3. Choose `Run workflow`.
+4. Use `dry_run: true` to generate the review payload without posting a comment.
+5. Use `dry_run: false` only when an Issue #70 comment should be posted.
+
+## Duplicate Guard
+
+Before posting, the workflow checks recent Issue #70 comments for an automated review entry with today's UTC date. If one exists, it skips posting to avoid obvious same-day retry spam.
+
+## Schedule Activation
+
+GitHub scheduled workflows run only from workflow files present on the repository's default branch. This workflow will not run on a PR branch merely because the file exists there. It becomes scheduled only after the workflow file is merged into `main`, assuming GitHub Actions are enabled for the repository.
+
+To disable or change the schedule later, edit the `cron` entry in `.github/workflows/mit-probationary-review.yml` or disable the workflow in GitHub Actions.

--- a/docs/operations/tracker-sync/2026-04-20-mit-review-automation.md
+++ b/docs/operations/tracker-sync/2026-04-20-mit-review-automation.md
@@ -1,0 +1,27 @@
+# Tracker Sync — MIT Review Automation
+
+Date: 2026-04-20
+
+## Reason
+
+Direct live tracker access was not used in this pass. This fallback artifact records the intended tracker update for `PRD-42` so the governed row can be reconciled manually without creating duplicate feature rows.
+
+## Governed Row
+
+- PRD ID: `PRD-42`
+- PRD File: `docs/product/prd/prd-42-source-governance-and-defaults.md`
+- Work type: scheduled evidence automation
+
+## Intended Tracker Update
+
+- Status: `In Review`
+- Decision: `keep`
+- Notes: Added daily GitHub Actions automation to collect MIT Technology Review probationary runtime evidence and post the agreed review template to GitHub Issue #70. The workflow does not activate sources, change MVP defaults, change donor fallback defaults, change source-policy boosts, or expose a public debug endpoint.
+
+## Verification Payload
+
+- Target issue: `#70` (`MIT probationary runtime review`)
+- Workflow: `.github/workflows/mit-probationary-review.yml`
+- Script: `scripts/mit-probationary-review.mjs`
+- Schedule: daily at 13:20 UTC after merge to the default branch
+- Manual trigger: `workflow_dispatch` with `dry_run`

--- a/docs/product/prd/prd-42-source-governance-and-defaults.md
+++ b/docs/product/prd/prd-42-source-governance-and-defaults.md
@@ -41,6 +41,7 @@ The product needs a narrow high-signal source mix. If catalog additions, fallbac
 - `src/lib/observability/pipeline-run.ts` builds a safe runtime source-resolution snapshot with governed source IDs only.
 - `src/lib/pipeline/ingestion/index.ts` emits an ID-only structured log for runtime source resolution and attaches the same snapshot to pipeline-run metadata for local/test inspection.
 - `src/lib/data.ts` attaches an ID-only no-argument runtime source-resolution audit snapshot to the existing server-side dashboard/homepage request log so deployed audits can verify resolution without adding a public debug route.
+- `.github/workflows/mit-probationary-review.yml` and `scripts/mit-probationary-review.mjs` collect daily repo-safe evidence for MIT Technology Review's probationary runtime review and post the agreed template to GitHub Issue #70 without changing source activation policy.
 - `src/app/sources/page.tsx` presents catalog state as optional/importable rather than default ingestion.
 
 ## Dependencies / Risks
@@ -57,6 +58,7 @@ The product needs a narrow high-signal source mix. If catalog additions, fallbac
 - Probationary runtime activation is controlled by an explicit source-ID allowlist and can be evaluated or rolled back without changing MVP public defaults.
 - Runtime source observability separates MVP public defaults, donor fallback defaults, probationary runtime IDs, and resolved no-argument runtime IDs without exposing feed URLs or registry dumps.
 - Deployed route logs include an ID-only no-argument source-resolution audit snapshot while preserving the supplied MVP public source path used for dashboard rendering.
+- Daily MIT probationary review automation posts evidence only; it does not activate, deactivate, promote, or rank sources by policy.
 - Source preference treatment is granted only through the shared source-policy module.
 - Tests assert exact public defaults, donor defaults, and BBC/CNBC exclusion.
 - Repo-safe documentation explains source onboarding, validation states, default promotion, and the difference between supported, importable, preferred, and active-default sources.

--- a/scripts/mit-probationary-review.mjs
+++ b/scripts/mit-probationary-review.mjs
@@ -1,0 +1,463 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import Parser from "rss-parser";
+
+const DEFAULT_OUTPUT_PATH = "mit-probationary-review.md";
+const DEFAULT_JSON_OUTPUT_PATH = "mit-probationary-review.json";
+const MIT_SOURCE_ID = "mit-technology-review";
+const MAX_TOP_ITEMS = 5;
+
+function parseArgs(argv) {
+  const args = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const current = argv[index];
+
+    if (!current.startsWith("--")) continue;
+
+    const key = current.slice(2);
+    const next = argv[index + 1];
+
+    if (!next || next.startsWith("--")) {
+      args[key] = "true";
+      continue;
+    }
+
+    args[key] = next;
+    index += 1;
+  }
+
+  return args;
+}
+
+function readText(filePath) {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function extractConstArray(sourceText, constName) {
+  const match = sourceText.match(new RegExp(`export const ${constName} = \\[([\\s\\S]*?)\\] as const;`));
+
+  if (!match) {
+    throw new Error(`Unable to find ${constName} in donor registry`);
+  }
+
+  return [...match[1].matchAll(/"([^"]+)"/g)].map((entry) => entry[1]);
+}
+
+function findObjectBounds(sourceText, idIndex) {
+  let start = idIndex;
+
+  while (start >= 0 && sourceText[start] !== "{") {
+    start -= 1;
+  }
+
+  if (start < 0) {
+    throw new Error("Unable to find source object start");
+  }
+
+  let depth = 0;
+
+  for (let index = start; index < sourceText.length; index += 1) {
+    const character = sourceText[index];
+
+    if (character === "{") depth += 1;
+    if (character === "}") depth -= 1;
+
+    if (depth === 0) {
+      return {
+        start,
+        end: index + 1,
+      };
+    }
+  }
+
+  throw new Error("Unable to find source object end");
+}
+
+function extractStringField(block, fieldName) {
+  return block.match(new RegExp(`${fieldName}: "([^"]+)"`))?.[1] ?? null;
+}
+
+function extractNumberField(block, fieldName) {
+  const value = block.match(new RegExp(`${fieldName}: ([0-9_]+)`))?.[1];
+
+  return value ? Number(value.replaceAll("_", "")) : null;
+}
+
+function extractFeedDefinitions(repoRoot) {
+  const donorRoot = path.join(repoRoot, "src/adapters/donors");
+  const donorDirs = fs
+    .readdirSync(donorRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(donorRoot, entry.name, "index.ts"))
+    .filter((filePath) => fs.existsSync(filePath));
+  const feeds = [];
+
+  for (const filePath of donorDirs) {
+    const sourceText = readText(filePath);
+    const idMatches = [...sourceText.matchAll(/id: "([^"]+)"/g)];
+
+    for (const match of idMatches) {
+      const bounds = findObjectBounds(sourceText, match.index ?? 0);
+      const block = sourceText.slice(bounds.start, bounds.end);
+      const fetchBlock = block.match(/fetch: \{([\s\S]*?)\n\s+\}/)?.[1] ?? "";
+      const feedUrl = extractStringField(fetchBlock, "feedUrl");
+
+      if (!feedUrl) continue;
+
+      feeds.push({
+        id: match[1],
+        donor: extractStringField(block, "donor"),
+        source: extractStringField(block, "source"),
+        status: extractStringField(block, "status"),
+        availability: extractStringField(block, "availability"),
+        maxItems: extractNumberField(fetchBlock, "maxItems") ?? MAX_TOP_ITEMS,
+        feedUrl,
+      });
+    }
+  }
+
+  return feeds;
+}
+
+function sanitizeTitle(title) {
+  return String(title ?? "Untitled item")
+    .replace(/https?:\/\/\S+/gi, "[link]")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 180);
+}
+
+function itemAgeHours(item, now) {
+  const published = item.isoDate || item.pubDate || item.updated;
+  const date = published ? new Date(published) : null;
+
+  if (!date || Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return Number(((now.getTime() - date.getTime()) / 36e5).toFixed(1));
+}
+
+function categoryText(categories) {
+  if (typeof categories === "string") return categories;
+
+  return (categories ?? [])
+    .map((category) => {
+      if (typeof category === "string") return category;
+      if (category && typeof category === "object") return category._ ?? "";
+      return "";
+    })
+    .filter(Boolean)
+    .join(" ");
+}
+
+function classifySignal(items) {
+  const highSignalPatterns = [
+    /\bai\b/i,
+    /artificial intelligence/i,
+    /robot/i,
+    /cyber/i,
+    /chip/i,
+    /semiconductor/i,
+    /climate/i,
+    /energy/i,
+    /science/i,
+    /technology/i,
+    /policy/i,
+    /security/i,
+  ];
+  const noisyPatterns = [
+    /sponsored/i,
+    /alumni/i,
+    /quiz/i,
+    /auction/i,
+    /celebrity/i,
+    /sports/i,
+    /recipe/i,
+  ];
+  const topItems = items.slice(0, MAX_TOP_ITEMS);
+  const highSignalCount = topItems.filter((item) => {
+    const text = `${item.title} ${item.contentSnippet ?? ""} ${categoryText(item.categories)}`;
+    return highSignalPatterns.some((pattern) => pattern.test(text));
+  }).length;
+  const noisyCount = topItems.filter((item) => {
+    const text = `${item.title} ${item.contentSnippet ?? ""} ${categoryText(item.categories)}`;
+    return noisyPatterns.some((pattern) => pattern.test(text));
+  }).length;
+
+  if (topItems.length === 0) {
+    return {
+      judgment: "mixed",
+      noisyCount,
+      highSignalCount,
+      note: "No MIT items were available, so automatic editorial judgment is not reliable.",
+    };
+  }
+
+  if (highSignalCount >= 3 && noisyCount <= 1) {
+    return {
+      judgment: "mostly relevant",
+      noisyCount,
+      highSignalCount,
+      note: "Rule-based keyword checks found several technology or policy-relevant items.",
+    };
+  }
+
+  if (noisyCount >= 2) {
+    return {
+      judgment: "mixed",
+      noisyCount,
+      highSignalCount,
+      note: "Rule-based checks found multiple likely noisy or off-mission items.",
+    };
+  }
+
+  return {
+    judgment: "mixed",
+    noisyCount,
+    highSignalCount,
+    note: "Automatic editorial judgment is conservative; human review should confirm item quality.",
+  };
+}
+
+function tokenSet(text) {
+  const stopWords = new Set(
+    "the a an and or of to in for on with from by is are was were be been as at that this it its into how why what who will can could should would has have had not but about new old latest live news world global".split(
+      " ",
+    ),
+  );
+
+  return new Set(
+    String(text)
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, " ")
+      .split(/\s+/)
+      .filter((token) => token.length > 2 && !stopWords.has(token)),
+  );
+}
+
+function jaccard(left, right) {
+  const leftSet = tokenSet(left);
+  const rightSet = tokenSet(right);
+  const intersection = [...leftSet].filter((token) => rightSet.has(token)).length;
+  const union = new Set([...leftSet, ...rightSet]).size;
+
+  return union ? intersection / union : 0;
+}
+
+async function fetchFeedItems(parser, feed, now) {
+  const parsed = await parser.parseURL(feed.feedUrl);
+
+  return {
+    title: parsed.title,
+    items: (parsed.items ?? []).map((item) => ({
+      title: sanitizeTitle(item.title),
+      ageHours: itemAgeHours(item, now),
+      categories: categoryText(item.categories),
+      contentSnippet: String(item.contentSnippet ?? item.content ?? "").replace(/\s+/g, " ").slice(0, 240),
+    })),
+  };
+}
+
+function formatList(items) {
+  if (items.length === 0) return "none observed";
+
+  return items.map((item) => item.title).join("; ");
+}
+
+function formatFreshness(items) {
+  if (items.length === 0) return "no MIT items observed";
+
+  return items
+    .map((item) => `${item.title}: ${item.ageHours === null ? "unknown age" : `${item.ageHours}h old`}`)
+    .join("; ");
+}
+
+function buildDuplicationNote(mitItems, baselineItems, baselineFailures, signal) {
+  if (mitItems.length === 0) {
+    return "No MIT items observed; duplication risk could not be assessed.";
+  }
+
+  if (baselineItems.length === 0) {
+    return "Default-feed comparison unavailable; duplication judgment is limited.";
+  }
+
+  const nearestScores = mitItems.map((mitItem) =>
+    Math.max(
+      ...baselineItems.map((baselineItem) =>
+        jaccard(`${mitItem.title} ${mitItem.contentSnippet}`, `${baselineItem.title} ${baselineItem.contentSnippet}`),
+      ),
+    ),
+  );
+  const highOverlapCount = nearestScores.filter((score) => score >= 0.2).length;
+  const failureNote =
+    baselineFailures.length > 0
+      ? ` ${baselineFailures.length} default comparison feed(s) were unreachable, so this is partial evidence.`
+      : "";
+  const noiseNote =
+    signal.noisyCount > 0
+      ? ` Rule-based noise flags in top MIT items: ${signal.noisyCount}.`
+      : " No rule-based noise flags in top MIT items.";
+
+  if (highOverlapCount > 0) {
+    return `Possible duplicate pressure: ${highOverlapCount} top MIT item(s) had moderate title/snippet overlap with fetched default feeds.${failureNote}${noiseNote}`;
+  }
+
+  return `No obvious title/snippet duplication against fetched default feeds.${failureNote}${noiseNote}`;
+}
+
+function buildContributionUsefulness(feedReachable, topItems, signal) {
+  if (!feedReachable) {
+    return "not useful in this sample because the MIT feed was not reachable";
+  }
+
+  if (topItems.length === 0) {
+    return "not useful in this sample because no MIT items were observed";
+  }
+
+  if (signal.judgment === "mostly relevant") {
+    return "potentially useful; top MIT items include multiple technology or policy-relevant signals";
+  }
+
+  return "uncertain; MIT is contributing items, but automatic signal judgment remains conservative";
+}
+
+function buildComment(evidence) {
+  return `### Review entry
+- Date/time: ${evidence.checkedAt}
+- Environment: production
+- no-argument runtime resolution observed: ${evidence.resolutionObserved}
+- probationary_runtime_source_ids: ${evidence.probationaryRuntimeSourceIds.join(", ") || "none"}
+- resolved_probationary_source_ids: ${evidence.resolvedProbationarySourceIds.join(", ") || "none"}
+- MIT feed reachable: ${evidence.mitFeedReachable}
+- MIT item count observed: ${evidence.mitItemCountObserved}
+- Top MIT item titles: ${formatList(evidence.topMitItems)}
+- Freshness of top items: ${formatFreshness(evidence.topMitItems)}
+- Signal quality judgment: ${evidence.signalQualityJudgment}
+- Duplication/noise notes: ${evidence.duplicationNoiseNotes}
+- Contribution usefulness: ${evidence.contributionUsefulness}
+- Keep / remove / insufficient evidence: insufficient evidence
+- Notes: ${evidence.notes}
+
+### Decision reminder
+Do not use a single entry to change source activation policy.
+Collect multiple entries before deciding whether to:
+- keep MIT as probationary
+- remove MIT
+- evaluate Foreign Affairs as the next one-source activation candidate
+`;
+}
+
+async function collectEvidence({ repoRoot }) {
+  const now = new Date();
+  const parser = new Parser({
+    timeout: 15_000,
+    headers: {
+      "user-agent": "daily-intelligence-mit-review/1.0",
+    },
+  });
+  const registryText = readText(path.join(repoRoot, "src/adapters/donors/registry.ts"));
+  const probationaryRuntimeSourceIds = extractConstArray(registryText, "PROBATIONARY_RUNTIME_FEED_IDS");
+  const defaultDonorFeedIds = extractConstArray(registryText, "DEFAULT_DONOR_FEED_IDS");
+  const feedDefinitions = extractFeedDefinitions(repoRoot);
+  const feedById = new Map(feedDefinitions.map((feed) => [feed.id, feed]));
+  const resolvedProbationarySourceIds = probationaryRuntimeSourceIds.filter((sourceId) => {
+    const feed = feedById.get(sourceId);
+
+    return feed?.status === "active" && feed.availability === "probationary";
+  });
+  const mitFeed = feedById.get(MIT_SOURCE_ID);
+
+  if (!mitFeed) {
+    throw new Error("MIT Technology Review feed is not present in existing donor adapter files");
+  }
+
+  let mitFeedReachable = "no";
+  let mitItems = [];
+  let mitFetchNote = "";
+
+  try {
+    const mitFeedResult = await fetchFeedItems(parser, mitFeed, now);
+    mitItems = mitFeedResult.items.slice(0, mitFeed.maxItems);
+    mitFeedReachable = "yes";
+  } catch (error) {
+    mitFetchNote = ` MIT feed fetch failed: ${error instanceof Error ? error.message : String(error)}.`;
+  }
+
+  const baselineItems = [];
+  const baselineFailures = [];
+
+  for (const sourceId of defaultDonorFeedIds) {
+    const feed = feedById.get(sourceId);
+
+    if (!feed) {
+      baselineFailures.push(sourceId);
+      continue;
+    }
+
+    try {
+      const result = await fetchFeedItems(parser, feed, now);
+      baselineItems.push(...result.items.slice(0, feed.maxItems));
+    } catch {
+      baselineFailures.push(sourceId);
+    }
+  }
+
+  const signal = classifySignal(mitItems);
+  const resolutionObserved =
+    resolvedProbationarySourceIds.includes(MIT_SOURCE_ID) &&
+    probationaryRuntimeSourceIds.length === 1
+      ? "yes"
+      : "no";
+  const topMitItems = mitItems.slice(0, MAX_TOP_ITEMS);
+  const notes = [
+    "Automated review uses existing donor registry and adapter files plus live RSS fetches.",
+    "It does not query private Vercel logs or make source-policy decisions.",
+    signal.note,
+    mitFetchNote.trim(),
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return {
+    checkedAt: now.toISOString(),
+    resolutionObserved,
+    probationaryRuntimeSourceIds,
+    resolvedProbationarySourceIds,
+    mitFeedReachable,
+    mitItemCountObserved: mitItems.length,
+    topMitItems,
+    signalQualityJudgment: signal.judgment,
+    duplicationNoiseNotes: buildDuplicationNote(topMitItems, baselineItems, baselineFailures, signal),
+    contributionUsefulness: buildContributionUsefulness(mitFeedReachable === "yes", topMitItems, signal),
+    notes,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const repoRoot = process.cwd();
+  const outputPath = path.resolve(repoRoot, args.output || DEFAULT_OUTPUT_PATH);
+  const jsonOutputPath = path.resolve(repoRoot, args["json-output"] || DEFAULT_JSON_OUTPUT_PATH);
+  const evidence = await collectEvidence({ repoRoot });
+  const comment = buildComment(evidence);
+
+  fs.writeFileSync(outputPath, comment);
+  fs.writeFileSync(jsonOutputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+
+  if (args.print === "true") {
+    process.stdout.write(comment);
+  }
+}
+
+try {
+  await main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+
+  process.stderr.write(`MIT probationary review failed: ${message}\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Adds a daily GitHub Actions workflow to collect MIT Technology Review probationary runtime evidence.
- Posts the agreed review template to Issue #70.
- Supports manual dry-run dispatch.
- Uses existing donor registry and adapter files as source of truth.

## Non-Changes
- No source activation/deactivation.
- No MVP default changes.
- No donor fallback default changes.
- No source-policy boost changes.
- No public debug endpoint.

## Safety
- Issue comments omit feed URLs, credentials, cookies, headers, tokens, emails, user IDs, and registry dumps.
- Workflow uses `contents: read` and `issues: write`.
- Duplicate same-day automated comments are skipped.

## Validation
- npm install
- lint
- full unit tests
- build
- workflow YAML validation
- local script execution
- payload safety scan
- Issue #70 target validation
- governance gate
- local route smoke
- Chromium + WebKit Playwright
