### PR TITLE
[codex] Record duplicate stash retirement

### DIFF
--- a/docs/engineering/change-records/2026-04-20-worktree-branch-ownership-map.md
+++ b/docs/engineering/change-records/2026-04-20-worktree-branch-ownership-map.md
@@ -436,3 +436,21 @@ Operational conclusion:
 - No stash was applied, popped, dropped, moved, or rewritten.
 - `stash@{1}` should be the first stash considered for retirement, but only after explicit approval naming that stash.
 - `stash@{0}` and `stash@{2}` should remain protected until separate feature-port or archival decisions are made.
+
+## Phase 7 Duplicate Tracker-Sync Stash Retirement
+
+The low-risk duplicate tracker-sync stash was retired after explicit approval.
+
+Retirement proof:
+- Approved target before retirement: `stash@{1}` at `95bb9c71dfaf14b2c81544dd1f9d6cdc99ef0a89`.
+- Target contents: one untracked duplicate file, `docs/operations/tracker-sync/2026-04-19-explicit-default-source-ingestion 2.md`.
+- Preservation proof: the stash file content matched current `docs/operations/tracker-sync/2026-04-19-explicit-default-source-ingestion.md`.
+- Retired target: only `95bb9c71dfaf14b2c81544dd1f9d6cdc99ef0a89`.
+- Preserved stashes after retirement: `b34f620170fcc419b7dd7e280e0b8e91fae09882` and `6571ec2245d09a16eb4107f3c0c7cef8e6cab9da`.
+- Recovery bundle remained present after retirement.
+
+Operational conclusion:
+- The remaining stash count is two.
+- The current `stash@{0}` is the PRD-43 responsive-shell preservation stash.
+- The current `stash@{1}` is the historical importance-scoring preservation stash.
+- Both remaining stashes are feature-bearing and must remain protected until separate feature-port or archival decisions are made.

--- a/docs/engineering/change-records/2026-04-21-stash-preservation-review.md
+++ b/docs/engineering/change-records/2026-04-21-stash-preservation-review.md
@@ -79,6 +79,20 @@ The remaining stashes are preservation refs, not active continuation lanes. Futu
 4. Preserve evidence before any stash retirement.
 5. Drop a stash only after explicit approval naming that stash.
 
-## Next Recommendation
+## Retirement Update
 
-Review `stash@{1}` for retirement first. It is the only stash in this review that appears to contain no unique feature payload. Keep `stash@{0}` and `stash@{2}` protected until separate feature-port or archival decisions are made.
+The source-onboarding tracker-sync duplicate was retired after explicit approval.
+
+Retirement proof:
+- Approved target before retirement: `stash@{1}` at `95bb9c71dfaf14b2c81544dd1f9d6cdc99ef0a89`.
+- Approved target contents: one untracked file, `docs/operations/tracker-sync/2026-04-19-explicit-default-source-ingestion 2.md`.
+- Preservation proof: the stash file content matched current `docs/operations/tracker-sync/2026-04-19-explicit-default-source-ingestion.md`.
+- Retirement action: dropped only `stash@{1}` at `95bb9c71dfaf14b2c81544dd1f9d6cdc99ef0a89`.
+- Preserved after retirement: PRD-43 responsive-shell stash `b34f620170fcc419b7dd7e280e0b8e91fae09882`.
+- Preserved after retirement: historical importance-scoring stash `6571ec2245d09a16eb4107f3c0c7cef8e6cab9da`.
+- Recovery bundle remained present.
+
+Current recommendation:
+- Keep the two remaining feature-bearing stashes protected.
+- Do not apply either remaining stash wholesale.
+- Do not drop another stash without a separate explicit approval naming the exact stash and commit.


### PR DESCRIPTION
## Summary
- Record the approved retirement of the duplicate source-onboarding tracker-sync stash.
- Preserve proof that the retired stash file matched the current canonical tracker-sync file.
- Clarify that the two remaining stashes are feature-bearing and remain protected.

## Safety
- Dropped only the approved stash commit `95bb9c71dfaf14b2c81544dd1f9d6cdc99ef0a89`.
- Preserved PRD-43 responsive-shell stash `b34f620170fcc419b7dd7e280e0b8e91fae09882`.
- Preserved historical importance-scoring stash `6571ec2245d09a16eb4107f3c0c7cef8e6cab9da`.
- Recovery bundle remains present.

## Validation
- `git diff --check` passed
- `python3 scripts/release-governance-gate.py` passed
- `npm run governance:coverage` passed
