### PR TITLE
Fix upload-aware CI fast path governance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  classify-changes:
+    name: classify-upload-changes
+    runs-on: ubuntu-latest
+    outputs:
+      upload_only: ${{ steps.classifier.outputs.upload_only }}
+      run_full_ci: ${{ steps.classifier.outputs.run_full_ci }}
+      classification: ${{ steps.classifier.outputs.classification }}
+      changed_file_count: ${{ steps.classifier.outputs.changed_file_count }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Classify PR change scope
+        id: classifier
+        run: |
+          python scripts/classify-upload-only-changes.py \
+            --base-sha "${{ github.event.pull_request.base.sha }}" \
+            --head-sha "${{ github.event.pull_request.head.sha }}"
+
+  upload-lightweight-validation:
+    name: upload-lightweight-validation
+    runs-on: ubuntu-latest
+    needs: classify-changes
+    if: ${{ needs.classify-changes.outputs.upload_only == 'true' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate approved upload-only change set
+        run: |
+          python scripts/classify-upload-only-changes.py \
+            --base-sha "${{ github.event.pull_request.base.sha }}" \
+            --head-sha "${{ github.event.pull_request.head.sha }}" \
+            --require-upload-only \
+            --validate-upload-files
+
   lint:
     name: pr-lint
     runs-on: ubuntu-latest
+    needs: classify-changes
+    if: ${{ needs.classify-changes.outputs.run_full_ci == 'true' }}
     env:
       NEXT_TELEMETRY_DISABLED: 1
     steps:
@@ -33,7 +85,10 @@ jobs:
   unit-tests:
     name: pr-unit-tests
     runs-on: ubuntu-latest
-    needs: lint
+    needs:
+      - classify-changes
+      - lint
+    if: ${{ needs.classify-changes.outputs.run_full_ci == 'true' }}
     env:
       NEXT_TELEMETRY_DISABLED: 1
     steps:
@@ -55,7 +110,10 @@ jobs:
   build:
     name: pr-build
     runs-on: ubuntu-latest
-    needs: lint
+    needs:
+      - classify-changes
+      - lint
+    if: ${{ needs.classify-changes.outputs.run_full_ci == 'true' }}
     env:
       NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
       NEXT_PUBLIC_SUPABASE_ANON_KEY: test-anon-key
@@ -84,7 +142,10 @@ jobs:
   e2e-chromium:
     name: pr-e2e-chromium
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - classify-changes
+      - build
+    if: ${{ needs.classify-changes.outputs.run_full_ci == 'true' }}
     env:
       NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
       NEXT_PUBLIC_SUPABASE_ANON_KEY: test-anon-key
@@ -125,7 +186,10 @@ jobs:
   e2e-webkit:
     name: pr-e2e-webkit
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - classify-changes
+      - build
+    if: ${{ needs.classify-changes.outputs.run_full_ci == 'true' }}
     env:
       NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
       NEXT_PUBLIC_SUPABASE_ANON_KEY: test-anon-key
@@ -167,6 +231,8 @@ jobs:
     name: pr-summary
     runs-on: ubuntu-latest
     needs:
+      - classify-changes
+      - upload-lightweight-validation
       - lint
       - unit-tests
       - build
@@ -174,21 +240,37 @@ jobs:
       - e2e-webkit
     if: always()
     steps:
+      - name: Verify classifier completed
+        if: ${{ needs.classify-changes.result != 'success' }}
+        run: |
+          echo "Change classifier did not complete successfully; required PR summary cannot prove the CI path." >&2
+          exit 1
+
+      - name: Verify upload lightweight validation result
+        if: ${{ needs.classify-changes.outputs.upload_only == 'true' && needs.upload-lightweight-validation.result != 'success' }}
+        run: |
+          echo "Upload-only change set detected but lightweight validation did not pass." >&2
+          exit 1
+
       - name: Checkout
+        if: ${{ needs.classify-changes.outputs.run_full_ci == 'true' }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node
+        if: ${{ needs.classify-changes.outputs.run_full_ci == 'true' }}
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "npm"
 
       - name: Install dependencies
+        if: ${{ needs.classify-changes.outputs.run_full_ci == 'true' }}
         run: npm ci
 
       - name: Generate PR summary
+        if: ${{ needs.classify-changes.outputs.run_full_ci == 'true' }}
         env:
           PR_BASE_REF: ${{ github.base_ref }}
           PR_HEAD_REF: ${{ github.head_ref }}
@@ -199,5 +281,23 @@ jobs:
             echo "### Required remaining gates"
             echo "- Preview gate: still required outside this workflow"
             echo "- Human auth/session gate: still required outside this workflow"
+            echo "- Final merge approval: still required by branch protection"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish upload-only fast-path summary
+        if: ${{ needs.classify-changes.outputs.upload_only == 'true' }}
+        run: |
+          {
+            echo "## PR Gate Summary"
+            echo ""
+            echo "Upload-only change set detected; running lightweight validation path"
+            echo ""
+            echo "- Changed files classified: ${{ needs.classify-changes.outputs.changed_file_count }}"
+            echo "- Heavy required jobs were skipped with successful skipped-job conclusions."
+            echo "- Lightweight validation check: ${{ needs.upload-lightweight-validation.result }}"
+            echo ""
+            echo "### Required remaining gates"
+            echo "- Preview gate: still required outside this workflow when the change affects deployed behavior"
+            echo "- Human auth/session gate: not applicable unless auth/session behavior changed"
             echo "- Final merge approval: still required by branch protection"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/engineering/protocols/ci-fast-path-and-emergency-bypass.md
+++ b/docs/engineering/protocols/ci-fast-path-and-emergency-bypass.md
@@ -1,0 +1,81 @@
+# CI Fast Path and Emergency Bypass Protocol
+
+## Purpose
+- Keep protected `main` checks reliable while avoiding unnecessary heavy CI for narrowly approved upload-only changes.
+- Define the admin-only emergency bypass pattern for cases where protected-branch governance itself blocks an urgent production repair.
+
+## Scope
+- Applies to pull requests targeting `main`.
+- This is governance and CI remediation, not a product feature workflow.
+- This protocol does not weaken normal branch protection or replace required CI design fixes.
+
+## Upload-Aware Required Check Fast Path
+- The PR Gate workflow must still run for every pull request.
+- Do not use workflow-level `paths`, `paths-ignore`, branch filters, or commit-message skip annotations for required checks.
+- The workflow classifies the actual PR diff inside the workflow, then uses job-level conditions for heavy jobs.
+- Skipped heavy jobs are acceptable only after the classifier has selected the upload-only path; a skipped workflow is not acceptable because required checks can remain pending.
+
+### Approved Upload-Only Allowlist
+- Path prefix: `public/uploads/`
+- File statuses: added or modified only.
+- Extensions: `.avif`, `.gif`, `.ico`, `.jpeg`, `.jpg`, `.png`, `.webp`
+- Maximum file size: 10 MiB per file.
+
+### Explicitly Not Upload-Only
+- Any path outside `public/uploads/`.
+- Deletions, renames, copies, type changes, conflicts, or malformed diff entries.
+- SVG, HTML, CSS, JavaScript, TypeScript, JSON, YAML, lockfiles, configuration, scripts, source code, workflows, docs, Supabase files, or governance files.
+- Any uncertain or unparseable diff.
+
+### Required Logging
+The classifier must emit exactly one of these decisions:
+- `Upload-only change set detected; running lightweight validation path`
+- `Non-upload changes detected; running full CI`
+- `Ambiguous or unapproved changes detected; running full CI`
+
+### Lightweight Validation
+For upload-only changes, the workflow verifies the changed file list, allowlisted paths and extensions, file existence, and file size. It does not claim lint, test, build, Playwright, auth, SSR, preview, or production coverage.
+
+## Normal Merge Path
+- Protected `main` requires the normal PR checks and human approval.
+- Product, engineering, remediation, and governance work must follow the full merge path unless it is classified as approved upload-only by the workflow.
+- A bypass must not be used to avoid fixing broken CI, missing docs, missing tests, or branch freshness problems.
+
+## Emergency Bypass Criteria
+An emergency bypass may be considered only when all of the following are true:
+- There is an urgent production-impacting issue or release-blocking governance failure.
+- Normal branch protection is preventing a time-sensitive repair.
+- The change has been reviewed by an authorized human approver.
+- The bypass action is narrower and safer than waiting for the normal checks to recover.
+- A follow-up remediation plan exists before the bypass is executed.
+
+## Authorized Actors
+- Authorization: repository owner, release owner, or another explicitly delegated maintainer.
+- Execution: only actors configured as bypass actors in GitHub rulesets or branch protection for `main`.
+- Routine contributors and automation should not have emergency bypass authority by default.
+
+## Approval Requirements
+- Record the rationale in the PR, incident note, or release coordination thread.
+- Identify the authorizing person and the executing person.
+- State which required check or protection is being bypassed and why normal recovery is not viable in time.
+- Confirm no secrets, credentials, sensitive logs, or unsafe operational details are included.
+
+## Execution Steps In GitHub
+- Open repository settings for branch protection or rulesets protecting `main`.
+- Confirm normal required checks remain configured.
+- Confirm bypass actors are narrowly scoped to the approved admin or maintainer actors.
+- Use the GitHub UI bypass affordance only for the approved emergency PR or merge action.
+- Do not remove required checks, broaden actor permissions, or turn the bypass into a standing developer workflow.
+
+## Audit And Logging Expectations
+- Leave the PR history intact.
+- Record the reason, authorizer, executor, impacted checks, and follow-up owner.
+- Preserve GitHub audit log visibility by using named actors, not shared credentials.
+- Add or update an incident, bug-fix, testing, or change-record document when the bypass reflects a meaningful operational failure.
+
+## Post-Incident Remediation Checklist
+- Restore or confirm normal protections immediately after the emergency action.
+- Run the full local and PR validation path as soon as technically possible.
+- Repair the underlying CI, ruleset, or branch-protection issue.
+- Document what happened, why bypass was justified, and what prevents recurrence.
+- Do not mark the work complete until follow-up validation and documentation are closed.

--- a/docs/engineering/protocols/release-automation-operating-guide.md
+++ b/docs/engineering/protocols/release-automation-operating-guide.md
@@ -56,6 +56,14 @@
   - `release-governance-gate`
 - GitHub branch protection must separately require those checks; the repo workflows alone do not make them blocking.
 - These jobs automate install, lint, build, unit/integration tests, Chromium plus WebKit Playwright smoke coverage, artifact upload, and PR summary generation.
+- Upload-aware fast path:
+  - The PR Gate workflow still runs for every PR targeting `main`.
+  - `classify-upload-changes` classifies the PR diff before heavy jobs run.
+  - Approved upload-only changes may skip the heavy required jobs by job-level conditions, which gives those job checks skipped-success conclusions instead of leaving required checks pending.
+  - `pr-summary` remains a required running check and fails if the upload lightweight validation job does not pass.
+  - The only approved upload-only path is `public/uploads/` with added or modified `.avif`, `.gif`, `.ico`, `.jpeg`, `.jpg`, `.png`, or `.webp` files no larger than 10 MiB.
+  - Unapproved, ambiguous, deleted, renamed, copied, executable, config, workflow, source, docs, Supabase, or governance files run the full CI path.
+  - Detailed rules live in `docs/engineering/protocols/ci-fast-path-and-emergency-bypass.md`.
 
 ### 2a. Release Governance Gate
 - Workflow: [release-governance-gate.yml](/Users/bm/Documents/daily-intelligence-aggregator-main/.github/workflows/release-governance-gate.yml)
@@ -172,6 +180,7 @@
 
 ## Required External Configuration
 - GitHub branch protection must require the PR checks listed above.
+- GitHub rulesets or branch protection may configure narrowly scoped admin-only bypass actors for emergency use, but normal required checks must remain in force for everyday work.
 - Vercel preview automation must provide a preview URL to the Preview Gate workflow.
 - GitHub repo variable `PRODUCTION_BASE_URL` is optional overall and should point at the canonical production URL only if automatic post-merge verification and `Merged -> Built` promotion are desired.
 - GitHub secrets `GOOGLE_SERVICE_ACCOUNT_JSON` and `GOOGLE_SHEET_ID` must be configured for Google Sheets status sync.
@@ -188,8 +197,10 @@
   - `pr-e2e-webkit`
   - `pr-summary`
   - `release-governance-gate`
+- Confirm `classify-upload-changes` and `upload-lightweight-validation` are visible as PR Gate contexts, while the stable required names above remain unchanged.
 - Confirm the rule applies to pull requests targeting `main`.
 - Confirm a failing required check blocks merge instead of allowing a maintainer merge-through by default.
+- Confirm any bypass actor list is restricted to authorized emergency admins and is not available to routine contributors or automation by default.
 - Re-verify on a real pull request by checking that the merge box reports required checks and refuses merge when one required check is failing.
 - Repo evidence note:
   - PR #34 proved that the workflow could fail without blocking merge before branch protection was aligned.

--- a/scripts/classify-upload-only-changes.py
+++ b/scripts/classify-upload-only-changes.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+
+APPROVED_UPLOAD_PATH_PREFIXES = ("public/uploads/",)
+APPROVED_UPLOAD_EXTENSIONS = (
+    ".avif",
+    ".gif",
+    ".ico",
+    ".jpeg",
+    ".jpg",
+    ".png",
+    ".webp",
+)
+ALLOWED_UPLOAD_STATUSES = {"A", "M"}
+MAX_UPLOAD_FILE_BYTES = 10 * 1024 * 1024
+
+UPLOAD_ONLY_MESSAGE = "Upload-only change set detected; running lightweight validation path"
+NON_UPLOAD_MESSAGE = "Non-upload changes detected; running full CI"
+AMBIGUOUS_MESSAGE = "Ambiguous or unapproved changes detected; running full CI"
+
+
+@dataclass(frozen=True)
+class ChangedFile:
+    status: str
+    path: str
+
+
+@dataclass(frozen=True)
+class Classification:
+    upload_only: bool
+    run_full_ci: bool
+    result: str
+    message: str
+    changed_files: tuple[ChangedFile, ...]
+    reasons: tuple[str, ...]
+
+
+def load_changed_files(repo_root: Path, base_sha: str, head_sha: str) -> list[ChangedFile]:
+    diff_range = f"{base_sha}...{head_sha}"
+    result = subprocess.run(
+        ["git", "diff", "--name-status", "-z", diff_range],
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.decode("utf-8", errors="replace").strip() or "git diff failed")
+
+    parts = [part.decode("utf-8", errors="replace") for part in result.stdout.split(b"\0") if part]
+    changed_files: list[ChangedFile] = []
+    index = 0
+    while index < len(parts):
+        status = parts[index]
+        index += 1
+        if status.startswith(("R", "C")):
+            if index + 1 >= len(parts):
+                raise RuntimeError("git diff rename/copy output was incomplete")
+            old_path = parts[index]
+            new_path = parts[index + 1]
+            index += 2
+            changed_files.append(ChangedFile(status=status, path=new_path))
+            if old_path != new_path:
+                continue
+        else:
+            if index >= len(parts):
+                raise RuntimeError("git diff name-status output was incomplete")
+            path = parts[index]
+            index += 1
+            changed_files.append(ChangedFile(status=status, path=path))
+
+    return changed_files
+
+
+def parse_changed_file(value: str) -> ChangedFile:
+    if ":" not in value:
+        raise argparse.ArgumentTypeError("changed file must use STATUS:path form")
+    status, path = value.split(":", 1)
+    if not status or not path:
+        raise argparse.ArgumentTypeError("changed file must include both STATUS and path")
+    return ChangedFile(status=status, path=path)
+
+
+def normalize_path(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def path_is_safe(path: str) -> bool:
+    if not path:
+        return False
+    normalized = normalize_path(path)
+    pure_path = PurePosixPath(normalized)
+    if pure_path.is_absolute():
+        return False
+    return ".." not in pure_path.parts
+
+
+def normalized_status(status: str) -> str:
+    return status[:1].upper()
+
+
+def is_approved_upload_path(path: str) -> bool:
+    normalized = normalize_path(path)
+    return normalized.startswith(APPROVED_UPLOAD_PATH_PREFIXES)
+
+
+def is_approved_upload_extension(path: str) -> bool:
+    suffix = PurePosixPath(normalize_path(path)).suffix.lower()
+    return suffix in APPROVED_UPLOAD_EXTENSIONS
+
+
+def classify_changed_files(changed_files: list[ChangedFile]) -> Classification:
+    normalized_changes = tuple(
+        ChangedFile(status=change.status, path=normalize_path(change.path))
+        for change in changed_files
+    )
+    if not normalized_changes:
+        return Classification(
+            upload_only=False,
+            run_full_ci=True,
+            result="ambiguous",
+            message=AMBIGUOUS_MESSAGE,
+            changed_files=normalized_changes,
+            reasons=("No changed files were detected.",),
+        )
+
+    ambiguous_reasons: list[str] = []
+    non_upload_paths: list[str] = []
+
+    for change in normalized_changes:
+        path = change.path
+        status = normalized_status(change.status)
+
+        if not path_is_safe(path):
+            ambiguous_reasons.append(f"{path}: unsafe or ambiguous path")
+            continue
+
+        if is_approved_upload_path(path):
+            if status not in ALLOWED_UPLOAD_STATUSES:
+                ambiguous_reasons.append(f"{path}: unsupported upload file status {change.status}")
+            elif not is_approved_upload_extension(path):
+                ambiguous_reasons.append(f"{path}: unapproved upload file extension")
+            continue
+
+        non_upload_paths.append(path)
+
+    if ambiguous_reasons:
+        return Classification(
+            upload_only=False,
+            run_full_ci=True,
+            result="ambiguous",
+            message=AMBIGUOUS_MESSAGE,
+            changed_files=normalized_changes,
+            reasons=tuple(ambiguous_reasons),
+        )
+
+    if non_upload_paths:
+        return Classification(
+            upload_only=False,
+            run_full_ci=True,
+            result="non_upload",
+            message=NON_UPLOAD_MESSAGE,
+            changed_files=normalized_changes,
+            reasons=tuple(non_upload_paths),
+        )
+
+    return Classification(
+        upload_only=True,
+        run_full_ci=False,
+        result="upload_only",
+        message=UPLOAD_ONLY_MESSAGE,
+        changed_files=normalized_changes,
+        reasons=("All changed files are approved upload assets.",),
+    )
+
+
+def validate_upload_files(repo_root: Path, classification: Classification) -> list[str]:
+    errors: list[str] = []
+
+    for change in classification.changed_files:
+        path = normalize_path(change.path)
+        full_path = repo_root / path
+
+        if not full_path.is_file():
+            errors.append(f"{path}: expected an existing file for lightweight upload validation")
+            continue
+
+        size = full_path.stat().st_size
+        if size > MAX_UPLOAD_FILE_BYTES:
+            errors.append(
+                f"{path}: file size {size} bytes exceeds {MAX_UPLOAD_FILE_BYTES} byte limit"
+            )
+
+    return errors
+
+
+def write_github_output(path: str, classification: Classification) -> None:
+    outputs = {
+        "upload_only": "true" if classification.upload_only else "false",
+        "run_full_ci": "true" if classification.run_full_ci else "false",
+        "classification": classification.result,
+        "changed_file_count": str(len(classification.changed_files)),
+    }
+
+    with open(path, "a", encoding="utf-8") as handle:
+        for key, value in outputs.items():
+            handle.write(f"{key}={value}\n")
+
+
+def write_summary(path: str, classification: Classification) -> None:
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write("## Upload-aware CI classification\n\n")
+        handle.write(f"- Decision: {classification.message}\n")
+        handle.write(f"- Upload only: `{str(classification.upload_only).lower()}`\n")
+        handle.write(f"- Run full CI: `{str(classification.run_full_ci).lower()}`\n")
+        handle.write("- Approved upload path prefixes:\n")
+        for prefix in APPROVED_UPLOAD_PATH_PREFIXES:
+            handle.write(f"  - `{prefix}`\n")
+        handle.write("- Approved upload extensions:\n")
+        for extension in APPROVED_UPLOAD_EXTENSIONS:
+            handle.write(f"  - `{extension}`\n")
+        handle.write("\n### Changed files\n\n")
+        if classification.changed_files:
+            for change in classification.changed_files:
+                handle.write(f"- `{change.status}` `{change.path}`\n")
+        else:
+            handle.write("- none\n")
+        if classification.reasons:
+            handle.write("\n### Classification notes\n\n")
+            for reason in classification.reasons:
+                handle.write(f"- {reason}\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Classify whether a PR contains only approved upload asset changes."
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=Path(__file__).resolve().parent.parent,
+        type=Path,
+        help="Repository root.",
+    )
+    parser.add_argument("--base-sha", default="origin/main", help="Base commit or ref.")
+    parser.add_argument("--head-sha", default="HEAD", help="Head commit or ref.")
+    parser.add_argument(
+        "--changed-file",
+        action="append",
+        default=[],
+        type=parse_changed_file,
+        help="Test helper in STATUS:path form. May be repeated.",
+    )
+    parser.add_argument(
+        "--validate-upload-files",
+        action="store_true",
+        help="When upload-only, validate file existence and maximum file size.",
+    )
+    parser.add_argument(
+        "--require-upload-only",
+        action="store_true",
+        help="Fail if the change set is not upload-only.",
+    )
+    parser.add_argument(
+        "--github-output",
+        default=os.environ.get("GITHUB_OUTPUT", ""),
+        help="Optional GitHub Actions output file path.",
+    )
+    parser.add_argument(
+        "--github-step-summary",
+        default=os.environ.get("GITHUB_STEP_SUMMARY", ""),
+        help="Optional GitHub Actions step summary path.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+
+    try:
+        changed_files = (
+            list(args.changed_file)
+            if args.changed_file
+            else load_changed_files(repo_root, args.base_sha, args.head_sha)
+        )
+        classification = classify_changed_files(changed_files)
+    except Exception as exc:
+        classification = Classification(
+            upload_only=False,
+            run_full_ci=True,
+            result="classifier_error",
+            message=AMBIGUOUS_MESSAGE,
+            changed_files=tuple(),
+            reasons=(f"Classifier failed closed: {exc}",),
+        )
+
+    print(classification.message)
+    for reason in classification.reasons:
+        print(f"- {reason}")
+
+    if args.github_output:
+        write_github_output(args.github_output, classification)
+    if args.github_step_summary:
+        write_summary(args.github_step_summary, classification)
+
+    if args.require_upload_only and not classification.upload_only:
+        return 1
+
+    if args.validate_upload_files and classification.upload_only:
+        errors = validate_upload_files(repo_root, classification)
+        if errors:
+            print("Upload lightweight validation failed:", file=sys.stderr)
+            for error in errors:
+                print(f"- {error}", file=sys.stderr)
+            return 1
+        print("Upload lightweight validation passed.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/classify-upload-only-changes.test.py
+++ b/scripts/classify-upload-only-changes.test.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+CLASSIFIER_SPEC = importlib.util.spec_from_file_location(
+    "classify_upload_only_changes", SCRIPT_DIR / "classify-upload-only-changes.py"
+)
+if CLASSIFIER_SPEC is None or CLASSIFIER_SPEC.loader is None:
+    raise RuntimeError("Unable to load classify-upload-only-changes.py")
+classifier = importlib.util.module_from_spec(CLASSIFIER_SPEC)
+sys.modules[CLASSIFIER_SPEC.name] = classifier
+CLASSIFIER_SPEC.loader.exec_module(classifier)
+
+
+ChangedFile = classifier.ChangedFile
+classify_changed_files = classifier.classify_changed_files
+validate_upload_files = classifier.validate_upload_files
+
+
+class UploadOnlyChangeClassifierTests(unittest.TestCase):
+    def test_upload_only_approved_change_uses_lightweight_path(self) -> None:
+        result = classify_changed_files(
+            [
+                ChangedFile("A", "public/uploads/briefing-card.png"),
+                ChangedFile("M", "public/uploads/source-logo.webp"),
+            ]
+        )
+
+        self.assertTrue(result.upload_only)
+        self.assertFalse(result.run_full_ci)
+        self.assertEqual(result.result, "upload_only")
+        self.assertEqual(
+            result.message,
+            "Upload-only change set detected; running lightweight validation path",
+        )
+
+    def test_mixed_upload_and_code_change_runs_full_ci(self) -> None:
+        result = classify_changed_files(
+            [
+                ChangedFile("M", "public/uploads/briefing-card.png"),
+                ChangedFile("M", "src/app/page.tsx"),
+            ]
+        )
+
+        self.assertFalse(result.upload_only)
+        self.assertTrue(result.run_full_ci)
+        self.assertEqual(result.result, "non_upload")
+        self.assertEqual(result.message, "Non-upload changes detected; running full CI")
+
+    def test_non_upload_code_change_runs_full_ci(self) -> None:
+        result = classify_changed_files([ChangedFile("M", "src/lib/data.ts")])
+
+        self.assertFalse(result.upload_only)
+        self.assertTrue(result.run_full_ci)
+        self.assertEqual(result.result, "non_upload")
+
+    def test_unapproved_upload_extension_fails_closed_to_full_ci(self) -> None:
+        result = classify_changed_files([ChangedFile("A", "public/uploads/widget.js")])
+
+        self.assertFalse(result.upload_only)
+        self.assertTrue(result.run_full_ci)
+        self.assertEqual(result.result, "ambiguous")
+        self.assertEqual(
+            result.message,
+            "Ambiguous or unapproved changes detected; running full CI",
+        )
+
+    def test_upload_deletion_is_ambiguous_and_runs_full_ci(self) -> None:
+        result = classify_changed_files([ChangedFile("D", "public/uploads/old-card.png")])
+
+        self.assertFalse(result.upload_only)
+        self.assertTrue(result.run_full_ci)
+        self.assertEqual(result.result, "ambiguous")
+
+    def test_lightweight_validation_accepts_existing_small_upload_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            target = repo_root / "public/uploads/briefing-card.png"
+            target.parent.mkdir(parents=True)
+            target.write_bytes(b"png")
+            result = classify_changed_files([ChangedFile("A", "public/uploads/briefing-card.png")])
+
+            self.assertEqual(validate_upload_files(repo_root, result), [])
+
+    def test_lightweight_validation_rejects_missing_upload_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            result = classify_changed_files([ChangedFile("A", "public/uploads/missing.png")])
+
+            self.assertEqual(
+                validate_upload_files(repo_root, result),
+                [
+                    "public/uploads/missing.png: expected an existing file for lightweight upload validation"
+                ],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds an upload-aware classifier for the PR Gate workflow so approved upload-only changes can use a lightweight validation path while the required workflow still runs.
- Keeps existing required check names stable and skips heavy jobs only through job-level conditions after classification.
- Documents the admin-only emergency bypass governance pattern for protected `main`.

## Scope
This is governance / CI remediation, not a product feature. The branch is based on updated `main` and contains only the CI fast-path and bypass documentation files.

## Validation
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'yaml ok'"`
- `python3 scripts/classify-upload-only-changes.test.py`
- classifier simulations for upload-only, mixed upload + code, code-only, and unapproved upload extension cases
- `npm install`
- `npm run lint || true`
- `npm run test || true`
- `npm run build`

## Remaining Gates
- GitHub PR checks must validate the required-check behavior on a real PR.
- Admins must configure any emergency bypass actors manually in GitHub rulesets or branch protection; this PR does not weaken normal protections.