### PR TITLE
[codex] Remove feed loading time copy

### DIFF
--- a/docs/engineering/bug-fixes/remove-hardcoded-feed-loading-time-messaging.md
+++ b/docs/engineering/bug-fixes/remove-hardcoded-feed-loading-time-messaging.md
@@ -1,0 +1,33 @@
+# Remove Hardcoded Feed Loading Time Messaging — Bug-Fix Record
+
+## Classification
+- Title: Remove hardcoded feed loading time messaging
+- Type: Remediation (UX defect)
+
+## Summary
+- Problem addressed: the route-level loading UI displayed a fixed-duration loading estimate, which created a false expectation that loading should take a predictable amount of time.
+- Root Cause: Static placeholder copy not defined in the artifact system and not tied to real performance.
+
+## Fix
+- Fix: Replaced time-based loading message with neutral loading state.
+- Exact change: replaced the time-based loading sentence with the neutral loading copy `Preparing your feed...` while preserving the existing skeleton layout and component structure.
+- Related PRD: none. This is remediation alignment against the approved V1 artifacts, not a net-new product feature.
+
+## Validation
+- Automated checks:
+  - `npm install` passed with the existing npm audit warning.
+  - `npm run lint || true` passed.
+  - `npm run test || true` passed: 47 files, 243 tests.
+  - `npm run build` passed with existing Next.js workspace-root and module-type warnings.
+  - `npx playwright test --project=chromium --workers=1` passed: 28 tests.
+  - `npx playwright test --project=webkit --workers=1` passed: 28 tests.
+  - Local targeted browser check passed for `/` and signed-out `/account`: removed duration copy absent, one main landmark present, no framework error overlay, no browser console errors.
+- Human checks:
+  - Validate locally and in Vercel preview that the loading state no longer suggests a fake duration and that the skeleton layout still feels correct.
+
+## Tracker Closeout
+- Google Sheets tracker row updated and verified: not completed in this local Codex session.
+- Fallback tracker-sync file, if direct Sheets update was unavailable: `docs/operations/tracker-sync/2026-04-21-remove-hardcoded-feed-loading-time-messaging-tracker-sync.md`.
+
+## Remaining Risks / Follow-up
+- Loading duration perception still depends on actual runtime performance, which this remediation does not change.

--- a/docs/operations/tracker-sync/2026-04-21-remove-hardcoded-feed-loading-time-messaging-tracker-sync.md
+++ b/docs/operations/tracker-sync/2026-04-21-remove-hardcoded-feed-loading-time-messaging-tracker-sync.md
@@ -1,0 +1,39 @@
+# Tracker Sync Fallback - Remove Hardcoded Feed Loading Time Messaging
+
+- Date: 2026-04-21
+- Feature or fix title: Remove hardcoded feed loading time messaging
+- Type: Remediation (UX defect)
+- Branch: `fix/v1-production-remediation`
+- Implementation summary: Replaced the route-level feed loading message with neutral copy and preserved the existing skeleton layout.
+- Testing / validation status: Local install, lint, tests, build, Chromium Playwright, WebKit Playwright, and targeted browser checks passed in this session.
+- PRD summary path, if applicable: none. This remediation does not require a canonical PRD.
+- Bug-fix report path: `docs/engineering/bug-fixes/remove-hardcoded-feed-loading-time-messaging.md`
+
+## Exact Google Sheet Fields To Update
+
+- Workbook: `Features Table`
+- Sheet: `Intake Queue`
+- Feature Name
+- Type
+- Layer
+- Status
+- Decision
+- Owner
+- PRD File
+- Notes
+
+## Exact Manual Values To Enter
+
+- Feature Name: Remove hardcoded feed loading time messaging
+- Type: Remediation (UX defect)
+- Layer: Experience
+- Status: In Review
+- Decision: keep
+- Owner: Codex
+- PRD File: none
+- Notes: Static feed loading copy included a fixed-duration estimate that was not present in the approved V1 artifact set and was not tied to real performance measurement. The loading state now uses neutral copy while retaining the existing skeleton UI. No data fetching, routing, or new UX pattern was introduced.
+
+## Remaining Follow-Up Items Or Risks
+
+- Validate the loading state in Vercel preview.
+- Move or reconcile this intake item only if the PM maps it to an existing governed tracker row.

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -2,7 +2,7 @@ export default function Loading() {
   return (
     <main className="mx-auto min-h-screen w-full max-w-[1280px] px-4 pb-16 pt-6 sm:px-6 lg:px-8 lg:pb-24">
       <div className="rounded-card border border-[var(--border)] bg-[var(--card)] p-8">
-        <p className="text-sm font-medium text-[var(--text-secondary)]">Setting up your feed (10–20 seconds)...</p>
+        <p className="text-sm font-medium text-[var(--text-secondary)]">Preparing your feed...</p>
         <div className="skeleton-line h-4 w-40" />
         <div className="skeleton-card mt-4 h-12 max-w-2xl" />
         <div className="skeleton-line mt-4 h-6 max-w-xl" />

--- a/src/components/landing/homepage.test.tsx
+++ b/src/components/landing/homepage.test.tsx
@@ -102,9 +102,11 @@ describe("LandingHomepage", () => {
 
 describe("supporting states", () => {
   it("renders the loading shell", () => {
-    render(<Loading />);
+    const { container } = render(<Loading />);
     expect(screen.getAllByRole("main")).toHaveLength(1);
-    expect(screen.getByText("Setting up your feed (10–20 seconds)...")).toBeInTheDocument();
+    expect(screen.getByText("Preparing your feed...")).toBeInTheDocument();
+    expect(screen.queryByText(/10[–-]20 seconds/)).not.toBeInTheDocument();
+    expect(container.querySelectorAll(".skeleton-line, .skeleton-card").length).toBeGreaterThan(0);
   });
 
   it("renders the route error state", () => {


### PR DESCRIPTION
## Summary
- Replaces the hardcoded feed loading duration copy with neutral loading copy.
- Preserves the existing route-level loading component structure and skeleton UI.
- Adds a bug-fix/remediation note and tracker-sync fallback for governance closeout.

## Root Cause
Static placeholder loading copy included a fake duration estimate that was not part of the approved V1 artifact set and was not tied to real performance measurement.

## Validation
- npm install
- npm run lint || true
- npm run test || true
- npm run build
- npx playwright test --project=chromium --workers=1
- npx playwright test --project=webkit --workers=1
- Targeted local browser check for / and signed-out /account confirmed the old duration copy is absent, one main landmark renders, and no framework error overlay or console errors appear.

## Human Validation Needed
- Validate locally.
- Validate on Vercel preview.
- Confirm the loading state no longer sets an expectation of slowness.