### PR TITLE
fix: editorial history ordering

### DIFF
--- a/docs/bugs/editorial-history-ordering.md
+++ b/docs/bugs/editorial-history-ordering.md
@@ -1,0 +1,49 @@
+# Bug Report - Editorial History Ordering
+
+## Problem
+Editorial history cards could appear out of date order, such as April 23 before April 26 before April 25. That made the archive hard to review because older cards could jump ahead of newer cards after edits.
+
+## Root Cause
+The editorial history query read from `signal_posts` and ordered by `briefing_date` plus `rank`, but the page re-sorted the returned cards by `updatedAt` before render. Editing or publishing an older card changed `updated_at`, so that older briefing date could jump above newer dates.
+
+## Fix
+- Strengthened the `signal_posts` query ordering for the editorial review page.
+- Added `sortEditorialHistoryPostsReverseChronological()` as a defensive final sort after records are transformed.
+- Replaced the page-level `updatedAt` sort with the shared editorial history sort.
+- Kept homepage signal ranking, ingestion, clustering, scoring, editorial approval, and schema unchanged.
+
+## Timestamp Field Used For Sorting
+Primary date field: `briefing_date` / `briefingDate`, used as the editorial history signal date shown on each card.
+
+Within the same `briefingDate`, tie-breakers are:
+1. `published_at` / `publishedAt` descending
+2. `signal_score` / `signalScore` descending
+3. `created_at` / `createdAt` descending
+4. `updated_at` / `updatedAt` descending
+5. `id` ascending
+
+## Files Changed
+- `src/lib/signals-editorial.ts`
+- `src/lib/signals-editorial.test.ts`
+- `src/app/dashboard/signals/editorial-review/page.tsx`
+- `src/app/dashboard/signals/editorial-review/page.test.tsx`
+- `docs/bugs/editorial-history-ordering.md`
+- `docs/engineering/bug-fixes/editorial-history-ordering.md`
+- `docs/operations/tracker-sync/2026-04-26-editorial-history-ordering.md`
+
+## Tests Run
+- `npm install` passed.
+- `npm run test -- src/lib/signals-editorial.test.ts` passed: 1 file, 20 tests.
+- `npm run test -- src/app/dashboard/signals/editorial-review/page.test.tsx` passed: 1 file, 14 tests.
+- `npm run lint` passed.
+- `npm run test -- src/lib/signals-editorial.test.ts src/app/dashboard/signals/editorial-review/page.test.tsx` passed: 2 files, 34 tests.
+- `npm run build` passed.
+- `npm run test -- src/components/landing/homepage.test.tsx src/lib/homepage-model.test.ts src/app/page.test.tsx` passed: 3 files, 51 tests.
+- `python3 scripts/release-governance-gate.py` passed.
+- Dev server rule completed; local URL: `http://localhost:3000`.
+- `curl -I http://localhost:3000/dashboard/signals/editorial-review` returned `200 OK`.
+- `curl -s http://localhost:3000/dashboard/signals/editorial-review | rg -n "Admin sign-in required|Temporary issue|server problem|Top 5 Signals"` found the signed-out admin-gated page and no temporary server problem marker.
+
+## Remaining Risks
+- A signed-in admin browser pass is still needed to visually confirm live production-like `signal_posts` ordering with real account cookies.
+- Preview validation is still needed before merge readiness because local route probes do not prove deployed auth/session behavior.

--- a/docs/engineering/bug-fixes/editorial-history-ordering.md
+++ b/docs/engineering/bug-fixes/editorial-history-ordering.md
@@ -1,0 +1,46 @@
+# Editorial History Ordering Bug Fix
+
+## Summary
+- Date: 2026-04-26
+- Branch: `fix/editorial-history-ordering`
+- Area: `/dashboard/signals/editorial-review`
+- Data source: `signal_posts`
+
+## Problem
+Editorial history cards were not consistently rendered in reverse chronological order. Older signal dates could appear above newer signal dates after the older rows were edited or published.
+
+## Root Cause
+The server query ordered stored editorial rows by `briefing_date`, but the page then sorted the transformed posts by `updatedAt`. Because `updated_at` changes during editorial edits, it was not a stable history date and could reorder archived days incorrectly.
+
+## Fix
+- Added explicit query tie-breakers after `briefing_date`.
+- Added a shared defensive sort for editorial history posts after transformation.
+- Updated the page render path to use the shared sort instead of sorting by `updatedAt`.
+- Added tests for reverse date ordering and same-day stable tie-breaking.
+
+## Sorting Contract
+Primary field: `briefing_date` / `briefingDate`, because that is the editorial history signal date displayed on each card.
+
+Tie-breakers:
+1. `published_at` / `publishedAt` descending
+2. `signal_score` / `signalScore` descending
+3. `created_at` / `createdAt` descending
+4. `updated_at` / `updatedAt` descending
+5. `id` ascending
+
+## Validation
+- `npm install`
+- `npm run test -- src/lib/signals-editorial.test.ts`
+- `npm run test -- src/app/dashboard/signals/editorial-review/page.test.tsx`
+- `npm run lint`
+- `npm run test -- src/lib/signals-editorial.test.ts src/app/dashboard/signals/editorial-review/page.test.tsx`
+- `npm run build`
+- `npm run test -- src/components/landing/homepage.test.tsx src/lib/homepage-model.test.ts src/app/page.test.tsx`
+- `python3 scripts/release-governance-gate.py`
+- Dev server local route probe for `/dashboard/signals/editorial-review` returned `200 OK`.
+
+## Notes
+- No database schema change was required.
+- Homepage ranking logic was not changed.
+- Ingestion, clustering, scoring, and editorial approval logic were not changed.
+- Signed-in admin visual validation remains a preview/human check.

--- a/docs/operations/tracker-sync/2026-04-26-editorial-history-ordering.md
+++ b/docs/operations/tracker-sync/2026-04-26-editorial-history-ordering.md
@@ -1,0 +1,24 @@
+# Tracker Sync Fallback - Editorial History Ordering
+
+## Reason
+Direct Google Sheets tracker access was not used in this local implementation turn. This fallback records the manual tracker payload required by the repo closeout protocol.
+
+## Manual Update Payload
+- Work item: Editorial history ordering bug fix
+- Branch: `fix/editorial-history-ordering`
+- Status: `In Review`
+- Owner: Codex
+- Type: Bug fix
+- Summary: Editorial history cards now sort by `briefing_date` descending with deterministic tie-breakers, preventing older edited cards from jumping above newer signal dates.
+- Repo docs:
+  - `docs/bugs/editorial-history-ordering.md`
+  - `docs/engineering/bug-fixes/editorial-history-ordering.md`
+- Validation:
+  - `npm run lint`
+  - `npm run build`
+  - `npm run test -- src/lib/signals-editorial.test.ts src/app/dashboard/signals/editorial-review/page.test.tsx`
+  - `npm run test -- src/components/landing/homepage.test.tsx src/lib/homepage-model.test.ts src/app/page.test.tsx`
+  - `python3 scripts/release-governance-gate.py`
+- Remaining validation:
+  - Signed-in admin browser pass on the editorial review page.
+  - Vercel preview validation before merge readiness.

--- a/src/app/dashboard/signals/editorial-review/page.test.tsx
+++ b/src/app/dashboard/signals/editorial-review/page.test.tsx
@@ -3,9 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getEditorialReviewState = vi.fn();
 
-vi.mock("@/lib/signals-editorial", () => {
+vi.mock("@/lib/signals-editorial", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/signals-editorial")>();
+
   return {
-    SIGNALS_EDITORIAL_ROUTE: "/dashboard/signals/editorial-review",
+    ...actual,
     getEditorialReviewState,
   };
 });
@@ -21,6 +23,7 @@ vi.mock("@/app/dashboard/signals/editorial-review/actions", () => ({
 
 const reviewPost = {
   id: "signal-1",
+  briefingDate: "2026-04-24",
   rank: 1,
   title: "Signal 1",
   sourceName: "Source",
@@ -38,6 +41,9 @@ const reviewPost = {
   approvedBy: null,
   approvedAt: null,
   publishedAt: null,
+  isLive: false,
+  createdAt: "2026-04-24T08:00:00.000Z",
+  updatedAt: "2026-04-24T08:00:00.000Z",
   persisted: true,
 };
 
@@ -172,6 +178,59 @@ describe("signals editorial review page", () => {
       .toHaveValue("Approved editorial text");
     expect(screen.getByLabelText("Thesis / opening statement", { selector: "#editorialThesis-signal-published" }))
       .toHaveValue("Published editorial text");
+  });
+
+  it("renders editorial history cards in reverse briefing-date order without updated-date jumps", async () => {
+    getEditorialReviewState.mockResolvedValue({
+      ...createAuthorizedState([
+        {
+          ...reviewPost,
+          id: "signal-apr23",
+          title: "April 23 Signal",
+          briefingDate: "2026-04-23",
+          signalScore: 99,
+          createdAt: "2026-04-23T08:00:00.000Z",
+          updatedAt: "2026-04-26T12:00:00.000Z",
+        },
+        {
+          ...reviewPost,
+          id: "signal-apr26-b",
+          title: "April 26 Lower Signal",
+          briefingDate: "2026-04-26",
+          signalScore: 75,
+          createdAt: "2026-04-26T08:00:00.000Z",
+          updatedAt: "2026-04-24T12:00:00.000Z",
+        },
+        {
+          ...reviewPost,
+          id: "signal-apr25",
+          title: "April 25 Signal",
+          briefingDate: "2026-04-25",
+          signalScore: 88,
+          createdAt: "2026-04-25T08:00:00.000Z",
+          updatedAt: "2026-04-25T12:00:00.000Z",
+        },
+        {
+          ...reviewPost,
+          id: "signal-apr26-a",
+          title: "April 26 Higher Signal",
+          briefingDate: "2026-04-26",
+          signalScore: 95,
+          createdAt: "2026-04-26T08:00:00.000Z",
+          updatedAt: "2026-04-23T12:00:00.000Z",
+        },
+      ]),
+    });
+
+    const Page = (await import("@/app/dashboard/signals/editorial-review/page")).default;
+    render(await Page({ searchParams: Promise.resolve({ scope: "all" }) }));
+
+    expect(Array.from(document.querySelectorAll("h2")).map((heading) => heading.textContent)).toEqual([
+      "April 26 Higher Signal",
+      "April 26 Lower Signal",
+      "April 25 Signal",
+      "April 23 Signal",
+    ]);
   });
 
   it("shows structured editorial authoring fields and homepage preview simulation", async () => {

--- a/src/app/dashboard/signals/editorial-review/page.tsx
+++ b/src/app/dashboard/signals/editorial-review/page.tsx
@@ -19,6 +19,7 @@ import { Panel } from "@/components/ui/panel";
 import {
   SIGNALS_EDITORIAL_ROUTE,
   getEditorialReviewState,
+  sortEditorialHistoryPostsReverseChronological,
   type EditorialScopeFilter,
   type EditorialPostStatusFilter,
   type EditorialSignalPost,
@@ -86,7 +87,7 @@ export default async function SignalsEditorialReviewPage({ searchParams }: PageP
     );
   }
 
-  const posts = state.posts.slice().sort(sortEditorialPosts);
+  const posts = sortEditorialHistoryPostsReverseChronological(state.posts);
   const visiblePosts = posts;
   const topFivePosts = (state.currentTopFive ?? posts)
     .slice()
@@ -366,17 +367,6 @@ function getFilterCount(
 
 function isBulkApprovablePost(post: EditorialSignalPost) {
   return post.persisted && ["draft", "needs_review"].includes(post.editorialStatus);
-}
-
-function sortEditorialPosts(left: EditorialSignalPost, right: EditorialSignalPost) {
-  const leftUpdated = Date.parse(left.updatedAt ?? left.createdAt ?? "") || 0;
-  const rightUpdated = Date.parse(right.updatedAt ?? right.createdAt ?? "") || 0;
-
-  if (leftUpdated !== rightUpdated) {
-    return rightUpdated - leftUpdated;
-  }
-
-  return left.rank - right.rank;
 }
 
 function StatusFilterLink({

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -289,6 +289,61 @@ describe("signals editorial workflow", () => {
     expect(generateDailyBriefing).not.toHaveBeenCalled();
   });
 
+  it("loads editorial history in stable reverse briefing-date order", async () => {
+    const rows = [
+      createRow({
+        id: "signal-apr23",
+        briefing_date: "2026-04-23",
+        rank: 1,
+        signal_score: 99,
+        created_at: "2026-04-23T08:00:00.000Z",
+        updated_at: "2026-04-26T12:00:00.000Z",
+      }),
+      createRow({
+        id: "signal-apr26-b",
+        briefing_date: "2026-04-26",
+        rank: 2,
+        signal_score: 75,
+        created_at: "2026-04-26T08:00:00.000Z",
+        updated_at: "2026-04-24T12:00:00.000Z",
+      }),
+      createRow({
+        id: "signal-apr25",
+        briefing_date: "2026-04-25",
+        rank: 1,
+        signal_score: 88,
+        created_at: "2026-04-25T08:00:00.000Z",
+        updated_at: "2026-04-25T12:00:00.000Z",
+      }),
+      createRow({
+        id: "signal-apr26-a",
+        briefing_date: "2026-04-26",
+        rank: 1,
+        signal_score: 95,
+        created_at: "2026-04-26T08:00:00.000Z",
+        updated_at: "2026-04-23T12:00:00.000Z",
+      }),
+    ];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { getEditorialReviewState } = await loadEditorialModule();
+    const state = await getEditorialReviewState(undefined, { scope: "all" });
+
+    expect(state.kind).toBe("authorized");
+    if (state.kind !== "authorized") return;
+    expect(state.posts.map((post) => post.id)).toEqual([
+      "signal-apr26-a",
+      "signal-apr26-b",
+      "signal-apr25",
+      "signal-apr23",
+    ]);
+  });
+
   it("lets an admin save a draft", async () => {
     const rows = [createRow({ id: "signal-1" })];
     createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -260,6 +260,87 @@ function buildSignalPostCandidates(items: BriefingItem[]) {
   return items.slice(0, 5).map(mapBriefingItemToSignalPost);
 }
 
+function parseEditorialSortTime(value: string | null | undefined) {
+  const timestamp = Date.parse(value ?? "");
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function compareTimestampDescending(left: string | null | undefined, right: string | null | undefined) {
+  const leftTime = parseEditorialSortTime(left);
+  const rightTime = parseEditorialSortTime(right);
+
+  if (leftTime === null && rightTime === null) {
+    return 0;
+  }
+
+  if (leftTime === null) {
+    return 1;
+  }
+
+  if (rightTime === null) {
+    return -1;
+  }
+
+  return rightTime - leftTime;
+}
+
+function compareNumberDescending(left: number | null | undefined, right: number | null | undefined) {
+  const leftValue = typeof left === "number" && Number.isFinite(left) ? left : null;
+  const rightValue = typeof right === "number" && Number.isFinite(right) ? right : null;
+
+  if (leftValue === null && rightValue === null) {
+    return 0;
+  }
+
+  if (leftValue === null) {
+    return 1;
+  }
+
+  if (rightValue === null) {
+    return -1;
+  }
+
+  return rightValue - leftValue;
+}
+
+function compareEditorialHistoryPosts(left: EditorialSignalPost, right: EditorialSignalPost) {
+  const briefingDateComparison = compareTimestampDescending(left.briefingDate, right.briefingDate);
+
+  if (briefingDateComparison !== 0) {
+    return briefingDateComparison;
+  }
+
+  const publishedComparison = compareTimestampDescending(left.publishedAt, right.publishedAt);
+
+  if (publishedComparison !== 0) {
+    return publishedComparison;
+  }
+
+  const scoreComparison = compareNumberDescending(left.signalScore, right.signalScore);
+
+  if (scoreComparison !== 0) {
+    return scoreComparison;
+  }
+
+  const createdComparison = compareTimestampDescending(left.createdAt, right.createdAt);
+
+  if (createdComparison !== 0) {
+    return createdComparison;
+  }
+
+  const updatedComparison = compareTimestampDescending(left.updatedAt, right.updatedAt);
+
+  if (updatedComparison !== 0) {
+    return updatedComparison;
+  }
+
+  return left.id.localeCompare(right.id);
+}
+
+export function sortEditorialHistoryPostsReverseChronological(posts: EditorialSignalPost[]) {
+  return posts.slice().sort(compareEditorialHistoryPosts);
+}
+
 async function loadStoredSignalPosts(
   client: EditorialClient,
   input: {
@@ -297,8 +378,12 @@ async function loadStoredSignalPosts(
   const from = (input.page - 1) * EDITORIAL_PAGE_SIZE;
   const to = from + EDITORIAL_PAGE_SIZE - 1;
   const result = await queryBuilder
-    .order("briefing_date", { ascending: false })
-    .order("rank", { ascending: true })
+    .order("briefing_date", { ascending: false, nullsFirst: false })
+    .order("published_at", { ascending: false, nullsFirst: false })
+    .order("signal_score", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false, nullsFirst: false })
+    .order("updated_at", { ascending: false, nullsFirst: false })
+    .order("id", { ascending: true })
     .range(from, to);
 
   if (result.error) {
@@ -310,7 +395,9 @@ async function loadStoredSignalPosts(
   }
 
   return {
-    posts: ((result.data ?? []) as unknown as StoredSignalPost[]).map(mapStoredSignalPost),
+    posts: sortEditorialHistoryPostsReverseChronological(
+      ((result.data ?? []) as unknown as StoredSignalPost[]).map(mapStoredSignalPost),
+    ),
     totalCount: result.count ?? 0,
     errorMessage: null,
   };


### PR DESCRIPTION
## Summary
- Fixes editorial history card ordering on `/dashboard/signals/editorial-review`.
- Sorts history by `briefing_date` / `briefingDate` descending instead of `updatedAt`.
- Adds deterministic same-date tie-breakers and regression coverage.

## Root Cause
The editorial history query roughly ordered records by `briefing_date`, but the page re-sorted transformed cards by `updatedAt` before render. Editing an older card changed `updated_at`, letting older dates jump above newer dates.

## Fix
- Strengthened `signal_posts` query ordering for editorial history reads.
- Added `sortEditorialHistoryPostsReverseChronological()` as a defensive final sort after transformation.
- Updated the page render path to use that helper.
- Left homepage ranking, ingestion, clustering, scoring, editorial approval, and schema unchanged.

## Validation
- `npm install`
- `npm run lint`
- `npm run build`
- `npm run test -- src/lib/signals-editorial.test.ts src/app/dashboard/signals/editorial-review/page.test.tsx`
- `npm run test -- src/components/landing/homepage.test.tsx src/lib/homepage-model.test.ts src/app/page.test.tsx`
- `python3 scripts/release-governance-gate.py`
- Local dev: `http://localhost:3000`
- Local route probe: `curl -I http://localhost:3000/dashboard/signals/editorial-review` returned `200 OK`

## Remaining Checks
- Signed-in admin visual confirmation in preview/production for real `signal_posts` ordering.
