### PR TITLE
docs: add canonical terminology protocol

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,14 @@
 - [ ] PR title or branch includes canonical `PRD-XX` when this work maps to a governed feature
 - [ ] If this work is intentionally unmapped, expect Intake Queue review instead of direct `Sheet1` insertion
 
+## Terminology
+- [ ] Read `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`
+- [ ] Confirmed object level before coding: Article, Story Cluster, Signal, Card, or Surface Placement
+- [ ] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card
+- [ ] If legacy naming is inconsistent, documented it instead of silently expanding it
+- [ ] PRD clearly states which object level the feature modifies, if applicable
+- [ ] PRD does not describe UI cards as signals unless referring to the underlying Signal object
+
 ## Local Validation
 - [ ] App runs locally
 - [ ] Relevant flows tested

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,14 @@ git push origin --delete feature/<name>
 - Do not mix unrelated changes.
 - Do not modify unrelated files.
 
+## 2a. Terminology Requirement
+- Before implementation, read `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`.
+- Use Article, Story Cluster, Signal, Card, and Surface Placement according to the canonical definitions.
+- Do not use cluster, signal, story, or card interchangeably.
+- Before coding, confirm the object level being changed: Article, Story Cluster, Signal, Card, or Surface Placement.
+- Do not add new variable, file, function, component, or database terminology that blurs Cluster vs Signal vs Card.
+- If legacy naming is inconsistent, document it instead of silently expanding it.
+
 ## GOVERNANCE HOTSPOT RULES
 
 Detailed gate ownership lives in `docs/engineering/protocols/governance-gate-map.md`.

--- a/docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md
+++ b/docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md
@@ -1,0 +1,100 @@
+# Boot Up Canonical Terminology
+
+## Purpose
+
+Boot Up uses a staged intelligence object model. This document defines the canonical terms that future PRDs, implementation prompts, code reviews, and cleanup audits must use when discussing ingestion, grouping, ranking, rendering, and placement.
+
+The goal is to prevent drift between "article," "story," "cluster," "signal," and "card" language. These terms describe different object levels and must not be used interchangeably.
+
+## Canonical Object Flow
+
+```text
+Article -> Story Cluster -> Signal -> Card -> Surface Placement
+```
+
+Boot Up should conceptually rank Signals, not raw Articles or raw Story Clusters. Cards and surface placements are presentation decisions layered on top of Signal identity.
+
+## Definitions
+
+### Article
+
+An Article is a single source item from RSS, API, TLDR-discovered URL, newsletter-derived source item, or another ingestion source.
+
+It is raw input. It should not be treated as the final ranked product object.
+
+### Story Cluster
+
+A Story Cluster is a group of Articles about the same real-world event, topic, or development.
+
+It is a structural grouping object. It deduplicates and organizes source evidence. It does not itself equal a Signal.
+
+### Signal
+
+A Signal is a ranked, interpreted unit of importance derived from one or more Story Clusters.
+
+It answers:
+- What happened?
+- Why does it matter?
+- What caused it?
+- What does it connect to?
+- Why should the user care today?
+
+Signals are the conceptual product objects that Boot Up ranks for user attention.
+
+### Card
+
+A Card is a UI rendering of a Signal.
+
+A Card is not the Signal itself. The same Signal may appear differently depending on surface, viewport, editorial state, or interaction state.
+
+### Surface Placement
+
+A Surface Placement is the contextual placement of a Signal or Card in the product.
+
+Examples:
+- homepage top 5
+- politics tab
+- technology tab
+- editorial queue
+- archive/history page
+
+Surface Placement determines presentation and priority treatment. It does not define Signal identity.
+
+## Do / Do Not Usage
+
+| Term | Do | Do Not |
+| --- | --- | --- |
+| Article | Use for one source item from ingestion. | Do not call an Article a Signal just because it has a high score. |
+| Story Cluster | Use for grouped source evidence about the same event, topic, or development. | Do not treat a Story Cluster as the interpreted ranked object. |
+| Signal | Use for the ranked, interpreted unit derived from Story Cluster evidence. | Do not use Signal for a CSS card, source article, or raw cluster unless legacy naming forces it and the mismatch is documented. |
+| Card | Use for the UI rendering of a Signal. | Do not describe a Card as the Signal identity. |
+| Surface Placement | Use for where a Signal or Card appears in the product. | Do not use placement names like "Top 5" or "politics tab" as if they create separate Signal identities. |
+
+## Correct And Incorrect Wording
+
+Correct:
+- "The ingestion layer created Articles from Reuters and TLDR-discovered URLs."
+- "The clustering layer grouped five Articles into one Story Cluster."
+- "The ranking layer promoted the interpreted Signal derived from that Story Cluster."
+- "The homepage renders the Signal as a compact Card."
+- "The politics tab is a Surface Placement for the same underlying Signal."
+
+Incorrect:
+- "This card is a signal."
+- "Rank the raw articles as homepage signals."
+- "The cluster is the final signal."
+- "Create a separate signal for every homepage placement."
+- "The story card and signal can be used interchangeably."
+
+Preferred rewrite:
+- Instead of "top 5 cards are the signals," say "the homepage top 5 Surface Placement renders five Signal Cards."
+- Instead of "rank clusters for the homepage," say "derive Signals from Story Cluster evidence, then rank the Signals for homepage placement."
+- Instead of "persist card identity," say "persist the Signal identity or the Surface Placement, depending on the actual object being changed."
+
+## Enforcement Rule
+
+Future PRDs and implementation prompts must use Article, Story Cluster, Signal, Card, and Surface Placement according to these definitions.
+
+Before implementation, the author or agent must identify which object level the change modifies. If the existing code uses legacy names that blur the object level, document the mismatch in the PRD, implementation note, or audit instead of silently expanding the ambiguity.
+
+Explicit warning: "cluster," "signal," "story," and "card" must not be used interchangeably. When a legacy symbol uses one of those words differently from this canonical terminology, treat that as technical debt and preserve behavior until a scoped cleanup is approved.

--- a/docs/engineering/TERMINOLOGY_DRIFT_AUDIT.md
+++ b/docs/engineering/TERMINOLOGY_DRIFT_AUDIT.md
@@ -1,0 +1,47 @@
+# Terminology Drift Audit
+
+## Purpose
+
+This audit records known terminology risks after searching the repo for `signal`, `signals`, `cluster`, `clusters`, `card`, `cards`, `story`, and `stories`.
+
+This is documentation-only. No code, schema, ranking, clustering, homepage, or runtime behavior was changed.
+
+## Summary
+
+The highest-risk drift is not ordinary UI styling that uses `card` as a visual token. The main risk is object-level ambiguity where code or docs use `signal`, `cluster`, `story`, and `card` to describe different layers of the pipeline.
+
+## Potentially Ambiguous Files
+
+| File | Drift observed | Recommended future cleanup | Cleanup type |
+| --- | --- | --- | --- |
+| `src/lib/models/signal-cluster.ts` | The structural grouping model is named `SignalCluster`, which blurs Story Cluster and Signal. | Rename or alias toward `StoryCluster` only in a scoped compatibility plan with tests. | Code naming |
+| `src/lib/pipeline/clustering/index.ts` | `clusterNormalizedArticles()` returns `SignalCluster[]`, mixing clustering output with signal terminology. | Document current legacy naming, then migrate to `StoryCluster` terminology when pipeline contracts can move together. | Code naming |
+| `src/lib/scoring/scoring-engine.ts` | Ranking operates on clustered evidence and returns ranked cluster results, which can be read as ranking clusters rather than derived Signals. | Introduce explicit docs or types that distinguish ranked Story Cluster evidence from interpreted Signal output before any architecture change. | Code naming |
+| `src/lib/ranking.ts` | `RankedCluster`, `rankingSignals`, and display-signal strings use "signal" both for product importance and for explanatory badges. | Separate "ranking evidence labels" from canonical Signal terminology in a scoped naming pass. | Code naming |
+| `src/lib/types.ts` | `EventIntelligence.signals`, `BriefingItem.rankingSignals`, `signalRole`, and `EventSignalStrength` mix signal metrics, display labels, and product object language. | Add compatibility comments or new canonical object types before expanding these fields. | Code naming |
+| `src/lib/data.ts` | Converts ranked clusters and persisted signal posts into `BriefingItem`, so Article, Story Cluster, Signal, and Card layers can collapse into one payload. | Future data-model work should state which object level `BriefingItem` represents on each path. | Code naming |
+| `src/lib/homepage-model.ts` | `HomepageEvent`, `topSignalEventIds`, `earlySignals`, and surface selectors combine Signal identity with homepage placement logic. | Add explicit Surface Placement terminology before changing homepage selection logic. | Code naming |
+| `src/lib/signals-editorial.ts` | `signal_posts` stores editorial/public Top 5 rows that may represent published Signal Cards or placements rather than canonical Signal identity. | Treat `signal_posts` as legacy persisted presentation/editorial rows unless a future schema plan defines canonical Signal identity. | Database naming |
+| `supabase/migrations/20260423090000_signals_admin_editorial_layer.sql` | `public.signal_posts` naming can imply canonical Signal storage. | Do not rename in-place; future schema work should define whether this table stores Signals, Cards, or Surface Placements. | Database naming |
+| `src/components/story-card.tsx` | `StoryCard` renders a `BriefingItem` and uses `rankingDisplaySignals`; "story," "card," and "signal" appear in one component boundary. | Rename only through a scoped UI/component cleanup after canonical object mapping is defined. | Code naming |
+| `src/app/signals/page.tsx` | Public route copy uses "Top 5 Signals" for a rendered/published list. | Clarify in future UI copy whether the page is a Surface Placement that renders Signal Cards. | Product/UI copy |
+| `src/app/dashboard/signals/editorial-review/page.tsx` | Editorial review refers to current cards, signal posts, and Top 5 Signals in the same workflow. | Future editorial docs should state whether editors are editing Signal interpretation, Card copy, or Surface Placement rows. | Product/UI copy |
+| `docs/product/prd/prd-06-event-clustering-foundation.md` | Uses event clusters before canonical Story Cluster terminology existed. | Update only when the PRD is next touched for a scoped product change. | Documentation-only |
+| `docs/product/prd/prd-36-signal-display-cap.md` | Describes capped dashboard display as "signals," which can blur Signal identity and Card rendering. | Future revisions should say the cap is a Surface Placement/Card rendering rule. | Documentation-only |
+| `docs/product/prd/prd-53-signals-admin-editorial-layer.md` | Editorial workflow uses "signal posts," "homepage cards," and "Top 5 Signals" together. | Future revisions should distinguish edited Signal interpretation from rendered Card copy and published placement rows. | Documentation-only |
+| `docs/product/prd/prd-57-homepage-volume-layers.md` | Mostly clear on surface behavior, but uses "Top 5 Signals" and "story family" around homepage placement logic. | Future revisions should explicitly classify Top 5, Developing Now, and category modules as Surface Placements. | Documentation-only |
+
+## Terms That Were Not Automatically Changed
+
+- `card` in CSS variables, UI primitives, and visual component classes is usually legitimate presentation terminology.
+- `signal` in `AbortController.signal`, process exit signals, and governance "fix signal" output is unrelated to product Signal terminology.
+- News headlines may naturally contain "signals" as a verb, such as "Fed signals rates."
+- Existing database names such as `signal_posts` were not changed because schema renames require a separate migration and compatibility plan.
+
+## Recommended Future Cleanup Sequence
+
+1. Add compatibility comments around the highest-risk legacy terms in pipeline model boundaries.
+2. Define whether `BriefingItem` is a Signal view model, Card view model, or mixed compatibility payload.
+3. Scope any `SignalCluster` to `StoryCluster` rename as a dedicated code-naming change with tests.
+4. Treat `signal_posts` as legacy naming until a future schema plan defines canonical Signal identity versus Card or Surface Placement persistence.
+5. Refresh PRDs opportunistically when they are next materially edited; do not churn historical PRDs only for terminology.

--- a/docs/engineering/bug-fixes/templates/bug-fix-record-template.md
+++ b/docs/engineering/bug-fixes/templates/bug-fix-record-template.md
@@ -8,6 +8,12 @@
 - Exact change:
 - Related PRD:
 
+## Terminology Requirement
+- Before implementation, read `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`.
+- [ ] Confirmed object level before coding: Article, Story Cluster, Signal, Card, or Surface Placement.
+- [ ] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [ ] If legacy naming is inconsistent, document it instead of silently expanding it.
+
 ## Validation
 - Automated checks:
 - Human checks:

--- a/docs/engineering/protocols/bug-tracking-governance.md
+++ b/docs/engineering/protocols/bug-tracking-governance.md
@@ -9,6 +9,12 @@
 - Use one bug-fix record per meaningful defect or tightly related defect family.
 - Prefer updating the existing bug-fix record instead of creating `v2`, `final`, `follow-up`, or duplicate files for the same root cause.
 
+## Terminology Requirement
+- Before implementation, read `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`.
+- Use Article, Story Cluster, Signal, Card, and Surface Placement according to the canonical definitions.
+- Do not use cluster, signal, story, or card interchangeably.
+- Bug-fix records must state which object level was affected when the defect involves ingestion, clustering, ranking, UI cards, or placement behavior.
+
 ## When a Bug-Fix Record Is Required
 - A branch or PR is explicitly framed as a fix, bug, hotfix, or regression repair.
 - A non-trivial defect changes runtime, data, automation, workflow, or release behavior.

--- a/docs/engineering/protocols/engineering-protocol.md
+++ b/docs/engineering/protocols/engineering-protocol.md
@@ -66,6 +66,19 @@
 - documentation update requirement
 - sanitization rule
 
+## 4a. Terminology Requirement
+- Before implementation, read `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`.
+- Use Article, Story Cluster, Signal, Card, and Surface Placement according to the canonical definitions.
+- Do not use cluster, signal, story, or card interchangeably.
+- Every substantial PRD or implementation prompt must identify which object level the work modifies: Article, Story Cluster, Signal, Card, or Surface Placement.
+- New variable, file, function, component, and database terminology must not blur Cluster vs Signal vs Card.
+- If legacy naming is inconsistent, document the mismatch instead of silently expanding it.
+
+Implementation checklist:
+- [ ] Confirmed object level before coding: Article, Story Cluster, Signal, Card, or Surface Placement.
+- [ ] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [ ] If legacy naming is inconsistent, document it instead of silently expanding it.
+
 ## 5. Dev Server Rule
 - Before starting the dev server:
 - check port `3000`
@@ -296,6 +309,10 @@ Never bypass worktree safety with --force or --ignore-other-worktrees for ordina
 - Local validation passed.
 - Preview validation passed.
 - Docs updated.
+- [ ] Terminology check completed against `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`.
+- [ ] Confirmed object level before coding: Article, Story Cluster, Signal, Card, or Surface Placement.
+- [ ] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [ ] If legacy naming is inconsistent, document it instead of silently expanding it.
 - No blockers remain.
 
 ## 12. Debugging Protocol

--- a/docs/engineering/protocols/prd-template.md
+++ b/docs/engineering/protocols/prd-template.md
@@ -15,6 +15,12 @@
 
 ## Implementation Shape / System Impact
 
+## Terminology Requirement
+- Before implementation, read `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`.
+- Use Article, Story Cluster, Signal, Card, and Surface Placement according to the canonical definitions.
+- Do not use cluster, signal, story, or card interchangeably.
+- Object level modified:
+
 ## Dependencies / Risks
 
 ## Acceptance Criteria
@@ -25,6 +31,9 @@
 
 ## Closeout Checklist
 - Scope completed:
+- [ ] Terminology check completed: Article, Story Cluster, Signal, Card, and Surface Placement are used according to the canonical terminology document.
+- [ ] PRD clearly states which object level the feature modifies.
+- [ ] PRD does not describe UI cards as signals unless referring to the underlying Signal object.
 - Tests run:
 - Local validation complete:
 - Preview validation complete, if applicable:

--- a/docs/engineering/protocols/release-automation-operating-guide.md
+++ b/docs/engineering/protocols/release-automation-operating-guide.md
@@ -11,6 +11,14 @@
 - Merge only after the automated gates pass, preview is verified, the human auth checklist is completed, and release docs are updated.
 - Production verification happens after merge to `main`.
 
+## Terminology Requirement
+- Before implementation, read `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`.
+- Use Article, Story Cluster, Signal, Card, and Surface Placement according to the canonical definitions.
+- Do not use cluster, signal, story, or card interchangeably.
+- [ ] Confirmed object level before coding: Article, Story Cluster, Signal, Card, or Surface Placement.
+- [ ] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [ ] If legacy naming is inconsistent, document it instead of silently expanding it.
+
 ## Release Gates
 ### 1. Local Gate
 - Command: `npm run release:local`
@@ -128,6 +136,10 @@
 
 ### 7. Closeout Checklist
 - Scope completed.
+- [ ] Terminology check completed against `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`.
+- [ ] Confirmed object level before coding: Article, Story Cluster, Signal, Card, or Surface Placement.
+- [ ] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [ ] If legacy naming is inconsistent, document it instead of silently expanding it.
 - Tests run and results recorded.
 - Local validation complete.
 - Preview validation complete when applicable.

--- a/docs/engineering/protocols/release-machine.md
+++ b/docs/engineering/protocols/release-machine.md
@@ -27,6 +27,14 @@ Before implementation starts, Codex must explicitly decide and report:
 - what scope is included
 - what scope is excluded
 
+Terminology Requirement:
+- Before implementation, read `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`.
+- Use Article, Story Cluster, Signal, Card, and Surface Placement according to the canonical definitions.
+- Do not use cluster, signal, story, or card interchangeably.
+- [ ] Confirmed object level before coding: Article, Story Cluster, Signal, Card, or Surface Placement.
+- [ ] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [ ] If legacy naming is inconsistent, document it instead of silently expanding it.
+
 Rules:
 - one feature or fix per branch unless this is an intentional consolidation branch
 - do not mix unrelated work

--- a/docs/engineering/protocols/test-checklist.md
+++ b/docs/engineering/protocols/test-checklist.md
@@ -4,6 +4,9 @@
 - Correct branch is being used.
 - No unrelated changes are included.
 - Scope matches the task.
+- [ ] Confirmed object level before coding: Article, Story Cluster, Signal, Card, or Surface Placement.
+- [ ] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [ ] If legacy naming is inconsistent, document it instead of silently expanding it.
 
 ## 2. Local Validation
 - App runs locally.
@@ -35,6 +38,9 @@
 
 ## 7. Documentation Check
 - Canonical PRD updated if applicable.
+- [ ] Terminology check completed: Article, Story Cluster, Signal, Card, and Surface Placement are used according to the canonical terminology document.
+- [ ] PRD clearly states which object level the feature modifies.
+- [ ] PRD does not describe UI cards as signals unless referring to the underlying Signal object.
 - Product brief added or updated if the feature work is meaningful.
 - `docs/product/feature-system.csv` updated if applicable.
 - Bug-fix, incident, or change-record doc created if applicable.

--- a/docs/product/briefs/templates/release-brief-template.md
+++ b/docs/product/briefs/templates/release-brief-template.md
@@ -6,6 +6,14 @@
 ## Scope
 - 
 
+## Terminology Requirement
+- Before implementation, read `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`.
+- Use Article, Story Cluster, Signal, Card, and Surface Placement according to the canonical definitions.
+- Do not use cluster, signal, story, or card interchangeably.
+- [ ] Confirmed object level before coding: Article, Story Cluster, Signal, Card, or Surface Placement.
+- [ ] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [ ] If legacy naming is inconsistent, document it instead of silently expanding it.
+
 ## Explicit Exclusions
 - Real third-party OAuth automation with personal accounts
 - Subjective UX judgment

--- a/docs/product/documentation-rules.md
+++ b/docs/product/documentation-rules.md
@@ -8,6 +8,7 @@ This repository uses a controlled documentation system. The goal is to keep docs
 - `Record ID` in `Sheet1` is immutable and may only be used as the governed lookup key for automation.
 - Automation must never write formula/computed columns or silently overwrite human-managed fields in Google Sheets.
 - Tracker closeout is part of Definition of Done: update and verify the live Google Sheet, or create a fallback tracker-sync file in `docs/operations/tracker-sync/` with the exact manual update payload.
+- Terminology requirement: before implementation, read `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`. Use Article, Story Cluster, Signal, Card, and Surface Placement according to the canonical definitions. Do not use cluster, signal, story, or card interchangeably.
 - `docs/product/feature-system.csv` is the repo-side control layer for PRD mapping, build order, and durable governance metadata.
 - The CSV is the product control layer and its schema is locked to exactly 12 columns in this exact order:
   `Layer, Feature Name, Priority, Status, Description, Owner, Dependency, Build Order, Decision, Last Updated, prd_id, prd_file`
@@ -52,13 +53,14 @@ This repository uses a controlled documentation system. The goal is to keep docs
 1. Check `docs/product/feature-system.csv` first.
 2. Work from the next feature marked `decision = build` with the lowest `build_order`.
 3. Respect dependencies before implementation.
-4. If the feature already has a PRD, update that file instead of creating a new one.
-5. Preserve the Google Sheets governance model: mapped work belongs in `Sheet1`, while unmapped or ambiguous work must go to `Intake Queue`.
-6. Do not create governed `Sheet1` rows automatically from GitHub merges or repo automation.
-7. During active branch work, set `status = In Progress`.
-8. When implementation is complete but awaiting merge or review, set `status = In Review`.
-9. After merge or explicit user acceptance, set `status = Built`, `decision = keep`, and update `last_updated`.
-10. Before closeout, verify the Google Sheets tracker row or create a fallback tracker-sync markdown file with the exact manual update payload.
+4. Complete the terminology check and state which object level the work modifies: Article, Story Cluster, Signal, Card, or Surface Placement.
+5. If the feature already has a PRD, update that file instead of creating a new one.
+6. Preserve the Google Sheets governance model: mapped work belongs in `Sheet1`, while unmapped or ambiguous work must go to `Intake Queue`.
+7. Do not create governed `Sheet1` rows automatically from GitHub merges or repo automation.
+8. During active branch work, set `status = In Progress`.
+9. When implementation is complete but awaiting merge or review, set `status = In Review`.
+10. After merge or explicit user acceptance, set `status = Built`, `decision = keep`, and update `last_updated`.
+11. Before closeout, verify the Google Sheets tracker row or create a fallback tracker-sync markdown file with the exact manual update payload.
 
 ## Change Control
 - Do not implement features marked `delay` or `kill`.


### PR DESCRIPTION
## Summary
- Add a canonical Boot Up terminology document defining Article, Story Cluster, Signal, Card, and Surface Placement.
- Add protocol/template checklist enforcement so future PRDs and implementation prompts identify object level before coding.
- Add a terminology drift audit that reports ambiguous legacy naming without mass-renaming code.

## Scope
- Documentation and protocol only.
- No code renames, database migrations, ranking changes, clustering changes, UI behavior changes, or dev server work.

## Validation
- git diff --check HEAD~1..HEAD
- npm run governance:coverage
- Prior local validation before rebase: npm run lint passed.

## Terminology Risks Noted
- SignalCluster naming blurs Story Cluster vs Signal.
- rankingSignals and BriefingItem mix ranking evidence, Signal, and presentation concepts.
- signal_posts may represent editorial or placement rows rather than canonical Signal identity.
- StoryCard, /signals, and editorial review language mix Card, Signal, and Surface Placement terms.