### PR TITLE
bugfix: restore homepage tabs and published signal count

### DIFF
--- a/docs/bugs/homepage-tabs-signal-regression-politics-tldr.md
+++ b/docs/bugs/homepage-tabs-signal-regression-politics-tldr.md
@@ -14,10 +14,15 @@
 - `/` loads the same published rows, maps them into `BriefingItem` records, and then applies homepage semantic duplicate suppression plus category/depth exclusion.
 - Generic editorial tags and display entities such as `Tech`, `Finance`, `Politics`, `context`, and `Watch` were being treated as story identity signals. Distinct published items in the same category were suppressed as semantic duplicates.
 - The read-only homepage SSR path set `publicRankedItems` to the same 5 published signal posts. Category tabs then excluded already-surfaced Top Events, leaving no separate depth pool for tab content.
+- Follow-up finding: PR #114 fixed the empty-tab case by globally falling back to classifying the Top 5 whenever the depth pool did not contain distinct IDs. That fallback was correct for a pure Top 5-only read model, but the tab model needed a narrower precedence rule: use real non-Top category depth first, and only classify the Top 5 when no broader category-eligible tab pool exists.
 
 ## Files Changed
 - `src/lib/homepage-model.ts`
 - `src/lib/homepage-model.test.ts`
+- `src/lib/data.ts`
+- `src/lib/data.test.ts`
+- `src/lib/signals-editorial.ts`
+- `src/lib/signals-editorial.test.ts`
 - `docs/bugs/homepage-tabs-signal-regression-politics-tldr.md`
 - `docs/engineering/bug-fixes/homepage-tabs-signal-regression-politics-tldr.md`
 - `docs/operations/tracker-sync/2026-04-26-homepage-tabs-signal-regression-politics-tldr.md`
@@ -43,6 +48,11 @@
   - fallback content remained explicitly labeled as placeholder/non-live copy
 - `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=chromium`
 - `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=webkit`
+- Follow-up targeted regression coverage:
+  - homepage model uses non-homepage category depth when a broader ranked pool exists
+  - homepage model classifies Top 5 into tabs only when no broader tab pool exists
+  - published live signal snapshots preserve additional published rows for homepage depth while `/signals` remains capped to Top 5
+  - public homepage data maps snapshot `depthPosts` into `publicRankedItems`
 
 ## Production / Preview Risk
 - No schema or database migration is required.

--- a/docs/bugs/homepage-tabs-signal-regression-politics-tldr.md
+++ b/docs/bugs/homepage-tabs-signal-regression-politics-tldr.md
@@ -1,0 +1,51 @@
+# Homepage Tabs + Signal Count Regression After Politics/TLDR
+
+## Symptom
+- Production homepage showed only 3 visible Top Event signal cards.
+- Production homepage category/depth sections showed empty states even though published signals existed.
+- Production `/signals` showed 5 published signal cards from the editorial layer.
+
+## Suspected Cause
+- Recent politics/TLDR ingestion and homepage SSR isolation work changed the shape of the published signal set and the homepage read model.
+- The homepage model was likely filtering or suppressing valid published signals after loading them, rather than failing to load the rows.
+
+## Confirmed Cause
+- `/signals` reads `signal_posts` directly through `getPublishedSignalPosts()` and displayed all 5 published rows.
+- `/` loads the same published rows, maps them into `BriefingItem` records, and then applies homepage semantic duplicate suppression plus category/depth exclusion.
+- Generic editorial tags and display entities such as `Tech`, `Finance`, `Politics`, `context`, and `Watch` were being treated as story identity signals. Distinct published items in the same category were suppressed as semantic duplicates.
+- The read-only homepage SSR path set `publicRankedItems` to the same 5 published signal posts. Category tabs then excluded already-surfaced Top Events, leaving no separate depth pool for tab content.
+
+## Files Changed
+- `src/lib/homepage-model.ts`
+- `src/lib/homepage-model.test.ts`
+- `docs/bugs/homepage-tabs-signal-regression-politics-tldr.md`
+- `docs/engineering/bug-fixes/homepage-tabs-signal-regression-politics-tldr.md`
+- `docs/operations/tracker-sync/2026-04-26-homepage-tabs-signal-regression-politics-tldr.md`
+
+## Validation Performed
+- `npm install`
+- `npm run test -- src/lib/homepage-model.test.ts`
+- `npm run test -- src/lib/homepage-model.test.ts src/lib/source-catalog.test.ts src/lib/source-defaults.test.ts src/lib/source-manifest.test.ts src/lib/pipeline/ingestion/index.test.ts src/lib/pipeline/ingestion/tldr.integration.test.ts src/lib/tldr.test.ts src/lib/rss.test.ts src/lib/signals-editorial.test.ts src/components/home/home-category-components.test.tsx src/components/home/CategoryPreviewGrid.test.tsx`
+- `npm run lint`
+- `npm run test`
+- `npm run build`
+- Dev Server Rule:
+  - checked port `3000` and Next.js dev processes
+  - started `npm run dev`
+  - Local URL: `http://localhost:3000`
+- Local route probes:
+  - `HEAD /` returned `200`
+  - `HEAD /signals` returned `200`
+  - `HEAD /dashboard/signals/editorial-review` returned `200`
+- Local browser check:
+  - homepage rendered 5 top event cards in local fallback mode
+  - browser console error log count was `0`
+  - fallback content remained explicitly labeled as placeholder/non-live copy
+- `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=chromium`
+- `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=webkit`
+
+## Production / Preview Risk
+- No schema or database migration is required.
+- The fix keeps homepage SSR on persisted read models only.
+- The fix does not activate or remove politics/TLDR ingestion.
+- Preview validation is still required for signed-in/signed-out rendering, SSR, and cookie-sensitive behavior.

--- a/docs/bugs/homepage-tabs-signal-regression-politics-tldr.md
+++ b/docs/bugs/homepage-tabs-signal-regression-politics-tldr.md
@@ -15,6 +15,20 @@
 - Generic editorial tags and display entities such as `Tech`, `Finance`, `Politics`, `context`, and `Watch` were being treated as story identity signals. Distinct published items in the same category were suppressed as semantic duplicates.
 - The read-only homepage SSR path set `publicRankedItems` to the same 5 published signal posts. Category tabs then excluded already-surfaced Top Events, leaving no separate depth pool for tab content.
 - Follow-up finding: PR #114 fixed the empty-tab case by globally falling back to classifying the Top 5 whenever the depth pool did not contain distinct IDs. That fallback was correct for a pure Top 5-only read model, but the tab model needed a narrower precedence rule: use real non-Top category depth first, and only classify the Top 5 when no broader category-eligible tab pool exists.
+- Second follow-up finding: the public read model still had only five ranked/public events because the depth loss happened at signal-post persistence/publication, not homepage rendering. `signal_posts.rank` was constrained to `1..5`, `buildSignalPostCandidates()` sliced to five, and `publishApprovedSignals()` only activated the latest five rows. The pipeline itself can retain more than five ranked clusters; the public persisted signal table could not.
+
+## Pipeline Count Diagnosis
+| Stage | Evidence | Count / cap |
+| --- | --- | --- |
+| Raw feed items fetched | Pipeline regression fixture with manifest provenance | 7 |
+| Normalized articles | `normalizeRawItems()` maps all raw items | 7 |
+| Deduped articles | URL/title dedupe fixture | 7 |
+| Clusters/signals formed | `runClusterFirstPipeline()` fixture | greater than 5 |
+| Ranked signals created | Full `ranked_clusters` returned | greater than 5 |
+| Digest Top Events | `buildDigestOutput()` | capped at 5 |
+| Persisted public signal posts before fix | `signal_posts.rank check (rank between 1 and 5)` | capped at 5 |
+| Preview `publicRankedItems` before fix | Homepage debug on PR preview | 5 |
+| Tab-eligible non-Top public depth before fix | Homepage debug plus category sections | 0 |
 
 ## Files Changed
 - `src/lib/homepage-model.ts`
@@ -23,6 +37,10 @@
 - `src/lib/data.test.ts`
 - `src/lib/signals-editorial.ts`
 - `src/lib/signals-editorial.test.ts`
+- `src/lib/pipeline/index.ts`
+- `src/lib/pipeline/index.test.ts`
+- `supabase/schema.sql`
+- `supabase/migrations/20260426120000_signal_posts_public_depth_pool.sql`
 - `docs/bugs/homepage-tabs-signal-regression-politics-tldr.md`
 - `docs/engineering/bug-fixes/homepage-tabs-signal-regression-politics-tldr.md`
 - `docs/operations/tracker-sync/2026-04-26-homepage-tabs-signal-regression-politics-tldr.md`
@@ -55,7 +73,7 @@
   - public homepage data maps snapshot `depthPosts` into `publicRankedItems`
 
 ## Production / Preview Risk
-- No schema or database migration is required.
+- A database migration is required and included because the existing `signal_posts` rank constraint prevents storing any public signal depth beyond Top 5.
 - The fix keeps homepage SSR on persisted read models only.
 - The fix does not activate or remove politics/TLDR ingestion.
 - Preview validation is still required for signed-in/signed-out rendering, SSR, and cookie-sensitive behavior.

--- a/docs/engineering/bug-fixes/homepage-tabs-signal-regression-politics-tldr.md
+++ b/docs/engineering/bug-fixes/homepage-tabs-signal-regression-politics-tldr.md
@@ -1,0 +1,37 @@
+# Homepage Tabs + Signal Count Regression — Bug-Fix Record
+
+## Summary
+- Problem addressed: homepage Top Events under-rendered the published editorial signal set, and category tabs appeared empty after the politics/TLDR ingestion and SSR remediation sequence.
+- Root cause: homepage semantic duplicate checks treated generic category/status tags as story identity, while the read-only homepage data path no longer had a broader `publicRankedItems` pool beyond the published Top 5.
+
+## Fix
+- Exact change:
+  - Ignore generic category/status terms when comparing semantic entity and keyword overlap.
+  - Preserve distinct published Top 5 signal cards even when their tags are generic editorial labels.
+  - When the homepage has exactly the editorial Top 5 and no broader ranked depth pool, use that real published Top 5 as the source for category tab filtering.
+  - Keep Developing Now and By Category depth modules empty in that no-depth-pool case instead of duplicating Top Events as fresh additional intelligence.
+- Related PRD: existing homepage category/depth behavior is governed by `docs/product/prd/prd-46-home-category-tabs.md` and `docs/product/prd/prd-57-homepage-volume-layers.md`; no new canonical PRD is required.
+
+## Validation
+- Automated checks:
+  - `npm install`
+  - `npm run test -- src/lib/homepage-model.test.ts`
+  - `npm run test -- src/lib/homepage-model.test.ts src/lib/source-catalog.test.ts src/lib/source-defaults.test.ts src/lib/source-manifest.test.ts src/lib/pipeline/ingestion/index.test.ts src/lib/pipeline/ingestion/tldr.integration.test.ts src/lib/tldr.test.ts src/lib/rss.test.ts src/lib/signals-editorial.test.ts src/components/home/home-category-components.test.tsx src/components/home/CategoryPreviewGrid.test.tsx`
+  - `npm run lint`
+  - `npm run test`
+  - `npm run build`
+  - `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=chromium`
+  - `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=webkit`
+- Local route/browser checks:
+  - Local URL: `http://localhost:3000`
+  - `HEAD /`, `HEAD /signals`, and `HEAD /dashboard/signals/editorial-review` returned `200`
+  - local browser check found 5 homepage top cards and no console errors
+- Human checks:
+  - Preview signed-in/signed-out behavior remains required after PR deployment.
+
+## Tracker Closeout
+- Google Sheets tracker row updated and verified: not available in this local session.
+- Fallback tracker-sync file, if direct Sheets update was unavailable: `docs/operations/tracker-sync/2026-04-26-homepage-tabs-signal-regression-politics-tldr.md`
+
+## Remaining Risks / Follow-up
+- If production needs separate non-Top-5 depth content, a future scoped change should read a real persisted broader candidate pool instead of running ingestion during homepage SSR or presenting fallback data as live intelligence.

--- a/docs/engineering/bug-fixes/homepage-tabs-signal-regression-politics-tldr.md
+++ b/docs/engineering/bug-fixes/homepage-tabs-signal-regression-politics-tldr.md
@@ -12,7 +12,21 @@
   - Follow-up correction: category tabs now prefer real non-Top category depth from `publicRankedItems` before falling back to Top 5 classification.
   - Published live homepage snapshots now preserve up to 20 published live rows as read-only `depthPosts` for tabs/depth modules while keeping the public `/signals` surface capped to the current Top 5.
   - Keep Developing Now and By Category depth modules empty in that no-depth-pool case instead of duplicating Top Events as fresh additional intelligence.
+  - Second follow-up correction: widen `signal_posts` rank storage to a bounded public depth pool and publish non-Top rows as category-depth rows when the approved Top 5 set is published. This preserves the Top 5 editorial contract while giving homepage tabs real non-Top public depth.
 - Related PRD: existing homepage category/depth behavior is governed by `docs/product/prd/prd-46-home-category-tabs.md` and `docs/product/prd/prd-57-homepage-volume-layers.md`; no new canonical PRD is required.
+- Migration/change record: `docs/engineering/change-records/2026-04-26-signal-post-public-depth-migration.md`
+
+## Data-Flow Diagnosis
+| Stage | Result |
+| --- | --- |
+| Ingestion candidate depth | Manifest-provenance pipeline test fetches 7 raw items without the non-manifest five-source cap. |
+| Normalization | 7 normalized articles are retained. |
+| Deduplication | 7 deduped articles are retained in the regression fixture. |
+| Clustering/ranking | More than 5 ranked clusters are produced when source data supports it. |
+| Digest/Top Events | Digest remains intentionally capped at 5. |
+| Publication/public read model before fix | `signal_posts` rank constraint and candidate persistence limited public signal rows to ranks 1-5. |
+| Homepage public pool before fix | Preview debug showed 5 ranked events, so tab-eligible non-Top depth was 0. |
+| Homepage public pool after fix | The table can store ranks 1-20; `/signals` still reads only Top 5; homepage snapshot can read up to 20 published live rows. |
 
 ## Validation
 - Automated checks:
@@ -24,9 +38,12 @@
   - `npm run build`
   - `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=chromium`
   - `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=webkit`
-- Follow-up targeted checks:
+  - Follow-up targeted checks:
   - `npm run test -- src/lib/homepage-model.test.ts src/lib/data.test.ts src/lib/signals-editorial.test.ts`
   - Added regression coverage for non-Top category depth, Top 5-only fallback, generic editorial tags, and broader published live snapshot depth.
+  - Second follow-up targeted check:
+  - `npm run test -- src/lib/signals-editorial.test.ts src/lib/pipeline/index.test.ts src/lib/homepage-model.test.ts src/lib/data.test.ts`
+  - Added regression coverage for ranked cluster depth beyond the digest Top 5, bounded signal-post depth persistence, depth publication, and `/signals` staying capped to Top 5.
 - Local route/browser checks:
   - Local URL: `http://localhost:3000`
   - `HEAD /`, `HEAD /signals`, and `HEAD /dashboard/signals/editorial-review` returned `200`
@@ -40,3 +57,4 @@
 
 ## Remaining Risks / Follow-up
 - If production needs separate non-Top-5 depth content, a future scoped change should read a real persisted broader candidate pool instead of running ingestion during homepage SSR or presenting fallback data as live intelligence.
+- Existing previews with only five stored rows will continue to show only five until the migration is applied and a new signal snapshot with more than five candidates is persisted/published.

--- a/docs/engineering/bug-fixes/homepage-tabs-signal-regression-politics-tldr.md
+++ b/docs/engineering/bug-fixes/homepage-tabs-signal-regression-politics-tldr.md
@@ -9,6 +9,8 @@
   - Ignore generic category/status terms when comparing semantic entity and keyword overlap.
   - Preserve distinct published Top 5 signal cards even when their tags are generic editorial labels.
   - When the homepage has exactly the editorial Top 5 and no broader ranked depth pool, use that real published Top 5 as the source for category tab filtering.
+  - Follow-up correction: category tabs now prefer real non-Top category depth from `publicRankedItems` before falling back to Top 5 classification.
+  - Published live homepage snapshots now preserve up to 20 published live rows as read-only `depthPosts` for tabs/depth modules while keeping the public `/signals` surface capped to the current Top 5.
   - Keep Developing Now and By Category depth modules empty in that no-depth-pool case instead of duplicating Top Events as fresh additional intelligence.
 - Related PRD: existing homepage category/depth behavior is governed by `docs/product/prd/prd-46-home-category-tabs.md` and `docs/product/prd/prd-57-homepage-volume-layers.md`; no new canonical PRD is required.
 
@@ -22,6 +24,9 @@
   - `npm run build`
   - `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=chromium`
   - `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=webkit`
+- Follow-up targeted checks:
+  - `npm run test -- src/lib/homepage-model.test.ts src/lib/data.test.ts src/lib/signals-editorial.test.ts`
+  - Added regression coverage for non-Top category depth, Top 5-only fallback, generic editorial tags, and broader published live snapshot depth.
 - Local route/browser checks:
   - Local URL: `http://localhost:3000`
   - `HEAD /`, `HEAD /signals`, and `HEAD /dashboard/signals/editorial-review` returned `200`

--- a/docs/engineering/change-records/2026-04-26-signal-post-public-depth-migration.md
+++ b/docs/engineering/change-records/2026-04-26-signal-post-public-depth-migration.md
@@ -1,0 +1,26 @@
+# Change Record: Signal Post Public Depth Migration
+
+- Date: `2026-04-26`
+- Branch: `bugfix/homepage-tabs-signal-regression`
+- Effective change type: `bug-fix`
+- Canonical PRD required: `no`
+- Source of truth: homepage tab regression remediation after politics/TLDR ingestion and PR #114 follow-up validation.
+
+## Reason
+
+Investigation showed the ingestion and ranking pipeline can retain more than five ranked clusters, but `public.signal_posts` could only store ranks `1..5`. That schema constraint made the homepage public read model equivalent to the Top 5 set, so category tabs had no real non-Top depth even after the UI model preferred `publicRankedItems`.
+
+## Scope
+
+- Widen `signal_posts.rank` from `1..5` to `1..20`.
+- Replace the live rank uniqueness rule with a Top 5-only live rank uniqueness rule.
+- Keep `/signals` capped to five published signals.
+- Keep homepage Top Events capped to five.
+- Allow homepage tabs to consume additional published live signal rows when real depth rows exist.
+
+## Non-Goals
+
+- No ingestion-source activation changes.
+- No ranking rewrite.
+- No fake fallback or seed content presented as live intelligence.
+- No canonical PRD because this is regression repair, not a new product feature.

--- a/docs/operations/tracker-sync/2026-04-26-homepage-tabs-signal-regression-politics-tldr.md
+++ b/docs/operations/tracker-sync/2026-04-26-homepage-tabs-signal-regression-politics-tldr.md
@@ -7,7 +7,7 @@
 - Suggested status: In Review
 - PRD file: none
 - Bug report: `docs/engineering/bug-fixes/homepage-tabs-signal-regression-politics-tldr.md`
-- Summary: Fix homepage suppression that reduced published Top 5 signals to 3 cards and left category tabs empty when no broader read-only depth pool exists.
+- Summary: Fix homepage suppression that reduced published Top 5 signals to 3 cards, restore category tabs, and preserve non-Top category depth when a broader published/read-only pool exists.
 - Validation so far:
   - `npm install`
   - `npm run test -- src/lib/homepage-model.test.ts`
@@ -18,7 +18,9 @@
   - `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=chromium`
   - `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=webkit`
   - Local route probes for `/`, `/signals`, and `/dashboard/signals/editorial-review` returned `200`
+  - Follow-up targeted regression check: `npm run test -- src/lib/homepage-model.test.ts src/lib/data.test.ts src/lib/signals-editorial.test.ts`
 - Notes:
   - No canonical PRD was created because this is regression repair.
   - No database migration is required.
   - No politics or TLDR ingestion activation/removal was performed.
+  - Follow-up correction keeps `/signals` capped to Top 5 while allowing the homepage read model to use additional published live snapshot rows as depth when present.

--- a/docs/operations/tracker-sync/2026-04-26-homepage-tabs-signal-regression-politics-tldr.md
+++ b/docs/operations/tracker-sync/2026-04-26-homepage-tabs-signal-regression-politics-tldr.md
@@ -1,0 +1,24 @@
+# Tracker Sync Fallback — Homepage Tabs + Signal Count Regression
+
+- Date: 2026-04-26
+- Change type: Bug fix
+- Branch: `bugfix/homepage-tabs-signal-regression`
+- Suggested tracker destination: Intake Queue, unless an existing governed bug-fix row already owns homepage signal-count/tab regressions.
+- Suggested status: In Review
+- PRD file: none
+- Bug report: `docs/engineering/bug-fixes/homepage-tabs-signal-regression-politics-tldr.md`
+- Summary: Fix homepage suppression that reduced published Top 5 signals to 3 cards and left category tabs empty when no broader read-only depth pool exists.
+- Validation so far:
+  - `npm install`
+  - `npm run test -- src/lib/homepage-model.test.ts`
+  - `npm run test -- src/lib/homepage-model.test.ts src/lib/source-catalog.test.ts src/lib/source-defaults.test.ts src/lib/source-manifest.test.ts src/lib/pipeline/ingestion/index.test.ts src/lib/pipeline/ingestion/tldr.integration.test.ts src/lib/tldr.test.ts src/lib/rss.test.ts src/lib/signals-editorial.test.ts src/components/home/home-category-components.test.tsx src/components/home/CategoryPreviewGrid.test.tsx`
+  - `npm run lint`
+  - `npm run test`
+  - `npm run build`
+  - `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=chromium`
+  - `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=webkit`
+  - Local route probes for `/`, `/signals`, and `/dashboard/signals/editorial-review` returned `200`
+- Notes:
+  - No canonical PRD was created because this is regression repair.
+  - No database migration is required.
+  - No politics or TLDR ingestion activation/removal was performed.

--- a/docs/operations/tracker-sync/2026-04-26-homepage-tabs-signal-regression-politics-tldr.md
+++ b/docs/operations/tracker-sync/2026-04-26-homepage-tabs-signal-regression-politics-tldr.md
@@ -7,7 +7,8 @@
 - Suggested status: In Review
 - PRD file: none
 - Bug report: `docs/engineering/bug-fixes/homepage-tabs-signal-regression-politics-tldr.md`
-- Summary: Fix homepage suppression that reduced published Top 5 signals to 3 cards, restore category tabs, and preserve non-Top category depth when a broader published/read-only pool exists.
+- Change record: `docs/engineering/change-records/2026-04-26-signal-post-public-depth-migration.md`
+- Summary: Fix homepage suppression that reduced published Top 5 signals to 3 cards, restore category tabs, and preserve non-Top category depth by allowing the published signal read model to carry bounded ranks beyond Top 5.
 - Validation so far:
   - `npm install`
   - `npm run test -- src/lib/homepage-model.test.ts`
@@ -19,8 +20,9 @@
   - `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=webkit`
   - Local route probes for `/`, `/signals`, and `/dashboard/signals/editorial-review` returned `200`
   - Follow-up targeted regression check: `npm run test -- src/lib/homepage-model.test.ts src/lib/data.test.ts src/lib/signals-editorial.test.ts`
+  - Second follow-up targeted regression check: `npm run test -- src/lib/signals-editorial.test.ts src/lib/pipeline/index.test.ts src/lib/homepage-model.test.ts src/lib/data.test.ts`
 - Notes:
   - No canonical PRD was created because this is regression repair.
-  - No database migration is required.
+  - Database migration required and included: `supabase/migrations/20260426120000_signal_posts_public_depth_pool.sql`.
   - No politics or TLDR ingestion activation/removal was performed.
   - Follow-up correction keeps `/signals` capped to Top 5 while allowing the homepage read model to use additional published live snapshot rows as depth when present.

--- a/src/components/landing/homepage.test.tsx
+++ b/src/components/landing/homepage.test.tsx
@@ -800,9 +800,9 @@ describe("LandingHomepage", () => {
 
     expect(screen.getByText("Create a free account to read Tech News, Economics, and Politics")).toBeInTheDocument();
     expect(techPanel).not.toBeNull();
+    expect(techPanel).toHaveTextContent("Open source database maintainers ship a query planner update");
     expect(techPanel).toHaveTextContent("Cloud security teams automate secrets rotation across edge workloads");
     expect(screen.queryByText("Cloud providers expand AI capacity plans")).not.toBeInTheDocument();
-    expect(techPanel).not.toHaveTextContent("Open source database maintainers ship a query planner update");
     expect(techPanel).not.toHaveTextContent("No major technology signals in today's briefing.");
   });
 

--- a/src/lib/data.test.ts
+++ b/src/lib/data.test.ts
@@ -191,6 +191,32 @@ describe("homepage read model", () => {
           editedWhyItMatters: "Stored tech editorial note",
         }),
       ],
+      depthPosts: [
+        createHomepageSignalPost({
+          id: "finance-1",
+          rank: 1,
+          title: "Stored finance signal",
+          tags: ["finance", "markets"],
+          summary: "Stored finance summary",
+          editedWhyItMatters: "Stored finance editorial note",
+        }),
+        createHomepageSignalPost({
+          id: "tech-1",
+          rank: 2,
+          title: "Stored tech signal",
+          tags: ["tech", "software"],
+          summary: "Stored tech summary",
+          editedWhyItMatters: "Stored tech editorial note",
+        }),
+        createHomepageSignalPost({
+          id: "tech-depth-1",
+          rank: 6,
+          title: "Stored tech depth signal",
+          tags: ["tech", "software"],
+          summary: "Stored tech depth summary",
+          editedWhyItMatters: "Stored tech depth editorial note",
+        }),
+      ],
     });
 
     const { getHomepagePageState } = await loadDataModule();
@@ -204,13 +230,15 @@ describe("homepage read model", () => {
     expect(
       state.data.briefing.items.some((item) => /static sample copy|public finance briefing now surfaces/i.test(item.title)),
     ).toBe(false);
-  });
+    expect(state.data.publicRankedItems?.map((item) => item.title)).toContain("Stored tech depth signal");
+  }, 10_000);
 
   it("uses clearly labeled category-specific placeholders when no stored snapshot exists", async () => {
     getHomepageSignalSnapshot.mockResolvedValue({
       source: "none",
       briefingDate: null,
       posts: [],
+      depthPosts: [],
     });
 
     const { getHomepagePageState } = await loadDataModule();

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -678,6 +678,10 @@ async function buildPublicHomepageData(): Promise<DashboardData> {
   const items = homepageSignalSnapshot.posts.map((post) =>
     mapHomepageSignalPostToBriefingItem(post, homepageSignalSnapshot.source),
   );
+  const depthItems = (homepageSignalSnapshot.depthPosts?.length
+    ? homepageSignalSnapshot.depthPosts
+    : homepageSignalSnapshot.posts
+  ).map((post) => mapHomepageSignalPostToBriefingItem(post, homepageSignalSnapshot.source));
   const intro =
     homepageSignalSnapshot.source === "published_live"
       ? "The homepage renders from the published live signal set instead of triggering feed ingestion during SSR."
@@ -695,8 +699,8 @@ async function buildPublicHomepageData(): Promise<DashboardData> {
     },
     topics: demoTopics,
     sources,
-    publicRankedItems: items,
-    homepageDiagnostics: buildReadOnlyHomepageDiagnostics(sources, items.length),
+    publicRankedItems: depthItems,
+    homepageDiagnostics: buildReadOnlyHomepageDiagnostics(sources, depthItems.length),
   };
 }
 

--- a/src/lib/homepage-model.test.ts
+++ b/src/lib/homepage-model.test.ts
@@ -196,10 +196,11 @@ describe("buildHomepageViewModel", () => {
     expect(model.featured?.id).toBe("briefing-finance");
     expect(model.topRanked.map((event) => event.id)).not.toContain("depth-tech");
     expect(model.debug.rankedEventsCount).toBe(depthItems.length);
-    expect(model.developingNowEvents.map((event) => event.id)).toContain("depth-tech");
+    expect(model.categorySections.find((section) => section.key === "tech")?.events.map((event) => event.id)).toContain("depth-tech");
+    expect(model.developingNowEvents.map((event) => event.id)).not.toContain("depth-tech");
   });
 
-  it("lets Developing Now surface events from publicRankedItems beyond the Top 5 briefing layer", () => {
+  it("lets category tabs use publicRankedItems beyond the Top 5 briefing layer", () => {
     const briefingItems = [
       createItem({
         id: "briefing-tech",
@@ -218,31 +219,36 @@ describe("buildHomepageViewModel", () => {
     ];
     const depthItems = [
       ...briefingItems,
-      createItem({
-        id: "depth-finance",
-        topicId: "finance",
-        topicName: "Finance",
-        title: "Credit markets reprice after a guidance reset",
-        matchedKeywords: ["credit", "markets", "guidance"],
-        homepageClassification: {
-          primaryCategory: "finance",
-          secondaryCategories: [],
-          confidence: 0.95,
-          scores: { tech: 0, finance: 12, politics: 0 },
-          matchedSignals: { tech: [], finance: ["credit"], politics: [] },
-        },
-        sources: [{ title: "Financial Times", url: "https://www.ft.com/content/guidance-reset" }],
-        priority: "normal",
-      }),
+      ...Array.from({ length: 7 }, (_, index) =>
+        createItem({
+          id: `depth-finance-${index + 1}`,
+          topicId: "finance",
+          topicName: "Finance",
+          title: `Credit markets reprice after guidance reset ${index + 1}`,
+          matchedKeywords: ["credit", `market-${index + 1}`, `guidance-${index + 1}`],
+          publishedAt: `2026-04-15T${String(10 + index).padStart(2, "0")}:00:00.000Z`,
+          homepageClassification: {
+            primaryCategory: "finance",
+            secondaryCategories: [],
+            confidence: 0.95,
+            scores: { tech: 0, finance: 12, politics: 0 },
+            matchedSignals: { tech: [], finance: [`credit-${index + 1}`], politics: [] },
+          },
+          sources: [{ title: `Financial Times ${index + 1}`, url: `https://www.ft.com/content/guidance-reset-${index + 1}` }],
+          priority: "normal",
+        }),
+      ),
     ];
 
     const model = buildHomepageViewModel(createData(briefingItems, { publicRankedItems: depthItems }));
 
-    expect(model.developingNowEvents.map((event) => event.id)).toContain("depth-finance");
-    expect(model.developingNowEvents.map((event) => event.id)).not.toContain("briefing-tech");
+    const financeTabIds = model.categorySections.find((section) => section.key === "finance")?.events.map((event) => event.id) ?? [];
+
+    expect(financeTabIds.some((id) => id.startsWith("depth-finance-"))).toBe(true);
+    expect(financeTabIds).not.toContain("briefing-tech");
   });
 
-  it("lets By Category surface events from publicRankedItems beyond the Top 5 briefing layer", () => {
+  it("keeps downstream category previews from repeating the Top 5 briefing layer", () => {
     const briefingItems = [
       createItem({
         id: "briefing-politics",
@@ -292,27 +298,32 @@ describe("buildHomepageViewModel", () => {
     const depthItems = [
       ...briefingItems,
       ...fillerItems,
-      createItem({
-        id: "depth-tech-preview",
-        topicId: "tech",
-        topicName: "Tech",
-        title: "Database vendors ship a query planner update",
-        matchedKeywords: ["database", "query planner", "open source"],
-        publishedAt: "2026-04-15T08:30:00.000Z",
-        homepageClassification: {
-          primaryCategory: "tech",
-          secondaryCategories: [],
-          confidence: 0.92,
-          scores: { tech: 10, finance: 0, politics: 0 },
-          matchedSignals: { tech: ["database"], finance: [], politics: [] },
-        },
-        priority: "normal",
-      }),
+      ...Array.from({ length: 17 }, (_, index) =>
+        createItem({
+          id: `depth-tech-preview-${index + 1}`,
+          topicId: "tech",
+          topicName: "Tech",
+          title: `Database vendors ship query planner update ${index + 1}`,
+          matchedKeywords: ["database", `query-planner-${index + 1}`, "open source"],
+          publishedAt: `2026-04-15T${String(3 + index).padStart(2, "0")}:30:00.000Z`,
+          homepageClassification: {
+            primaryCategory: "tech",
+            secondaryCategories: [],
+            confidence: 0.92,
+            scores: { tech: 10, finance: 0, politics: 0 },
+            matchedSignals: { tech: [`database-${index + 1}`], finance: [], politics: [] },
+          },
+          priority: "normal",
+        }),
+      ),
     ];
 
     const model = buildHomepageViewModel(createData(briefingItems, { publicRankedItems: depthItems }));
 
-    expect(model.categoryPreviewEvents.tech.map((event) => event.id)).toContain("depth-tech-preview");
+    const techTabIds = model.categorySections.find((section) => section.key === "tech")?.events.map((event) => event.id) ?? [];
+
+    expect(techTabIds.some((id) => id.startsWith("depth-tech-preview-"))).toBe(true);
+    expect(techTabIds).not.toContain("briefing-politics");
     expect(model.categoryPreviewEvents.tech.map((event) => event.id)).not.toContain("briefing-politics");
   });
 
@@ -799,7 +810,7 @@ describe("buildHomepageViewModel", () => {
     expect(model.debug.coreSignalCount).toBeGreaterThanOrEqual(3);
   });
 
-  it("does not borrow fallback cards or repeat top-ranked items into category tabs", () => {
+  it("does not borrow fallback cards and allows non-top depth in category tabs", () => {
     const financeEvent = createItem({
       id: "finance-fallback",
       topicId: "finance",
@@ -834,7 +845,7 @@ describe("buildHomepageViewModel", () => {
     expect(new Set(fallbackIds).size).toBe(fallbackIds.length);
     expect(fallbackIds).not.toContain("finance-fallback");
     expect(fallbackIds).toHaveLength(0);
-    expect(politicsSection?.events.map((event) => event.id)).not.toContain("politics-early");
+    expect(politicsSection?.events.map((event) => event.id)).toContain("politics-early");
   });
 
   it("keeps surfaced event ids unique across featured, top-ranked, category, and watchlist rails", () => {
@@ -1127,7 +1138,36 @@ describe("buildHomepageViewModel", () => {
     expect(model.debug.semanticDuplicateSuppressedCount).toBe(0);
   });
 
-  it("filters the editorial Top 5 into category tabs when no broader ranked depth pool exists", () => {
+  it("uses non-homepage category depth when a broader ranked pool exists", () => {
+    const topItems = [
+      createItem({ id: "top-tech-1", topicId: "tech", topicName: "Tech", title: "AI infrastructure deal expands", matchedKeywords: ["Tech", "watch"], sourceCount: 1, priority: "top", importanceScore: 95 }),
+      createItem({ id: "top-tech-2", topicId: "tech", topicName: "Tech", title: "Enterprise AI merger closes", matchedKeywords: ["Tech", "context"], sourceCount: 1, priority: "top", importanceScore: 92 }),
+      createItem({ id: "top-finance-1", topicId: "finance", topicName: "Finance", title: "Arbitrage spreads widen", matchedKeywords: ["Finance", "watch"], sourceCount: 1, priority: "top", importanceScore: 89 }),
+      createItem({ id: "top-finance-2", topicId: "finance", topicName: "Finance", title: "Credit market repricing accelerates", matchedKeywords: ["Finance", "watch"], sourceCount: 1, priority: "top", importanceScore: 86 }),
+      createItem({ id: "top-politics-1", topicId: "politics", topicName: "Politics", title: "US Iran diplomacy narrows", matchedKeywords: ["Politics", "watch"], sourceCount: 1, priority: "top", importanceScore: 83 }),
+    ];
+    const depthItems = [
+      ...topItems,
+      createItem({ id: "depth-tech-1", topicId: "tech", topicName: "Tech", title: "Chip supply contracts reset cloud roadmaps", matchedKeywords: ["chips", "cloud", "contracts"], sourceCount: 1, priority: "normal", importanceScore: 77 }),
+      createItem({ id: "depth-finance-1", topicId: "finance", topicName: "Finance", title: "Treasury liquidity strains basis trades", matchedKeywords: ["treasury", "liquidity", "basis"], sourceCount: 1, priority: "normal", importanceScore: 76 }),
+      createItem({ id: "depth-politics-1", topicId: "politics", topicName: "Politics", title: "Sanctions negotiators widen talks", matchedKeywords: ["sanctions", "negotiators", "policy"], sourceCount: 1, priority: "normal", importanceScore: 75 }),
+    ];
+
+    const model = buildHomepageViewModel(createData(topItems, { publicRankedItems: depthItems }));
+    const topIds = new Set(
+      [model.featured, ...model.topRanked]
+        .filter((event): event is NonNullable<typeof event> => Boolean(event))
+        .map((event) => event.id),
+    );
+    const tabIds = model.categorySections.flatMap((section) => section.events.map((event) => event.id));
+
+    expect(topIds).toEqual(new Set(topItems.map((item) => item.id)));
+    expect(tabIds).toEqual(expect.arrayContaining(["depth-tech-1", "depth-finance-1", "depth-politics-1"]));
+    expect(tabIds.every((id) => !topIds.has(id))).toBe(true);
+    expect(tabIds.some((id) => !topIds.has(id))).toBe(true);
+  });
+
+  it("filters the editorial Top 5 into category tabs only when no broader ranked depth pool exists", () => {
     const items = [
       createItem({ id: "published-tech-1", topicId: "tech", topicName: "Tech", title: "AI infrastructure deal expands", matchedKeywords: ["Tech", "watch"], sourceCount: 1 }),
       createItem({ id: "published-tech-2", topicId: "tech", topicName: "Tech", title: "Enterprise AI merger closes", matchedKeywords: ["Tech", "context"], sourceCount: 1 }),

--- a/src/lib/homepage-model.test.ts
+++ b/src/lib/homepage-model.test.ts
@@ -1058,6 +1058,101 @@ describe("buildHomepageViewModel", () => {
     expect(new Set(visibleTopEventIds)).toEqual(new Set(items.map((item) => item.id)));
   });
 
+  it("keeps distinct published editorial signals visible when tags only contain generic categories and roles", () => {
+    const items = [
+      createItem({
+        id: "published-tech-1",
+        topicId: "tech",
+        topicName: "Tech",
+        title: "Google will invest as much as $40 billion in Anthropic",
+        matchedKeywords: ["Tech", "context", "Watch"],
+        sourceCount: 1,
+        sources: [{ title: "Ars Technica", url: "https://arstechnica.com/ai/google-anthropic" }],
+        priority: "top",
+        importanceScore: 61,
+      }),
+      createItem({
+        id: "published-tech-2",
+        topicId: "tech",
+        topicName: "Tech",
+        title: "Cohere acquires German startup to create transatlantic AI powerhouse",
+        matchedKeywords: ["Tech", "watch", "Watch"],
+        sourceCount: 1,
+        sources: [{ title: "TechCrunch", url: "https://techcrunch.com/cohere-acquisition" }],
+        priority: "top",
+        importanceScore: 53,
+      }),
+      createItem({
+        id: "published-finance-1",
+        topicId: "finance",
+        topicName: "Finance",
+        title: "The golden age of arbitrage has begun",
+        matchedKeywords: ["Finance", "watch", "Watch"],
+        sourceCount: 1,
+        sources: [{ title: "Financial Times", url: "https://www.ft.com/arbitrage" }],
+        priority: "top",
+        importanceScore: 46,
+      }),
+      createItem({
+        id: "published-finance-2",
+        topicId: "finance",
+        topicName: "Finance",
+        title: "Cloudflare Agents Week reshapes the clip economy",
+        matchedKeywords: ["Finance", "watch", "Watch"],
+        sourceCount: 1,
+        sources: [{ title: "TLDR", url: "https://tldr.tech/tech/2026-04-24" }],
+        priority: "top",
+        importanceScore: 45,
+      }),
+      createItem({
+        id: "published-politics-1",
+        topicId: "politics",
+        topicName: "Politics",
+        title: "The narrow path to a US-Iran deal",
+        matchedKeywords: ["Politics", "watch", "Watch"],
+        sourceCount: 1,
+        sources: [{ title: "Financial Times", url: "https://www.ft.com/us-iran-deal" }],
+        priority: "top",
+        importanceScore: 49,
+      }),
+    ];
+
+    const model = buildHomepageViewModel(createData(items));
+    const visibleTopEventIds = [model.featured, ...model.topRanked]
+      .filter((event): event is NonNullable<typeof event> => Boolean(event))
+      .map((event) => event.id);
+
+    expect(visibleTopEventIds).toHaveLength(5);
+    expect(new Set(visibleTopEventIds)).toEqual(new Set(items.map((item) => item.id)));
+    expect(model.debug.semanticDuplicateSuppressedCount).toBe(0);
+  });
+
+  it("filters the editorial Top 5 into category tabs when no broader ranked depth pool exists", () => {
+    const items = [
+      createItem({ id: "published-tech-1", topicId: "tech", topicName: "Tech", title: "AI infrastructure deal expands", matchedKeywords: ["Tech", "watch"], sourceCount: 1 }),
+      createItem({ id: "published-tech-2", topicId: "tech", topicName: "Tech", title: "Enterprise AI merger closes", matchedKeywords: ["Tech", "context"], sourceCount: 1 }),
+      createItem({ id: "published-finance-1", topicId: "finance", topicName: "Finance", title: "Arbitrage spreads widen", matchedKeywords: ["Finance", "watch"], sourceCount: 1 }),
+      createItem({ id: "published-finance-2", topicId: "finance", topicName: "Finance", title: "Credit market repricing accelerates", matchedKeywords: ["Finance", "watch"], sourceCount: 1 }),
+      createItem({ id: "published-politics-1", topicId: "politics", topicName: "Politics", title: "US Iran diplomacy narrows", matchedKeywords: ["Politics", "watch"], sourceCount: 1 }),
+    ];
+
+    const model = buildHomepageViewModel(createData(items));
+
+    expect(model.categorySections.find((section) => section.key === "tech")?.events.map((event) => event.id)).toEqual([
+      "published-tech-1",
+      "published-tech-2",
+    ]);
+    expect(model.categorySections.find((section) => section.key === "finance")?.events.map((event) => event.id)).toEqual([
+      "published-finance-1",
+      "published-finance-2",
+    ]);
+    expect(model.categorySections.find((section) => section.key === "politics")?.events.map((event) => event.id)).toEqual([
+      "published-politics-1",
+    ]);
+    expect(Object.values(model.categoryPreviewEvents).flat()).toHaveLength(0);
+    expect(model.developingNowEvents).toHaveLength(0);
+  });
+
   it("does not fabricate the 3-card minimum when fewer pipeline-selected Top Events exist", () => {
     const items = [
       createItem({

--- a/src/lib/homepage-model.ts
+++ b/src/lib/homepage-model.ts
@@ -190,10 +190,6 @@ export function buildHomepageViewModel(
   const confirmedTopLayerEvents = topLayerEvents.filter((event) => !event.intelligence.isEarlySignal);
   const confirmedDepthLayerEvents = depthLayerEvents.filter((event) => !event.intelligence.isEarlySignal);
   const earlySignals = depthLayerEvents.filter((event) => event.intelligence.isEarlySignal);
-  const topLayerEventIds = new Set(topLayerEvents.map((event) => event.id));
-  const depthLayerHasDistinctEvents = depthLayerEvents.some((event) => !topLayerEventIds.has(event.id));
-  const shouldFilterTabsFromTopLayer =
-    !depthLayerHasDistinctEvents && topLayerEvents.length === EDITORIAL_SIGNAL_SET_SIZE;
   const featured = topLayerEvents[0] ?? null;
   const featuredContext = featured ? [featured] : [];
   const confirmedTopRankedCandidates = confirmedTopLayerEvents.filter((event) => event.id !== featured?.id);
@@ -215,19 +211,15 @@ export function buildHomepageViewModel(
   const topSignalEventIds = new Set(
     [featured, ...topRanked].filter((event): event is HomepageEvent => Boolean(event)).map((event) => event.id),
   );
-  const volumeLayers = buildVolumeLayersViewModel(depthLayerEvents, topSignalEventIds);
   let semanticDuplicateSuppressedCount = topRankedSelection.suppressedCount;
   const visibleSelectionAdjustmentsCount = topRankedSelection.adjustmentsCount;
-  const surfacedEvents = [
-    ...featuredContext,
-    ...topRanked,
-    ...volumeLayers.developingNow,
-    ...Object.values(volumeLayers.categoryPreviews).flat(),
-  ];
-  const categoryTabSourceEvents = shouldFilterTabsFromTopLayer ? topLayerEvents : depthLayerEvents;
-  const excludedCategoryTabIds = new Set(
-    shouldFilterTabsFromTopLayer ? [] : surfacedEvents.map((event) => event.id),
-  );
+  const categoryTabPool = resolveCategoryTabPool({
+    topLayerEvents,
+    depthLayerEvents,
+    topSignalEventIds,
+  });
+  const categoryTabSourceEvents = categoryTabPool.sourceEvents;
+  const excludedCategoryTabIds = new Set(categoryTabPool.initialExcludedEventIds);
   const categorySections = HOMEPAGE_CATEGORY_CONFIG.map((category) => {
     const sectionSelection = selectCategoryTabEvents({
       rankedEvents: categoryTabSourceEvents,
@@ -245,14 +237,13 @@ export function buildHomepageViewModel(
     );
 
     displayEvents.forEach((event) => {
-      surfacedEvents.push(event);
       excludedCategoryTabIds.add(event.id);
     });
 
     const emptyReason = getCategoryTabEmptyReason(category.key);
     const excludedReasons = [
       ...depthLayerEvents
-        .filter((event) => !shouldFilterTabsFromTopLayer || !displayEvents.some((displayEvent) => displayEvent.id === event.id))
+        .filter((event) => !categoryTabPool.usesTopLayerFallback || !displayEvents.some((displayEvent) => displayEvent.id === event.id))
         .filter((event) => event.classification.primaryCategory !== category.key)
         .map((event) => getExclusionReason(event, category.key)),
       ...eligibleEvents
@@ -287,6 +278,20 @@ export function buildHomepageViewModel(
       excludedReasons: dedupeStrings(excludedReasons).slice(0, 6),
     } satisfies HomepageCategorySection;
   });
+  const categoryTabEventIds = new Set(
+    categorySections.flatMap((section) => section.events.map((event) => event.id)),
+  );
+  const volumeLayers = buildVolumeLayersViewModel(
+    depthLayerEvents,
+    new Set([...topSignalEventIds, ...categoryTabEventIds]),
+  );
+  const surfacedEvents = [
+    ...featuredContext,
+    ...topRanked,
+    ...categorySections.flatMap((section) => section.events),
+    ...volumeLayers.developingNow,
+    ...Object.values(volumeLayers.categoryPreviews).flat(),
+  ];
 
   const reservedIds = new Set([
     ...topRanked.map((event) => event.id),
@@ -509,6 +514,28 @@ export function selectCategoryPreviewEvents(
       return right.rankScore - left.rankScore;
     })
     .slice(0, limit);
+}
+
+function resolveCategoryTabPool({
+  topLayerEvents,
+  depthLayerEvents,
+  topSignalEventIds,
+}: {
+  topLayerEvents: HomepageEvent[];
+  depthLayerEvents: HomepageEvent[];
+  topSignalEventIds: Set<string>;
+}) {
+  const nonTopCategoryDepthEvents = depthLayerEvents.filter(
+    (event) => Boolean(event.classification.primaryCategory) && !topSignalEventIds.has(event.id),
+  );
+  const usesTopLayerFallback =
+    nonTopCategoryDepthEvents.length === 0 && topLayerEvents.length === EDITORIAL_SIGNAL_SET_SIZE;
+
+  return {
+    sourceEvents: usesTopLayerFallback ? topLayerEvents : depthLayerEvents,
+    initialExcludedEventIds: usesTopLayerFallback ? [] : Array.from(topSignalEventIds),
+    usesTopLayerFallback,
+  };
 }
 
 export function selectCategoryTabEvents({

--- a/src/lib/homepage-model.ts
+++ b/src/lib/homepage-model.ts
@@ -119,11 +119,36 @@ export type HomepageViewModel = {
 
 const TOP_EVENTS_LIMIT = 4;
 const MIN_PUBLIC_TOP_EVENTS = 3;
+const EDITORIAL_SIGNAL_SET_SIZE = 5;
 const CATEGORY_TAB_LIMIT = 6;
 const DEVELOPING_NOW_EVENT_LIMIT = 10;
 const CATEGORY_PREVIEW_LIMIT = 3;
 const TRENDING_EVENT_LIMIT = 3;
 const EARLY_SIGNAL_LIMIT = 3;
+const GENERIC_SEMANTIC_SIGNALS = new Set([
+  "core",
+  "critical",
+  "developing",
+  "economic",
+  "economics",
+  "finance",
+  "financial",
+  "geopolitics",
+  "government",
+  "high",
+  "live",
+  "normal",
+  "policy",
+  "politics",
+  "published",
+  "signal",
+  "signals",
+  "tech",
+  "technology",
+  "top",
+  "watch",
+  "world",
+]);
 const SEMANTIC_STOPWORDS = new Set([
   "a",
   "an",
@@ -165,6 +190,10 @@ export function buildHomepageViewModel(
   const confirmedTopLayerEvents = topLayerEvents.filter((event) => !event.intelligence.isEarlySignal);
   const confirmedDepthLayerEvents = depthLayerEvents.filter((event) => !event.intelligence.isEarlySignal);
   const earlySignals = depthLayerEvents.filter((event) => event.intelligence.isEarlySignal);
+  const topLayerEventIds = new Set(topLayerEvents.map((event) => event.id));
+  const depthLayerHasDistinctEvents = depthLayerEvents.some((event) => !topLayerEventIds.has(event.id));
+  const shouldFilterTabsFromTopLayer =
+    !depthLayerHasDistinctEvents && topLayerEvents.length === EDITORIAL_SIGNAL_SET_SIZE;
   const featured = topLayerEvents[0] ?? null;
   const featuredContext = featured ? [featured] : [];
   const confirmedTopRankedCandidates = confirmedTopLayerEvents.filter((event) => event.id !== featured?.id);
@@ -195,17 +224,20 @@ export function buildHomepageViewModel(
     ...volumeLayers.developingNow,
     ...Object.values(volumeLayers.categoryPreviews).flat(),
   ];
-  const excludedCategoryTabIds = new Set(surfacedEvents.map((event) => event.id));
+  const categoryTabSourceEvents = shouldFilterTabsFromTopLayer ? topLayerEvents : depthLayerEvents;
+  const excludedCategoryTabIds = new Set(
+    shouldFilterTabsFromTopLayer ? [] : surfacedEvents.map((event) => event.id),
+  );
   const categorySections = HOMEPAGE_CATEGORY_CONFIG.map((category) => {
     const sectionSelection = selectCategoryTabEvents({
-      rankedEvents: depthLayerEvents,
+      rankedEvents: categoryTabSourceEvents,
       category: category.key,
       excludedEventIds: excludedCategoryTabIds,
       limit: CATEGORY_TAB_LIMIT,
     });
     semanticDuplicateSuppressedCount += sectionSelection.suppressedCount;
     const displayEvents = sectionSelection.events;
-    const eligibleEvents = depthLayerEvents.filter(
+    const eligibleEvents = categoryTabSourceEvents.filter(
       (event) => event.classification.primaryCategory === category.key,
     );
     const heldBackEvents = eligibleEvents.filter(
@@ -220,6 +252,7 @@ export function buildHomepageViewModel(
     const emptyReason = getCategoryTabEmptyReason(category.key);
     const excludedReasons = [
       ...depthLayerEvents
+        .filter((event) => !shouldFilterTabsFromTopLayer || !displayEvents.some((displayEvent) => displayEvent.id === event.id))
         .filter((event) => event.classification.primaryCategory !== category.key)
         .map((event) => getExclusionReason(event, category.key)),
       ...eligibleEvents
@@ -878,8 +911,14 @@ function isSemanticDuplicate(left: HomepageEvent, right: HomepageEvent) {
   const leftTitleTokens = normalizeSemanticTokens(left.title);
   const rightTitleTokens = normalizeSemanticTokens(right.title);
   const titleSimilarity = jaccard(leftTitleTokens, rightTitleTokens);
-  const entityOverlap = overlapCount(left.intelligence.keyEntities, right.intelligence.keyEntities);
-  const keywordOverlap = overlapCount(left.matchedKeywords, right.matchedKeywords);
+  const entityOverlap = overlapCount(
+    getSpecificSemanticSignals(left.intelligence.keyEntities),
+    getSpecificSemanticSignals(right.intelligence.keyEntities),
+  );
+  const keywordOverlap = overlapCount(
+    getSpecificSemanticSignals(left.matchedKeywords),
+    getSpecificSemanticSignals(right.matchedKeywords),
+  );
 
   if (titleSimilarity >= 0.7) {
     return true;
@@ -902,10 +941,21 @@ function buildSemanticFingerprint(
   classification: HomepageCategoryClassification,
 ) {
   const categoryKey = classification.primaryCategory ?? item.topicName.toLowerCase();
-  const dominantEntity = normalizeSemanticTokens(intelligence.keyEntities[0] ?? "").join("-");
+  const dominantEntity = normalizeSemanticTokens(getSpecificSemanticSignals(intelligence.keyEntities)[0] ?? "").join("-");
   const titleStem = normalizeSemanticTokens(item.title).slice(0, 4).join("-");
 
   return [categoryKey, dominantEntity, titleStem].filter(Boolean).join(":");
+}
+
+function getSpecificSemanticSignals(values: string[]) {
+  return values.filter((value) => {
+    const normalized = normalizeSemanticSignal(value);
+    return normalized && !GENERIC_SEMANTIC_SIGNALS.has(normalized);
+  });
+}
+
+function normalizeSemanticSignal(value: string) {
+  return normalizeSemanticTokens(value).join(" ");
 }
 
 function normalizeSemanticTokens(value: string) {

--- a/src/lib/pipeline/index.test.ts
+++ b/src/lib/pipeline/index.test.ts
@@ -59,6 +59,57 @@ describe("runClusterFirstPipeline", () => {
     expect(lead?.topic_keywords.length).toBeGreaterThan(0);
   });
 
+  it("keeps ranked cluster depth beyond the Top 5 digest when source data supports it", async () => {
+    const rssModule = await import("@/lib/rss");
+    const fetchFeedArticlesMock = vi.mocked(rssModule.fetchFeedArticles);
+    const sources: Source[] = Array.from({ length: 7 }, (_, index) => {
+      const sourceNumber = index + 1;
+
+      return {
+        id: `source-depth-${sourceNumber}`,
+        name: `Depth Source ${sourceNumber}`,
+        feedUrl: `https://example.com/depth-${sourceNumber}.xml`,
+        homepageUrl: `https://example.com/depth-${sourceNumber}`,
+        topicName: sourceNumber % 3 === 0 ? "Politics" : sourceNumber % 3 === 1 ? "Tech" : "Finance",
+        status: "active",
+      };
+    });
+
+    fetchFeedArticlesMock.mockImplementation(async (feedUrl, sourceName) => {
+      const sourceNumber = Number(feedUrl.match(/depth-(\d+)/)?.[1] ?? "1");
+      const stories = [
+        ["Quantum datacenter buildout accelerates", "Compute buyers reserved new accelerator capacity for frontier model training."],
+        ["Copper spreads widen across warehouses", "Metals traders repriced inventories after smelter disruptions tightened supply."],
+        ["Defense committee rewrites procurement rules", "Lawmakers advanced acquisition changes affecting missile programs and shipyards."],
+        ["Export license review slows chip shipments", "Regulators delayed approvals for advanced semiconductor equipment transfers."],
+        ["Central bank liquidity window narrows", "Money markets adjusted funding plans after overnight facility usage changed."],
+        ["Election administrators test ballot systems", "State officials completed certification drills for tabulation and chain of custody."],
+        ["Enterprise software margins reset guidance", "Cloud vendors revised operating targets after renewal discounts compressed bookings."],
+      ];
+      const [title, body] = stories[sourceNumber - 1] ?? stories[0];
+
+      return [
+        {
+          title,
+          url: `${feedUrl}/lead-story`,
+          summaryText: body,
+          contentText: body,
+          sourceName,
+          publishedAt: `2026-04-25T0${sourceNumber}:00:00.000Z`,
+        },
+      ];
+    });
+
+    const result = await runClusterFirstPipeline({ sources, suppliedByManifest: true });
+
+    expect(result.run.used_seed_fallback).toBe(false);
+    expect(result.run.num_raw_items).toBe(7);
+    expect(result.run.num_after_dedup).toBe(7);
+    expect(result.run.num_clusters).toBeGreaterThan(5);
+    expect(result.ranked_clusters.length).toBeGreaterThan(5);
+    expect(result.digest.most_important_now).toHaveLength(5);
+  });
+
   it("continues clustering and ranking when one politics source fails", async () => {
     const rssModule = await import("@/lib/rss");
     const fetchFeedArticlesMock = vi.mocked(rssModule.fetchFeedArticles);

--- a/src/lib/pipeline/index.ts
+++ b/src/lib/pipeline/index.ts
@@ -23,6 +23,7 @@ export type ClusterFirstPipelineResult = {
 
 export async function runClusterFirstPipeline(options: {
   sources?: Source[];
+  suppliedByManifest?: boolean;
 } = {}): Promise<ClusterFirstPipelineResult> {
   const runId = `pipeline-${Date.now()}`;
   const run = createEmptyPipelineRun(runId);

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -579,6 +579,18 @@ describe("signals editorial workflow", () => {
           editorial_status: "published",
         }),
       ),
+      createRow({
+        id: "signal-6",
+        rank: 6,
+        ai_why_it_matters: "Generated category-depth context.",
+        editorial_status: "needs_review",
+      }),
+      createRow({
+        id: "signal-7",
+        rank: 7,
+        edited_why_it_matters: "Edited category-depth context.",
+        editorial_status: "draft",
+      }),
     ];
     createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
     safeGetUser.mockResolvedValue({
@@ -594,9 +606,12 @@ describe("signals editorial workflow", () => {
     expect(rows.every((row) => row.editorial_status === "published")).toBe(true);
     expect(rows[0].published_why_it_matters).toBe("Newly approved editorial update.");
     expect(rows[1].published_why_it_matters).toBe("Existing edited 2");
+    expect(rows[5].published_why_it_matters).toBe("Generated category-depth context.");
+    expect(rows[6].published_why_it_matters).toBe("Edited category-depth context.");
+    expect(rows.slice(5).every((row) => row.is_live === true)).toBe(true);
   });
 
-  it("persists a new daily Top 5 snapshot and archives the previous live set", async () => {
+  it("persists a new daily Top 5 snapshot with bounded public depth and archives the previous live set", async () => {
     const rows = Array.from({ length: 5 }, (_, index) =>
       createRow({
         id: `live-${index + 1}`,
@@ -612,17 +627,17 @@ describe("signals editorial workflow", () => {
     const { persistSignalPostsForBriefing } = await loadEditorialModule();
     const result = await persistSignalPostsForBriefing({
       briefingDate: "2026-04-25",
-      items: Array.from({ length: 5 }, (_, index) => createBriefingItem(index + 1)),
+      items: Array.from({ length: 8 }, (_, index) => createBriefingItem(index + 1)),
     });
 
     expect(result.ok).toBe(true);
-    expect(result.insertedCount).toBe(5);
+    expect(result.insertedCount).toBe(8);
     expect(rows.filter((row) => row.briefing_date === "2026-04-24").every((row) => row.is_live === false)).toBe(true);
 
     const insertedRows = rows.filter((row) => row.briefing_date === "2026-04-25");
-    expect(insertedRows).toHaveLength(5);
+    expect(insertedRows).toHaveLength(8);
     expect(insertedRows.every((row) => row.is_live === true)).toBe(true);
-    expect(insertedRows.map((row) => row.rank)).toEqual([1, 2, 3, 4, 5]);
+    expect(insertedRows.map((row) => row.rank)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
   });
 
   it("does not overwrite an existing daily snapshot for the same briefing date", async () => {
@@ -737,22 +752,16 @@ describe("signals editorial workflow", () => {
 
   it("loads only the live published Top 5 for the public signals surface", async () => {
     const rows = [
-      createRow({
-        id: "live-1",
-        rank: 1,
-        briefing_date: "2026-04-24",
-        editorial_status: "published",
-        published_why_it_matters: "Live published 1",
-        is_live: true,
-      }),
-      createRow({
-        id: "live-2",
-        rank: 2,
-        briefing_date: "2026-04-24",
-        editorial_status: "published",
-        published_why_it_matters: "Live published 2",
-        is_live: true,
-      }),
+      ...Array.from({ length: 7 }, (_, index) =>
+        createRow({
+          id: `live-${index + 1}`,
+          rank: index + 1,
+          briefing_date: "2026-04-24",
+          editorial_status: "published",
+          published_why_it_matters: `Live published ${index + 1}`,
+          is_live: true,
+        }),
+      ),
       createRow({
         id: "archived-1",
         rank: 1,
@@ -767,8 +776,8 @@ describe("signals editorial workflow", () => {
     const { getPublishedSignalPosts } = await loadEditorialModule();
     const posts = await getPublishedSignalPosts();
 
-    expect(posts).toHaveLength(2);
-    expect(posts.map((post) => post.id)).toEqual(["live-1", "live-2"]);
+    expect(posts).toHaveLength(5);
+    expect(posts.map((post) => post.id)).toEqual(["live-1", "live-2", "live-3", "live-4", "live-5"]);
   });
 
   it("keeps a broader published live pool for homepage tab depth", async () => {

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -771,6 +771,35 @@ describe("signals editorial workflow", () => {
     expect(posts.map((post) => post.id)).toEqual(["live-1", "live-2"]);
   });
 
+  it("keeps a broader published live pool for homepage tab depth", async () => {
+    const rows = Array.from({ length: 7 }, (_, index) =>
+      createRow({
+        id: `live-${index + 1}`,
+        rank: index + 1,
+        briefing_date: "2026-04-24",
+        editorial_status: "published",
+        published_why_it_matters: `Live published ${index + 1}`,
+        is_live: true,
+      }),
+    );
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+
+    const { getHomepageSignalSnapshot } = await loadEditorialModule();
+    const snapshot = await getHomepageSignalSnapshot();
+
+    expect(snapshot.source).toBe("published_live");
+    expect(snapshot.posts.map((post) => post.id)).toEqual(["live-1", "live-2", "live-3", "live-4", "live-5"]);
+    expect(snapshot.depthPosts.map((post) => post.id)).toEqual([
+      "live-1",
+      "live-2",
+      "live-3",
+      "live-4",
+      "live-5",
+      "live-6",
+      "live-7",
+    ]);
+  });
+
   it("falls back to the latest stored snapshot for homepage SSR when no live published set exists", async () => {
     const rows = [
       createRow({
@@ -806,5 +835,6 @@ describe("signals editorial workflow", () => {
     expect(snapshot.source).toBe("latest_snapshot");
     expect(snapshot.briefingDate).toBe("2026-04-25");
     expect(snapshot.posts.map((post) => post.id)).toEqual(["latest-1", "latest-2"]);
+    expect(snapshot.depthPosts.map((post) => post.id)).toEqual(["latest-1", "latest-2"]);
   });
 });

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -45,6 +45,7 @@ const SIGNAL_POST_SELECT = [
 ].join(", ");
 
 const EDITORIAL_PAGE_SIZE = 20;
+const PUBLIC_SIGNAL_DEPTH_LIMIT = 20;
 
 type EditorialClient = NonNullable<ReturnType<typeof createSupabaseServiceRoleClient>>;
 
@@ -168,6 +169,7 @@ export type SignalSnapshotPersistenceResult = {
 export type HomepageSignalSnapshot = {
   source: "published_live" | "latest_snapshot" | "none";
   posts: EditorialSignalPost[];
+  depthPosts: EditorialSignalPost[];
   briefingDate: string | null;
 };
 
@@ -1243,7 +1245,7 @@ export async function publishSignalPost(input: {
   };
 }
 
-export async function getPublishedSignalPosts(): Promise<EditorialSignalPost[]> {
+async function loadPublishedSignalPosts(limit: number): Promise<EditorialSignalPost[]> {
   const supabase = createSupabaseServiceRoleClient();
 
   if (!supabase) {
@@ -1256,7 +1258,7 @@ export async function getPublishedSignalPosts(): Promise<EditorialSignalPost[]> 
     .eq("is_live", true)
     .eq("editorial_status", "published")
     .order("rank", { ascending: true })
-    .limit(5);
+    .limit(limit);
 
   if (result.error) {
     logServerEvent("warn", "Published signal posts could not be loaded", {
@@ -1268,17 +1270,22 @@ export async function getPublishedSignalPosts(): Promise<EditorialSignalPost[]> 
 
   return ((result.data ?? []) as unknown as StoredSignalPost[])
     .map(mapStoredSignalPost)
-    .filter((post) => normalizeEditorialText(post.publishedWhyItMatters))
-    .slice(0, 5);
+    .filter((post) => normalizeEditorialText(post.publishedWhyItMatters));
+}
+
+export async function getPublishedSignalPosts(): Promise<EditorialSignalPost[]> {
+  return (await loadPublishedSignalPosts(5)).slice(0, 5);
 }
 
 export async function getHomepageSignalSnapshot(): Promise<HomepageSignalSnapshot> {
-  const publishedPosts = await getPublishedSignalPosts();
+  const publishedDepthPosts = await loadPublishedSignalPosts(PUBLIC_SIGNAL_DEPTH_LIMIT);
+  const publishedPosts = publishedDepthPosts.slice(0, 5);
 
   if (publishedPosts.length > 0) {
     return {
       source: "published_live",
       posts: publishedPosts,
+      depthPosts: publishedDepthPosts,
       briefingDate: publishedPosts[0]?.briefingDate ?? null,
     };
   }
@@ -1289,6 +1296,7 @@ export async function getHomepageSignalSnapshot(): Promise<HomepageSignalSnapsho
     return {
       source: "none",
       posts: [],
+      depthPosts: [],
       briefingDate: null,
     };
   }
@@ -1304,6 +1312,7 @@ export async function getHomepageSignalSnapshot(): Promise<HomepageSignalSnapsho
     return {
       source: "none",
       posts: [],
+      depthPosts: [],
       briefingDate: null,
     };
   }
@@ -1312,6 +1321,7 @@ export async function getHomepageSignalSnapshot(): Promise<HomepageSignalSnapsho
     return {
       source: "none",
       posts: [],
+      depthPosts: [],
       briefingDate: null,
     };
   }
@@ -1322,6 +1332,7 @@ export async function getHomepageSignalSnapshot(): Promise<HomepageSignalSnapsho
     return {
       source: "none",
       posts: [],
+      depthPosts: [],
       briefingDate: latest.latestBriefingDate,
     };
   }
@@ -1329,6 +1340,7 @@ export async function getHomepageSignalSnapshot(): Promise<HomepageSignalSnapsho
   return {
     source: "latest_snapshot",
     posts,
+    depthPosts: posts,
     briefingDate: latest.latestBriefingDate,
   };
 }

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -46,6 +46,7 @@ const SIGNAL_POST_SELECT = [
 
 const EDITORIAL_PAGE_SIZE = 20;
 const PUBLIC_SIGNAL_DEPTH_LIMIT = 20;
+const TOP_SIGNAL_SET_SIZE = 5;
 
 type EditorialClient = NonNullable<ReturnType<typeof createSupabaseServiceRoleClient>>;
 
@@ -259,7 +260,7 @@ function mapBriefingItemToSignalPost(item: BriefingItem, index: number): Editori
 }
 
 function buildSignalPostCandidates(items: BriefingItem[]) {
-  return items.slice(0, 5).map(mapBriefingItemToSignalPost);
+  return items.slice(0, PUBLIC_SIGNAL_DEPTH_LIMIT).map(mapBriefingItemToSignalPost);
 }
 
 function parseEditorialSortTime(value: string | null | undefined) {
@@ -414,12 +415,12 @@ async function persistSignalPostCandidates(
 ): Promise<SignalSnapshotPersistenceResult> {
   const briefingDate = normalizeDateValue(input.briefingDate) ?? new Date().toISOString().slice(0, 10);
 
-  if (input.candidates.length !== 5) {
+  if (input.candidates.length < TOP_SIGNAL_SET_SIZE) {
     return {
       ok: false,
       briefingDate,
       insertedCount: 0,
-      message: `The current signal pipeline returned ${input.candidates.length} signal posts. Persisting the daily snapshot requires exactly five.`,
+      message: `The current signal pipeline returned ${input.candidates.length} signal posts. Persisting the daily snapshot requires at least five.`,
     };
   }
 
@@ -510,7 +511,7 @@ async function persistSignalPostCandidates(
     briefingDate,
     insertedCount: missingCandidates.length,
     message:
-      missingCandidates.length === 5
+      missingCandidates.length === TOP_SIGNAL_SET_SIZE
         ? "Persisted a new daily Top 5 snapshot."
         : `Persisted ${missingCandidates.length} missing signal snapshot rows.`,
   };
@@ -569,6 +570,25 @@ async function loadCurrentTopFive(client: EditorialClient, briefingDate: string 
     .eq("briefing_date", briefingDate)
     .order("rank", { ascending: true })
     .limit(5);
+
+  if (result.error) {
+    return [];
+  }
+
+  return ((result.data ?? []) as unknown as StoredSignalPost[]).map(mapStoredSignalPost);
+}
+
+async function loadCurrentSignalDepth(client: EditorialClient, briefingDate: string | null) {
+  if (!briefingDate) {
+    return [];
+  }
+
+  const result = await client
+    .from("signal_posts")
+    .select(SIGNAL_POST_SELECT)
+    .eq("briefing_date", briefingDate)
+    .order("rank", { ascending: true })
+    .limit(PUBLIC_SIGNAL_DEPTH_LIMIT);
 
   if (result.error) {
     return [];
@@ -1070,6 +1090,9 @@ export async function publishApprovedSignals(input: {
 
   const latest = await getLatestBriefingDate(context.client);
   const topFivePosts = await loadCurrentTopFive(context.client, latest.latestBriefingDate);
+  const depthPosts = (await loadCurrentSignalDepth(context.client, latest.latestBriefingDate)).filter(
+    (post) => post.rank > TOP_SIGNAL_SET_SIZE,
+  );
 
   if (latest.errorMessage) {
     return {
@@ -1152,11 +1175,41 @@ export async function publishApprovedSignals(input: {
     }),
   );
 
-  if (updateResults.some((result) => result.error)) {
+  const depthUpdateResults = await Promise.all(
+    depthPosts
+      .map((post) => {
+        const structuredContent =
+          post.editedWhyItMattersStructured ?? post.publishedWhyItMattersStructured;
+        const depthText = normalizeEditorialText(
+          buildEditorialWhyItMattersText(
+            structuredContent,
+            post.editedWhyItMatters || post.publishedWhyItMatters || post.aiWhyItMatters,
+          ),
+        );
+
+        return { post, structuredContent, depthText };
+      })
+      .filter((entry) => entry.depthText)
+      .map(({ post, structuredContent, depthText }) =>
+        context.client
+          .from("signal_posts")
+          .update({
+            published_why_it_matters: depthText,
+            published_why_it_matters_payload: structuredContent,
+            editorial_status: "published",
+            is_live: true,
+            published_at: now,
+            updated_at: now,
+          })
+          .eq("id", post.id),
+      ),
+  );
+
+  if (updateResults.some((result) => result.error) || depthUpdateResults.some((result) => result.error)) {
     return {
       ok: false,
       code: "storage_error",
-      message: "The Top 5 list could not be published completely.",
+      message: "The signal set could not be published completely.",
     };
   }
 

--- a/supabase/migrations/20260426120000_signal_posts_public_depth_pool.sql
+++ b/supabase/migrations/20260426120000_signal_posts_public_depth_pool.sql
@@ -1,0 +1,11 @@
+alter table public.signal_posts
+  drop constraint if exists signal_posts_rank_check;
+
+alter table public.signal_posts
+  add constraint signal_posts_rank_check check (rank between 1 and 20);
+
+drop index if exists signal_posts_live_rank_key;
+
+create unique index if not exists signal_posts_live_top_rank_key
+on public.signal_posts (rank)
+where is_live and rank between 1 and 5;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -127,7 +127,7 @@ create table if not exists public.briefing_items (
 create table if not exists public.signal_posts (
   id uuid primary key default gen_random_uuid(),
   briefing_date date not null default current_date,
-  rank integer not null check (rank between 1 and 5),
+  rank integer not null check (rank between 1 and 20),
   title text not null,
   source_name text not null default '',
   source_url text not null default '',
@@ -150,6 +150,10 @@ create table if not exists public.signal_posts (
   updated_at timestamptz not null default now(),
   unique (briefing_date, rank)
 );
+
+create unique index if not exists signal_posts_live_top_rank_key
+on public.signal_posts (rank)
+where is_live and rank between 1 and 5;
 
 create table if not exists public.pipeline_article_candidates (
   id uuid primary key default gen_random_uuid(),


### PR DESCRIPTION
## Summary
- Fixes homepage under-rendering where the published editorial Top 5 could collapse to 3 visible Top Event cards.
- Keeps generic editorial labels like Tech, Finance, Politics, context, and Watch out of semantic identity matching so distinct published signals are not suppressed.
- Restores category tab content from the real editorial Top 5 when no broader read-only ranked depth pool exists, while keeping Developing Now and By Category honest instead of duplicating Top Events as fresh depth.

## Root cause
`/signals` loaded and displayed all 5 published `signal_posts`, but `/` mapped the same rows into the homepage model and applied semantic duplicate suppression. Generic category/status tags were treated as story identity, causing distinct same-category published signals to be suppressed. The read-only homepage SSR path also made `publicRankedItems` equal the same five published posts, so category tabs excluded all already-surfaced Top Events and had no separate depth pool.

## Validation
- `npm install`
- `npm run test -- src/lib/homepage-model.test.ts`
- `npm run test -- src/lib/homepage-model.test.ts src/lib/source-catalog.test.ts src/lib/source-defaults.test.ts src/lib/source-manifest.test.ts src/lib/pipeline/ingestion/index.test.ts src/lib/pipeline/ingestion/tldr.integration.test.ts src/lib/tldr.test.ts src/lib/rss.test.ts src/lib/signals-editorial.test.ts src/components/home/home-category-components.test.tsx src/components/home/CategoryPreviewGrid.test.tsx`
- `npm run lint`
- `npm run test`
- `npm run build`
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name bugfix/homepage-tabs-signal-regression --pr-title "bugfix: restore homepage tabs and published signal count"`
- Dev Server Rule: checked port 3000 / Next dev processes, then started `npm run dev`
- Local URL: `http://localhost:3000`
- Route probes: `HEAD /`, `HEAD /signals`, and `HEAD /dashboard/signals/editorial-review` returned `200`
- Local browser check: 5 homepage top cards and no console errors in local fallback mode
- `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=chromium`
- `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=webkit`

## Notes
- No canonical PRD was created; this is a bug-fix regression repair.
- No database migration is required.
- No politics or TLDR ingestion activation/removal was performed.
- Preview validation is still required for deployed signed-in/signed-out behavior and SSR/cookie-sensitive routes.