### PR TITLE
[codex] Enforce why-it-matters pre-publish quality gate

### DIFF
--- a/docs/engineering/change-records/2026-04-27-signal-posts-schema-preflight-remediation.md
+++ b/docs/engineering/change-records/2026-04-27-signal-posts-schema-preflight-remediation.md
@@ -1,0 +1,34 @@
+# signal_posts Schema Preflight Remediation
+
+Date: 2026-04-27
+Change type: Remediation
+Source of truth: PR #115 why-it-matters quality gate remediation, `docs/engineering/SIGNAL_POSTS_OPERATIONAL_CONTRACT.md`
+
+## Summary
+
+PR #115 added validation columns to `public.signal_posts`. The branch code correctly referenced those columns, but a missed production migration can cause Supabase reads and writes to fail before any rows are returned. Without a preflight, those failures can look like legitimate empty editorial/homepage states.
+
+This remediation adds a cached server-side `signal_posts` schema preflight before the existing editorial/public read and write paths use the table.
+
+## Behavior
+
+- Checks the expected `signal_posts` Surface Placement/Card-copy read-model columns once per server module lifecycle.
+- Logs a clear server error with missing column names when the preflight fails.
+- Returns visible editorial storage warnings instead of silently returning an empty editorial queue.
+- Blocks `signal_posts` insertion with a clear message when the schema is missing required columns.
+- Surfaces homepage schema failures through the existing freshness/empty-state notice path instead of showing a generic prepared state.
+
+## Scope Boundaries
+
+- Does not modify quality gate validation rules.
+- Does not modify ranking, generation, clustering, or template generation logic.
+- Does not change the `signal_posts` schema.
+- Does not treat `signal_posts` as canonical Signal identity.
+- Does not reactivate `PersonalizedDashboard`, `ManualRefreshTrigger`, or any legacy dashboard path.
+- Does not create a new canonical PRD.
+
+## Validation
+
+- `npm run lint`
+- `npm run test`
+- `npm run build`

--- a/docs/engineering/change-records/2026-04-27-why-it-matters-pre-publish-quality-gate-remediation.md
+++ b/docs/engineering/change-records/2026-04-27-why-it-matters-pre-publish-quality-gate-remediation.md
@@ -1,0 +1,46 @@
+# Why-It-Matters Pre-Publish Quality Gate Remediation
+
+Date: 2026-04-27
+Change type: Remediation / alignment
+Source of truth: Product Position, PRD-35, PRD-53, prior why-it-matters quality-gate remediation
+
+## Summary
+
+The existing deterministic why-it-matters validator already flags broken template output when daily signal-post candidates are inserted into `public.signal_posts`. This remediation extends enforcement to the editorial state transition: human-edited card copy must pass the same deterministic quality gate before it can be approved or published.
+
+No new canonical PRD is required. This work aligns the existing PRD-35 quality floor and PRD-53 editorial approval flow.
+
+## Behavior
+
+- Draft persistence records the latest validation result for edited why-it-matters copy.
+- Approval revalidates the human-edited copy and keeps failed rows in `needs_review` with explicit failure details.
+- Top 5 publishing revalidates the exact text that would become `published_why_it_matters` before deactivating the old live set.
+- Individual publishing revalidates the exact approved text before writing public copy.
+- Public readers ignore rows explicitly marked `requires_human_rewrite`.
+- Editorial UI blocks publish affordances when a row requires human rewrite and shows the stored validation details.
+
+## Scope Boundaries
+
+- Does not modify homepage ranking or Action 1 scoring behavior.
+- Does not introduce LLM or external API calls.
+- Does not modify template generation, clustering, or ranking pipelines.
+- Does not treat `signal_posts` as canonical Signal identity; it remains a Surface Placement/Card-copy read model.
+- Does not create a new canonical PRD.
+
+## Production Schema Verification
+
+Verified against the linked production Supabase project on 2026-04-27:
+
+- `why_it_matters_validation_status`: `text`, `not null`, default `'passed'::text`
+- `why_it_matters_validation_failures`: `text[]`, `not null`, default `'{}'::text[]`
+- `why_it_matters_validation_details`: `text[]`, `not null`, default `'{}'::text[]`
+- `why_it_matters_validated_at`: `timestamptz`, nullable
+- Check constraint: `signal_posts_why_it_matters_validation_status_check`
+
+Existing production rows currently all store `why_it_matters_validation_status = 'passed'`.
+
+## Existing Bad Published Data
+
+This remediation does not rewrite already-published historical rows. A production inspection found published April 26 rows whose stored `published_why_it_matters` copy fails the current deterministic validator while still being marked `passed` from migration defaults.
+
+Launch follow-up: run a one-time editorial cleanup, rewrite, and republish affected April 26 rows, or regenerate the affected signal rows through the corrected editorial pipeline.

--- a/src/app/dashboard/signals/editorial-review/StructuredEditorialFields.tsx
+++ b/src/app/dashboard/signals/editorial-review/StructuredEditorialFields.tsx
@@ -57,8 +57,8 @@ export function SignalPostEditor({ post, storageReady }: SignalPostEditorProps) 
     post.persisted &&
     ["draft", "needs_review"].includes(post.editorialStatus) &&
     post.whyItMattersValidationStatus !== "requires_human_rewrite";
-  const canPublishPost = post.editorialStatus === "approved";
   const requiresHumanRewrite = post.whyItMattersValidationStatus === "requires_human_rewrite";
+  const canPublishPost = post.editorialStatus === "approved" && !requiresHumanRewrite;
   const toggleLabel = isExpanded ? "Collapse" : "Expand";
   const panelId = `editorial-panel-${post.id}`;
 
@@ -420,6 +420,10 @@ function FieldBlock({
 }
 
 function getPostStateHint(post: EditorialSignalPost) {
+  if (post.whyItMattersValidationStatus === "requires_human_rewrite") {
+    return "Rewrite the Why it matters copy and approve again before this card can publish.";
+  }
+
   if (post.editorialStatus === "approved") {
     return "Approved and waiting to publish. Publish this card or use Publish Top 5 Signals when the full Top 5 is ready.";
   }

--- a/src/app/dashboard/signals/editorial-review/page.tsx
+++ b/src/app/dashboard/signals/editorial-review/page.tsx
@@ -559,6 +559,14 @@ function getPublishBlockedReason(
     return "This Top 5 list is already published. Save and approve an edit to publish a new version.";
   }
 
+  const rewriteRequiredCount = posts.filter(
+    (post) => post.whyItMattersValidationStatus === "requires_human_rewrite",
+  ).length;
+
+  if (rewriteRequiredCount > 0) {
+    return `${rewriteRequiredCount} signal posts require a human rewrite before publishing.`;
+  }
+
   const blockedCount = posts.filter(
     (post) => !["approved", "published"].includes(post.editorialStatus),
   ).length;

--- a/src/lib/data.test.ts
+++ b/src/lib/data.test.ts
@@ -277,6 +277,30 @@ describe("homepage read model", () => {
     expect(viewModel.debug.categoryCounts).toEqual({ tech: 0, finance: 0, politics: 0 });
     expect(serializedOutput).not.toMatch(/placeholder|stored public signal snapshot|rail readable|sample slot/i);
   });
+
+  it("surfaces signal_posts schema preflight failures instead of a generic empty state", async () => {
+    getHomepageSignalSnapshot.mockResolvedValue({
+      source: "none",
+      briefingDate: null,
+      posts: [],
+      depthPosts: [],
+      errorMessage:
+        "signal_posts schema preflight failed. Missing expected columns: why_it_matters_validation_status.",
+    });
+
+    const { getHomepagePageState } = await loadDataModule();
+    const state = await getHomepagePageState("/");
+
+    expect(state.data.briefing.items).toEqual([]);
+    expect(state.data.briefing.intro).toBe(
+      "signal_posts schema preflight failed. Missing expected columns: why_it_matters_validation_status.",
+    );
+    expect(state.data.homepageFreshnessNotice).toEqual({
+      kind: "empty",
+      text: "signal_posts schema preflight failed. Missing expected columns: why_it_matters_validation_status.",
+      briefingDate: null,
+    });
+  });
 });
 
 describe("account page read model", () => {

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -477,7 +477,7 @@ function formatHomepageFreshnessDate(dateKey: string) {
   }).format(date);
 }
 
-function buildEmptyPublicHomepageData(): DashboardData {
+function buildEmptyPublicHomepageData(message = "Today's briefing is being prepared."): DashboardData {
   const sources = getSourcesForPublicSurface("public.home");
   const briefingDate = normalizeCalendarSafeBriefingDate(getBriefingDateKey(formatISO(new Date())));
 
@@ -487,7 +487,7 @@ function buildEmptyPublicHomepageData(): DashboardData {
       id: `empty-homepage-${getBriefingDateKey(briefingDate)}`,
       briefingDate,
       title: "Daily Executive Briefing",
-      intro: "Today's briefing is being prepared.",
+      intro: message,
       readingWindow: "0 minutes",
       items: [],
     },
@@ -496,7 +496,7 @@ function buildEmptyPublicHomepageData(): DashboardData {
     publicRankedItems: [],
     homepageFreshnessNotice: {
       kind: "empty",
-      text: "Today's briefing is being prepared.",
+      text: message,
       briefingDate: null,
     },
     homepageDiagnostics: buildReadOnlyHomepageDiagnostics(sources, 0),
@@ -508,7 +508,7 @@ async function buildPublicHomepageData(): Promise<DashboardData> {
   const sources = getSourcesForPublicSurface("public.home");
 
   if (homepageSignalSnapshot.posts.length === 0) {
-    return buildEmptyPublicHomepageData();
+    return buildEmptyPublicHomepageData(homepageSignalSnapshot.errorMessage);
   }
 
   const firstBriefingDate = homepageSignalSnapshot.briefingDate ?? homepageSignalSnapshot.posts[0]?.briefingDate;

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -109,7 +109,12 @@ function createBriefingItem(rank: number) {
   };
 }
 
-function createSupabaseMock(rows: SignalPostRow[]) {
+function createSupabaseMock(
+  rows: SignalPostRow[],
+  options: { missingColumns?: string[] } = {},
+) {
+  const missingColumns = new Set(options.missingColumns ?? []);
+
   return {
     rows,
     from(tableName: string) {
@@ -117,6 +122,7 @@ function createSupabaseMock(rows: SignalPostRow[]) {
 
       let operation: "select" | "update" | null = null;
       let updateValues: Partial<SignalPostRow> = {};
+      let selectError: { message: string } | null = null;
       const filters: Array<{ column: keyof SignalPostRow; value: unknown }> = [];
       const inclusionFilters: Array<{ column: keyof SignalPostRow; values: unknown[] }> = [];
       const lessThanFilters: Array<{ column: keyof SignalPostRow; value: unknown }> = [];
@@ -137,6 +143,14 @@ function createSupabaseMock(rows: SignalPostRow[]) {
       }
 
       function selectResult(limit?: number) {
+        if (selectError) {
+          return Promise.resolve({
+            data: null,
+            error: selectError,
+            count: 0,
+          });
+        }
+
         let data = applyFilters();
 
         if (orderRules.length > 0) {
@@ -170,8 +184,20 @@ function createSupabaseMock(rows: SignalPostRow[]) {
       }
 
       const builder = {
-        select() {
+        select(columns?: string) {
           operation = "select";
+          const selectedColumns = String(columns ?? "")
+            .split(",")
+            .map((column) => column.trim().split(/\s+/)[0])
+            .filter(Boolean);
+          const missingSelectedColumns = selectedColumns.filter((column) => missingColumns.has(column));
+
+          if (missingSelectedColumns.length > 0) {
+            selectError = {
+              message: `column signal_posts.${missingSelectedColumns[0]} does not exist`,
+            };
+          }
+
           return builder;
         },
         order(column: keyof SignalPostRow, options?: { ascending?: boolean }) {
@@ -301,6 +327,30 @@ describe("signals editorial workflow", () => {
         "No stored Top 5 signal snapshot exists yet. This page stays read-only until signal posts have been persisted.",
     });
     expect(generateDailyBriefing).not.toHaveBeenCalled();
+  });
+
+  it("fails editorial review visibly when the signal_posts schema preflight is missing columns", async () => {
+    createSupabaseServiceRoleClient.mockReturnValue(
+      createSupabaseMock([], {
+        missingColumns: ["why_it_matters_validation_status"],
+      }),
+    );
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { getEditorialReviewState } = await loadEditorialModule();
+    const state = await getEditorialReviewState();
+
+    expect(state.kind).toBe("authorized");
+    if (state.kind !== "authorized") return;
+    expect(state.posts).toEqual([]);
+    expect(state.storageReady).toBe(false);
+    expect(state.warning).toBe(
+      "signal_posts schema preflight failed. Missing expected columns: why_it_matters_validation_status.",
+    );
   });
 
   it("loads editorial history in stable reverse briefing-date order", async () => {
@@ -1037,5 +1087,47 @@ describe("signals editorial workflow", () => {
     expect(rejected?.whyItMattersValidationDetails).toContain(
       "missing specific noun: no named entity, number, country, organization, or person found",
     );
+  });
+
+  it("blocks signal_posts insertion visibly when the schema preflight is missing columns", async () => {
+    createSupabaseServiceRoleClient.mockReturnValue(
+      createSupabaseMock([], {
+        missingColumns: ["why_it_matters_validation_details"],
+      }),
+    );
+
+    const { persistSignalPostsForBriefing } = await loadEditorialModule();
+    const result = await persistSignalPostsForBriefing({
+      briefingDate: "2026-04-25",
+      items: [1, 2, 3, 4, 5].map(createBriefingItem),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      briefingDate: "2026-04-25",
+      insertedCount: 0,
+      message: "signal_posts schema preflight failed. Missing expected columns: why_it_matters_validation_details.",
+    });
+  });
+
+  it("returns a homepage snapshot schema error instead of silently emptying public results", async () => {
+    createSupabaseServiceRoleClient.mockReturnValue(
+      createSupabaseMock([], {
+        missingColumns: ["why_it_matters_validation_failures"],
+      }),
+    );
+
+    const { getHomepageSignalSnapshot } = await loadEditorialModule();
+    const snapshot = await getHomepageSignalSnapshot({
+      today: new Date("2026-04-26T12:00:00.000Z"),
+    });
+
+    expect(snapshot).toEqual({
+      source: "none",
+      posts: [],
+      depthPosts: [],
+      briefingDate: null,
+      errorMessage: "signal_posts schema preflight failed. Missing expected columns: why_it_matters_validation_failures.",
+    });
   });
 });

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -51,6 +51,10 @@ vi.mock("@/lib/observability/rss", () => ({
   captureRssFailure,
 }));
 
+function createValidWhyItMatters(label = "Anthropic") {
+  return `${label}'s growth is now structurally tied to Google and Amazon's infrastructure, not independent of it. At scale, that's a dependency, not just a partnership.`;
+}
+
 function createRow(overrides: Partial<SignalPostRow> = {}): SignalPostRow {
   return {
     id: overrides.id ?? `signal-${overrides.rank ?? 1}`,
@@ -433,11 +437,11 @@ describe("signals editorial workflow", () => {
     const { saveSignalDraft } = await loadEditorialModule();
     const result = await saveSignalDraft({
       postId: "signal-1",
-      editedWhyItMatters: " Human edited draft ",
+      editedWhyItMatters: ` ${createValidWhyItMatters()} `,
     });
 
     expect(result.ok).toBe(true);
-    expect(rows[0].edited_why_it_matters).toBe("Human edited draft");
+    expect(rows[0].edited_why_it_matters).toBe(createValidWhyItMatters());
     expect(rows[0].editorial_status).toBe("draft");
     expect(rows[0].edited_by).toBe("admin@example.com");
   });
@@ -484,12 +488,12 @@ describe("signals editorial workflow", () => {
     const { saveSignalDraft } = await loadEditorialModule();
     const result = await saveSignalDraft({
       postId: "signal-1",
-      editedWhyItMatters: "Updated historical editorial text.",
+      editedWhyItMatters: createValidWhyItMatters("Google"),
     });
 
     expect(result.ok).toBe(true);
     expect(result.message).toBe("Editorial changes saved.");
-    expect(rows[0].edited_why_it_matters).toBe("Updated historical editorial text.");
+    expect(rows[0].edited_why_it_matters).toBe(createValidWhyItMatters("Google"));
     expect(rows[0].editorial_status).toBe("approved");
   });
 
@@ -505,12 +509,12 @@ describe("signals editorial workflow", () => {
     const { saveSignalDraft } = await loadEditorialModule();
     const result = await saveSignalDraft({
       postId: "signal-1",
-      editedWhyItMatters: "Updated published editorial text.",
+      editedWhyItMatters: createValidWhyItMatters("Google"),
     });
 
     expect(result.ok).toBe(true);
-    expect(rows[0].edited_why_it_matters).toBe("Updated published editorial text.");
-    expect(rows[0].published_why_it_matters).toBe("Updated published editorial text.");
+    expect(rows[0].edited_why_it_matters).toBe(createValidWhyItMatters("Google"));
+    expect(rows[0].published_why_it_matters).toBe(createValidWhyItMatters("Google"));
     expect(rows[0].editorial_status).toBe("published");
   });
 
@@ -526,13 +530,72 @@ describe("signals editorial workflow", () => {
     const { approveSignalPost } = await loadEditorialModule();
     const result = await approveSignalPost({
       postId: "signal-1",
-      editedWhyItMatters: "Human approved why it matters.",
+      editedWhyItMatters: createValidWhyItMatters(),
     });
 
     expect(result.ok).toBe(true);
-    expect(rows[0].edited_why_it_matters).toBe("Human approved why it matters.");
+    expect(rows[0].edited_why_it_matters).toBe(createValidWhyItMatters());
     expect(rows[0].editorial_status).toBe("approved");
     expect(rows[0].approved_by).toBe("admin@example.com");
+  });
+
+  it("blocks approval when the human rewrite still fails validation", async () => {
+    const rows = [
+      createRow({
+        id: "signal-1",
+        why_it_matters_validation_status: "requires_human_rewrite",
+        why_it_matters_validation_failures: ["minimum_specificity"],
+        why_it_matters_validation_details: ["missing specificity"],
+      }),
+    ];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { approveSignalPost } = await loadEditorialModule();
+    const result = await approveSignalPost({
+      postId: "signal-1",
+      editedWhyItMatters: "This changes capital availability, competitive positioning, or market structure.",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("publish_blocked");
+    expect(rows[0].editorial_status).toBe("needs_review");
+    expect(rows[0].why_it_matters_validation_status).toBe("requires_human_rewrite");
+    expect(rows[0].why_it_matters_validation_failures).toContain("template_placeholder_language");
+    expect(rows[0].why_it_matters_validation_details.length).toBeGreaterThan(0);
+  });
+
+  it("lets a human-rewritten valid why-it-matters pass after a rejected draft", async () => {
+    const rows = [
+      createRow({
+        id: "signal-1",
+        why_it_matters_validation_status: "requires_human_rewrite",
+        why_it_matters_validation_failures: ["minimum_specificity"],
+        why_it_matters_validation_details: ["missing specificity"],
+      }),
+    ];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { approveSignalPost } = await loadEditorialModule();
+    const result = await approveSignalPost({
+      postId: "signal-1",
+      editedWhyItMatters: createValidWhyItMatters(),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(rows[0].editorial_status).toBe("approved");
+    expect(rows[0].why_it_matters_validation_status).toBe("passed");
+    expect(rows[0].why_it_matters_validation_failures).toEqual([]);
+    expect(rows[0].why_it_matters_validation_details).toEqual([]);
   });
 
   it("lets an admin approve multiple loaded signal posts", async () => {
@@ -553,7 +616,7 @@ describe("signals editorial workflow", () => {
     const result = await approveSignalPosts({
       posts: rows.map((row) => ({
         postId: row.id,
-        editedWhyItMatters: `Bulk approved ${row.rank}`,
+        editedWhyItMatters: createValidWhyItMatters(`Anthropic ${row.rank}`),
       })),
     });
 
@@ -578,7 +641,7 @@ describe("signals editorial workflow", () => {
     const { approveSignalPosts } = await loadEditorialModule();
     const result = await approveSignalPosts({
       posts: [
-        { postId: "signal-1", editedWhyItMatters: "Ready for approval." },
+        { postId: "signal-1", editedWhyItMatters: createValidWhyItMatters() },
         { postId: "signal-2", editedWhyItMatters: " " },
       ],
     });
@@ -620,7 +683,7 @@ describe("signals editorial workflow", () => {
       createRow({
         id: `signal-${index + 1}`,
         rank: index + 1,
-        edited_why_it_matters: `Human final ${index + 1}`,
+        edited_why_it_matters: createValidWhyItMatters(`Anthropic ${index + 1}`),
         editorial_status: index === 4 ? "draft" : "approved",
       }),
     );
@@ -639,20 +702,51 @@ describe("signals editorial workflow", () => {
     expect(rows.some((row) => row.editorial_status === "published")).toBe(false);
   });
 
+  it("blocks publishing when approved why-it-matters copy fails the pre-publish gate", async () => {
+    const rows = Array.from({ length: 5 }, (_, index) =>
+      createRow({
+        id: `signal-${index + 1}`,
+        rank: index + 1,
+        edited_why_it_matters:
+          index === 0
+            ? "This changes how investors price rates, demand, or risk in rates and equities over."
+            : createValidWhyItMatters(`Anthropic ${index + 1}`),
+        editorial_status: "approved",
+      }),
+    );
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { publishApprovedSignals } = await loadEditorialModule();
+    const result = await publishApprovedSignals();
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("publish_blocked");
+    expect(rows[0].editorial_status).toBe("needs_review");
+    expect(rows[0].why_it_matters_validation_status).toBe("requires_human_rewrite");
+    expect(rows[0].published_why_it_matters).toBeNull();
+    expect(rows.slice(1).every((row) => row.editorial_status === "approved")).toBe(true);
+    expect(rows.every((row) => row.is_live === false)).toBe(true);
+  });
+
   it("publishes approved edits without promoting unapproved depth fallback text", async () => {
     const rows = [
       createRow({
         id: "signal-1",
         rank: 1,
-        edited_why_it_matters: "Newly approved editorial update.",
+        edited_why_it_matters: createValidWhyItMatters("Google"),
         editorial_status: "approved",
       }),
       ...Array.from({ length: 4 }, (_, index) =>
         createRow({
           id: `signal-${index + 2}`,
           rank: index + 2,
-          edited_why_it_matters: `Existing edited ${index + 2}`,
-          published_why_it_matters: `Existing published ${index + 2}`,
+          edited_why_it_matters: createValidWhyItMatters(`Amazon ${index + 2}`),
+          published_why_it_matters: createValidWhyItMatters(`Google ${index + 2}`),
           editorial_status: "published",
         }),
       ),
@@ -681,8 +775,8 @@ describe("signals editorial workflow", () => {
 
     expect(result.ok).toBe(true);
     expect(rows.slice(0, 5).every((row) => row.editorial_status === "published")).toBe(true);
-    expect(rows[0].published_why_it_matters).toBe("Newly approved editorial update.");
-    expect(rows[1].published_why_it_matters).toBe("Existing edited 2");
+    expect(rows[0].published_why_it_matters).toBe(createValidWhyItMatters("Google"));
+    expect(rows[1].published_why_it_matters).toBe(createValidWhyItMatters("Amazon 2"));
     expect(rows[5].editorial_status).toBe("needs_review");
     expect(rows[5].published_why_it_matters).toBeNull();
     expect(rows[5].is_live).toBe(false);
@@ -787,7 +881,7 @@ describe("signals editorial workflow", () => {
         id: "signal-1",
         rank: 1,
         briefing_date: "2026-04-20",
-        edited_why_it_matters: "Approved historical editorial update.",
+        edited_why_it_matters: createValidWhyItMatters("Google"),
         editorial_status: "approved",
       }),
     ];
@@ -804,7 +898,7 @@ describe("signals editorial workflow", () => {
     expect(result.ok).toBe(true);
     expect(result.message).toBe("Signal post published.");
     expect(rows[0].editorial_status).toBe("published");
-    expect(rows[0].published_why_it_matters).toBe("Approved historical editorial update.");
+    expect(rows[0].published_why_it_matters).toBe(createValidWhyItMatters("Google"));
   });
 
   it("captures individual publish storage failures as RSS publish failures", async () => {
@@ -812,7 +906,7 @@ describe("signals editorial workflow", () => {
       id: "signal-1",
       rank: 1,
       briefing_date: "2026-04-20",
-      edited_why_it_matters: "Approved historical editorial update.",
+      edited_why_it_matters: createValidWhyItMatters("Google"),
       editorial_status: "approved",
     });
     createSupabaseServiceRoleClient.mockReturnValue({
@@ -869,15 +963,16 @@ describe("signals editorial workflow", () => {
   it("publishes structured approved signal post payloads for homepage rendering", async () => {
     const structured = {
       preview: "Structured teaser.",
-      thesis: "Structured thesis.",
-      sections: [{ title: "Why now", body: "The signal changes near-term planning." }],
+      thesis: "Google's cloud strategy is now structurally tied to Amazon and Anthropic's infrastructure choices.",
+      sections: [{ title: "Why now", body: "That makes the dependency visible to customers deciding where durable AI workloads should run." }],
     };
     const rows = [
       createRow({
         id: "signal-1",
         rank: 1,
         briefing_date: "2026-04-20",
-        edited_why_it_matters: "Structured thesis.\n\nWhy now: The signal changes near-term planning.",
+        edited_why_it_matters:
+          "Google's cloud strategy is now structurally tied to Amazon and Anthropic's infrastructure choices.\n\nWhy now: That makes the dependency visible to customers deciding where durable AI workloads should run.",
         edited_why_it_matters_payload: structured,
         editorial_status: "approved",
       }),
@@ -914,6 +1009,32 @@ describe("signals editorial workflow", () => {
     expect(rows[0].published_why_it_matters).toBeNull();
   });
 
+  it("blocks individual publishing when approved copy fails validation", async () => {
+    const rows = [
+      createRow({
+        id: "signal-1",
+        editorial_status: "approved",
+        edited_why_it_matters:
+          "This changes assumptions about defense posture, state capacity, or international alignment.",
+      }),
+    ];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { publishSignalPost } = await loadEditorialModule();
+    const result = await publishSignalPost({ postId: "signal-1" });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("publish_blocked");
+    expect(rows[0].editorial_status).toBe("needs_review");
+    expect(rows[0].why_it_matters_validation_status).toBe("requires_human_rewrite");
+    expect(rows[0].published_why_it_matters).toBeNull();
+  });
+
   it("loads only the live published Top 5 for the public signals surface", async () => {
     const rows = [
       ...Array.from({ length: 7 }, (_, index) =>
@@ -922,7 +1043,10 @@ describe("signals editorial workflow", () => {
           rank: index + 1,
           briefing_date: "2026-04-24",
           editorial_status: "published",
-          published_why_it_matters: `Live published ${index + 1}`,
+          published_why_it_matters: createValidWhyItMatters(`Google ${index + 1}`),
+          why_it_matters_validation_status: index === 2 ? "requires_human_rewrite" : "passed",
+          why_it_matters_validation_failures: index === 2 ? ["template_placeholder_language"] : [],
+          why_it_matters_validation_details: index === 2 ? ["placeholder copy"] : [],
           is_live: true,
         }),
       ),
@@ -940,20 +1064,20 @@ describe("signals editorial workflow", () => {
     const { getPublishedSignalPosts } = await loadEditorialModule();
     const posts = await getPublishedSignalPosts();
 
-    expect(posts).toHaveLength(5);
-    expect(posts.map((post) => post.id)).toEqual(["live-1", "live-2", "live-3", "live-4", "live-5"]);
+    expect(posts).toHaveLength(4);
+    expect(posts.map((post) => post.id)).toEqual(["live-1", "live-2", "live-4", "live-5"]);
   });
 
   it("uses today's published rows as the homepage Tier 1 signal set", async () => {
     const rows = Array.from({ length: 7 }, (_, index) =>
-      createRow({
-        id: `live-${index + 1}`,
-        rank: index + 1,
-        briefing_date: "2026-04-26",
-        editorial_status: "published",
-        published_why_it_matters: `Live published ${index + 1}`,
-        is_live: true,
-      }),
+        createRow({
+          id: `live-${index + 1}`,
+          rank: index + 1,
+          briefing_date: "2026-04-26",
+          editorial_status: "published",
+          published_why_it_matters: createValidWhyItMatters(`Google ${index + 1}`),
+          is_live: true,
+        }),
     );
     createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
 
@@ -992,7 +1116,7 @@ describe("signals editorial workflow", () => {
         briefing_date: "2026-04-25",
         rank: 1,
         editorial_status: "published",
-        published_why_it_matters: "Most recent published editorial text",
+        published_why_it_matters: createValidWhyItMatters("Google"),
         is_live: false,
       }),
       createRow({
@@ -1000,7 +1124,7 @@ describe("signals editorial workflow", () => {
         briefing_date: "2026-04-25",
         rank: 2,
         editorial_status: "published",
-        published_why_it_matters: "Second recent published editorial text",
+        published_why_it_matters: createValidWhyItMatters("Amazon"),
         is_live: false,
       }),
       createRow({
@@ -1016,7 +1140,7 @@ describe("signals editorial workflow", () => {
         briefing_date: "2026-04-24",
         rank: 1,
         editorial_status: "published",
-        published_why_it_matters: "Older published copy",
+        published_why_it_matters: createValidWhyItMatters("Microsoft"),
         is_live: false,
       }),
     ];
@@ -1095,7 +1219,7 @@ describe("signals editorial workflow", () => {
         briefing_date: "2026-04-25",
         rank: 2,
         editorial_status: "approved",
-        edited_why_it_matters: "Human editor rewrote the card with Google-specific infrastructure context.",
+        edited_why_it_matters: createValidWhyItMatters("Google"),
       }),
     ];
     createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -111,9 +111,10 @@ function createBriefingItem(rank: number) {
 
 function createSupabaseMock(
   rows: SignalPostRow[],
-  options: { missingColumns?: string[] } = {},
+  options: { missingColumns?: string[]; preflightTransportErrorColumns?: string[] } = {},
 ) {
   const missingColumns = new Set(options.missingColumns ?? []);
+  const preflightTransportErrorColumns = new Set(options.preflightTransportErrorColumns ?? []);
 
   return {
     rows,
@@ -123,6 +124,7 @@ function createSupabaseMock(
       let operation: "select" | "update" | null = null;
       let updateValues: Partial<SignalPostRow> = {};
       let selectError: { message: string } | null = null;
+      let selectedColumns: string[] = [];
       const filters: Array<{ column: keyof SignalPostRow; value: unknown }> = [];
       const inclusionFilters: Array<{ column: keyof SignalPostRow; values: unknown[] }> = [];
       const lessThanFilters: Array<{ column: keyof SignalPostRow; value: unknown }> = [];
@@ -186,7 +188,7 @@ function createSupabaseMock(
       const builder = {
         select(columns?: string) {
           operation = "select";
-          const selectedColumns = String(columns ?? "")
+          selectedColumns = String(columns ?? "")
             .split(",")
             .map((column) => column.trim().split(/\s+/)[0])
             .filter(Boolean);
@@ -205,6 +207,17 @@ function createSupabaseMock(
           return builder;
         },
         limit(count: number) {
+          const shouldReturnPreflightTransportError =
+            count === 0 && selectedColumns.some((column) => preflightTransportErrorColumns.has(column));
+
+          if (shouldReturnPreflightTransportError) {
+            return Promise.resolve({
+              data: null,
+              error: { message: "TypeError: fetch failed" },
+              count: 0,
+            });
+          }
+
           return selectResult(count);
         },
         range(from: number, to: number) {
@@ -1036,6 +1049,26 @@ describe("signals editorial workflow", () => {
 
     const { getHomepageSignalSnapshot } = await loadEditorialModule();
     const snapshot = await getHomepageSignalSnapshot({ today: new Date("2026-04-26T12:00:00.000Z") });
+
+    expect(snapshot).toEqual({
+      source: "none",
+      posts: [],
+      depthPosts: [],
+      briefingDate: null,
+    });
+  });
+
+  it("does not convert non-schema preflight transport errors into a homepage schema failure", async () => {
+    createSupabaseServiceRoleClient.mockReturnValue(
+      createSupabaseMock([], {
+        preflightTransportErrorColumns: ["id"],
+      }),
+    );
+
+    const { getHomepageSignalSnapshot } = await loadEditorialModule();
+    const snapshot = await getHomepageSignalSnapshot({
+      today: new Date("2026-04-26T12:00:00.000Z"),
+    });
 
     expect(snapshot).toEqual({
       source: "none",

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -220,19 +220,51 @@ function buildSignalPostsSchemaPreflightFailure(missingColumns: string[]): Signa
   };
 }
 
+function isMissingColumnError(error: unknown, column: string) {
+  const maybeError = error as { code?: unknown; message?: unknown; details?: unknown; hint?: unknown };
+  const normalizedColumn = column.toLowerCase();
+  const haystack = [
+    maybeError.code,
+    maybeError.message,
+    maybeError.details,
+    maybeError.hint,
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ")
+    .toLowerCase();
+
+  return (
+    haystack.includes("42703") ||
+    (haystack.includes("does not exist") &&
+      (haystack.includes(normalizedColumn) || haystack.includes(`signal_posts.${normalizedColumn}`))) ||
+    (haystack.includes("could not find") &&
+      haystack.includes(normalizedColumn) &&
+      haystack.includes("column"))
+  );
+}
+
 async function runSignalPostsSchemaPreflight(
   client: EditorialClient,
 ): Promise<SignalPostsSchemaPreflightResult> {
   const missingColumns: string[] = [];
   const errorMessages: string[] = [];
+  const nonSchemaErrorMessages: string[] = [];
 
   for (const column of SIGNAL_POST_REQUIRED_COLUMNS) {
     const result = await client.from("signal_posts").select(column).limit(0);
 
-    if (result.error) {
+    if (result.error && isMissingColumnError(result.error, column)) {
       missingColumns.push(column);
       errorMessages.push(`${column}: ${result.error.message}`);
+    } else if (result.error) {
+      nonSchemaErrorMessages.push(`${column}: ${result.error.message}`);
     }
+  }
+
+  if (nonSchemaErrorMessages.length > 0 && missingColumns.length === 0) {
+    logServerEvent("warn", "signal_posts schema preflight could not verify columns", {
+      errorMessages: nonSchemaErrorMessages,
+    });
   }
 
   if (missingColumns.length === 0) {

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -23,7 +23,7 @@ import {
 export const SIGNALS_EDITORIAL_ROUTE = "/dashboard/signals/editorial-review";
 export const PUBLIC_SIGNALS_ROUTE = "/signals";
 
-const SIGNAL_POST_SELECT = [
+const SIGNAL_POST_REQUIRED_COLUMNS = [
   "id",
   "briefing_date",
   "rank",
@@ -52,7 +52,9 @@ const SIGNAL_POST_SELECT = [
   "is_live",
   "created_at",
   "updated_at",
-].join(", ");
+];
+
+const SIGNAL_POST_SELECT = SIGNAL_POST_REQUIRED_COLUMNS.join(", ");
 
 const EDITORIAL_PAGE_SIZE = 20;
 const PUBLIC_SIGNAL_DEPTH_LIMIT = 20;
@@ -193,7 +195,70 @@ export type HomepageSignalSnapshot = {
   posts: EditorialSignalPost[];
   depthPosts: EditorialSignalPost[];
   briefingDate: string | null;
+  errorMessage?: string;
 };
+
+type SignalPostsSchemaPreflightResult =
+  | {
+      ok: true;
+      missingColumns: [];
+      message: null;
+    }
+  | {
+      ok: false;
+      missingColumns: string[];
+      message: string;
+    };
+
+let signalPostsSchemaPreflightPromise: Promise<SignalPostsSchemaPreflightResult> | null = null;
+
+function buildSignalPostsSchemaPreflightFailure(missingColumns: string[]): SignalPostsSchemaPreflightResult {
+  return {
+    ok: false,
+    missingColumns,
+    message: `signal_posts schema preflight failed. Missing expected columns: ${missingColumns.join(", ")}.`,
+  };
+}
+
+async function runSignalPostsSchemaPreflight(
+  client: EditorialClient,
+): Promise<SignalPostsSchemaPreflightResult> {
+  const missingColumns: string[] = [];
+  const errorMessages: string[] = [];
+
+  for (const column of SIGNAL_POST_REQUIRED_COLUMNS) {
+    const result = await client.from("signal_posts").select(column).limit(0);
+
+    if (result.error) {
+      missingColumns.push(column);
+      errorMessages.push(`${column}: ${result.error.message}`);
+    }
+  }
+
+  if (missingColumns.length === 0) {
+    return {
+      ok: true,
+      missingColumns: [],
+      message: null,
+    };
+  }
+
+  const failure = buildSignalPostsSchemaPreflightFailure(missingColumns);
+
+  logServerEvent("error", "signal_posts schema preflight failed", {
+    missingColumns,
+    errorMessages,
+  });
+
+  return failure;
+}
+
+function getSignalPostsSchemaPreflight(
+  client: EditorialClient,
+): Promise<SignalPostsSchemaPreflightResult> {
+  signalPostsSchemaPreflightPromise ??= runSignalPostsSchemaPreflight(client);
+  return signalPostsSchemaPreflightPromise;
+}
 
 function normalizeEditorialText(value: string | null | undefined) {
   return value?.trim() ?? "";
@@ -616,13 +681,25 @@ export async function persistSignalPostsForBriefing(input: {
   items: BriefingItem[];
 }): Promise<SignalSnapshotPersistenceResult> {
   const client = createSupabaseServiceRoleClient();
+  const briefingDate = normalizeDateValue(input.briefingDate) ?? new Date().toISOString().slice(0, 10);
 
   if (!client) {
     return {
       ok: false,
-      briefingDate: normalizeDateValue(input.briefingDate) ?? new Date().toISOString().slice(0, 10),
+      briefingDate,
       insertedCount: 0,
       message: "Editorial storage is unavailable. Configure Supabase and SUPABASE_SERVICE_ROLE_KEY.",
+    };
+  }
+
+  const schemaPreflight = await getSignalPostsSchemaPreflight(client);
+
+  if (!schemaPreflight.ok) {
+    return {
+      ok: false,
+      briefingDate,
+      insertedCount: 0,
+      message: schemaPreflight.message,
     };
   }
 
@@ -850,6 +927,27 @@ export async function getEditorialReviewState(
       currentTopFive: [],
       storageReady: false,
       warning: context.message,
+      page: normalizedPage,
+      pageSize: EDITORIAL_PAGE_SIZE,
+      totalMatchingPosts: 0,
+      latestBriefingDate: null,
+      appliedScope: normalizedScope,
+      appliedStatus: normalizedStatus,
+      appliedQuery: normalizedQuery,
+      appliedDate: normalizedDate,
+    };
+  }
+
+  const schemaPreflight = await getSignalPostsSchemaPreflight(context.client);
+
+  if (!schemaPreflight.ok) {
+    return {
+      kind: "authorized",
+      adminEmail: context.user.email ?? "",
+      posts: [],
+      currentTopFive: [],
+      storageReady: false,
+      warning: schemaPreflight.message,
       page: normalizedPage,
       pageSize: EDITORIAL_PAGE_SIZE,
       totalMatchingPosts: 0,
@@ -1530,6 +1628,12 @@ async function loadPublishedSignalPosts(limit: number): Promise<EditorialSignalP
     return [];
   }
 
+  const schemaPreflight = await getSignalPostsSchemaPreflight(supabase);
+
+  if (!schemaPreflight.ok) {
+    return [];
+  }
+
   const result = await supabase
     .from("signal_posts")
     .select(SIGNAL_POST_SELECT)
@@ -1564,6 +1668,18 @@ export async function getHomepageSignalSnapshot(input: { today?: Date } = {}): P
       posts: [],
       depthPosts: [],
       briefingDate: null,
+    };
+  }
+
+  const schemaPreflight = await getSignalPostsSchemaPreflight(supabase);
+
+  if (!schemaPreflight.ok) {
+    return {
+      source: "none",
+      posts: [],
+      depthPosts: [],
+      briefingDate: null,
+      errorMessage: schemaPreflight.message,
     };
   }
 

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -16,6 +16,7 @@ import { captureRssFailure, type RssFailureType, type RssPhase } from "@/lib/obs
 import type { BriefingItem, EditorialStatus } from "@/lib/types";
 import {
   flagCardForRewrite,
+  validateWhyItMatters,
   type WhyItMattersReviewStatus,
   type WhyItMattersValidationResult,
 } from "@/lib/why-it-matters-quality-gate";
@@ -418,6 +419,22 @@ function getValidationStatus(validation: WhyItMattersValidationResult): WhyItMat
   return validation.passed ? "passed" : "requires_human_rewrite";
 }
 
+function buildWhyItMattersValidationFields(validation: WhyItMattersValidationResult, validatedAt: string) {
+  return {
+    why_it_matters_validation_status: getValidationStatus(validation),
+    why_it_matters_validation_failures: validation.failures,
+    why_it_matters_validation_details: validation.failureDetails,
+    why_it_matters_validated_at: validatedAt,
+  };
+}
+
+function getValidationFailureMessage(validation: WhyItMattersValidationResult) {
+  const details = validation.failureDetails.slice(0, 3).join("; ");
+  return details
+    ? `Why it matters requires a human rewrite before publishing: ${details}`
+    : "Why it matters requires a human rewrite before publishing.";
+}
+
 function buildSignalPostCandidates(items: BriefingItem[]) {
   return items.slice(0, PUBLIC_SIGNAL_DEPTH_LIMIT).map(mapBriefingItemToSignalPost);
 }
@@ -805,6 +822,10 @@ function selectPublishedEditorialWhyItMatters(post: EditorialSignalPost) {
     return "";
   }
 
+  if (post.whyItMattersValidationStatus === "requires_human_rewrite") {
+    return "";
+  }
+
   return normalizeEditorialText(post.publishedWhyItMatters);
 }
 
@@ -1112,6 +1133,24 @@ export async function saveSignalDraft(input: {
   const editorialText = normalizeEditorialText(
     buildEditorialWhyItMattersText(structuredContent, input.editedWhyItMatters),
   );
+  const validation = validateWhyItMatters(editorialText);
+
+  if (!validation.passed && currentStatus === "published") {
+    return {
+      ok: false,
+      code: "publish_blocked",
+      message: getValidationFailureMessage(validation),
+    };
+  }
+
+  let nextEditorialStatus: EditorialStatus = "needs_review";
+  let successMessage = "Draft saved. Why it matters requires a human rewrite before approval.";
+
+  if (validation.passed) {
+    nextEditorialStatus = shouldPreserveStatus ? currentStatus : "draft";
+    successMessage = shouldPreserveStatus ? "Editorial changes saved." : "Draft saved.";
+  }
+
   const updateResult = await context.client
     .from("signal_posts")
     .update({
@@ -1123,7 +1162,8 @@ export async function saveSignalDraft(input: {
             published_why_it_matters_payload: structuredContent,
           }
         : {}),
-      editorial_status: shouldPreserveStatus ? currentStatus : "draft",
+      editorial_status: nextEditorialStatus,
+      ...buildWhyItMattersValidationFields(validation, now),
       edited_by: context.user.email ?? null,
       edited_at: now,
       updated_at: now,
@@ -1141,7 +1181,7 @@ export async function saveSignalDraft(input: {
   return {
     ok: true,
     code: "draft_saved",
-    message: shouldPreserveStatus ? "Editorial changes saved." : "Draft saved.",
+    message: successMessage,
   };
 }
 
@@ -1172,12 +1212,44 @@ async function approveSignalPostWithContext(
   }
 
   const now = new Date().toISOString();
+  const validation = validateWhyItMatters(editorialText);
+
+  if (!validation.passed) {
+    const flagResult = await context.client
+      .from("signal_posts")
+      .update({
+        edited_why_it_matters: editorialText,
+        edited_why_it_matters_payload: structuredContent,
+        editorial_status: "needs_review",
+        ...buildWhyItMattersValidationFields(validation, now),
+        edited_by: context.user.email ?? null,
+        edited_at: now,
+        updated_at: now,
+      })
+      .eq("id", input.postId);
+
+    if (flagResult.error) {
+      return {
+        ok: false,
+        code: "storage_error",
+        message: "The signal post could not be flagged for rewrite.",
+      };
+    }
+
+    return {
+      ok: false,
+      code: "publish_blocked",
+      message: getValidationFailureMessage(validation),
+    };
+  }
+
   const updateResult = await context.client
     .from("signal_posts")
     .update({
       edited_why_it_matters: editorialText,
       edited_why_it_matters_payload: structuredContent,
       editorial_status: "approved",
+      ...buildWhyItMattersValidationFields(validation, now),
       edited_by: context.user.email ?? null,
       edited_at: now,
       approved_by: context.user.email ?? null,
@@ -1294,9 +1366,13 @@ export async function approveSignalPosts(input: {
   const failedResults = results.filter((result) => !result.ok);
 
   if (failedResults.length > 0) {
+    const nonStorageFailure = failedResults.every((result) =>
+      result.code === "publish_blocked" || result.code === "empty_editorial_text",
+    );
+
     return {
       ok: false,
-      code: "storage_error",
+      code: nonStorageFailure ? "publish_blocked" : "storage_error",
       message:
         approvedCount > 0
           ? `Approved ${approvedCount} signal posts. ${failedResults.length} could not be approved.`
@@ -1346,12 +1422,14 @@ export async function resetSignalPostToAiDraft(input: {
     (lookup.data as Pick<StoredSignalPost, "ai_why_it_matters">).ai_why_it_matters,
   );
   const now = new Date().toISOString();
+  const validation = validateWhyItMatters(aiDraft);
   const updateResult = await context.client
     .from("signal_posts")
     .update({
       edited_why_it_matters: aiDraft,
       edited_why_it_matters_payload: null,
-      editorial_status: "draft",
+      editorial_status: validation.passed ? "draft" : "needs_review",
+      ...buildWhyItMattersValidationFields(validation, now),
       edited_by: context.user.email ?? null,
       edited_at: now,
       updated_at: now,
@@ -1441,6 +1519,57 @@ export async function publishApprovedSignals(input: {
   }
 
   const now = new Date().toISOString();
+  const topFivePublicationCandidates = topFivePosts.map((post) => {
+    const structuredContent =
+      post.editedWhyItMattersStructured ?? post.publishedWhyItMattersStructured;
+    const text = normalizeEditorialText(
+      buildEditorialWhyItMattersText(
+        structuredContent,
+        post.editedWhyItMatters || post.publishedWhyItMatters || "",
+      ),
+    );
+
+    return {
+      post,
+      structuredContent,
+      text,
+      validation: validateWhyItMatters(text),
+    };
+  });
+  const invalidTopFive = topFivePublicationCandidates.filter((entry) => !entry.validation.passed);
+
+  if (invalidTopFive.length > 0) {
+    const flagResults = await Promise.all(
+      invalidTopFive.map(({ post, validation }) =>
+        context.client
+          .from("signal_posts")
+          .update({
+            editorial_status: "needs_review",
+            ...buildWhyItMattersValidationFields(validation, now),
+            updated_at: now,
+          })
+          .eq("id", post.id),
+      ),
+    );
+
+    if (flagResults.some((result) => result.error)) {
+      return {
+        ok: false,
+        code: "storage_error",
+        message: "The invalid signal posts could not be flagged for rewrite.",
+      };
+    }
+
+    return {
+      ok: false,
+      code: "publish_blocked",
+      message:
+        invalidTopFive.length === 1
+          ? getValidationFailureMessage(invalidTopFive[0].validation)
+          : `${invalidTopFive.length} signal posts require human rewrite before publishing.`,
+    };
+  }
+
   const deactivateOldLiveSet = await context.client
     .from("signal_posts")
     .update({
@@ -1467,63 +1596,90 @@ export async function publishApprovedSignals(input: {
   }
 
   const updateResults = await Promise.all(
-    topFivePosts.map((post) => {
-      const structuredContent =
-        post.editedWhyItMattersStructured ?? post.publishedWhyItMattersStructured;
-
-      return context.client
+    topFivePublicationCandidates.map(({ post, structuredContent, text, validation }) =>
+      context.client
         .from("signal_posts")
         .update({
-          published_why_it_matters: normalizeEditorialText(
-            buildEditorialWhyItMattersText(
-              structuredContent,
-              post.editedWhyItMatters || post.publishedWhyItMatters || "",
-            ),
-          ),
+          published_why_it_matters: text,
           published_why_it_matters_payload: structuredContent,
           editorial_status: "published",
+          ...buildWhyItMattersValidationFields(validation, now),
           is_live: true,
           published_at: now,
           updated_at: now,
         })
-        .eq("id", post.id);
-    }),
+        .eq("id", post.id),
+    ),
+  );
+
+  const depthPublicationCandidates = depthPosts
+    .map((post) => {
+      const structuredContent =
+        post.editedWhyItMattersStructured ?? post.publishedWhyItMattersStructured;
+      const humanEditorialText = selectApprovedEditorialWhyItMatters(post);
+      const depthText = normalizeEditorialText(
+        humanEditorialText
+          ? buildEditorialWhyItMattersText(
+              structuredContent,
+              humanEditorialText,
+            )
+          : "",
+      );
+
+      return {
+        post,
+        structuredContent,
+        depthText,
+        validation: depthText ? validateWhyItMatters(depthText) : null,
+      };
+    })
+    .filter((entry) => entry.depthText);
+  const invalidDepthCandidates = depthPublicationCandidates.flatMap((entry) =>
+    entry.validation && !entry.validation.passed
+      ? [{ ...entry, validation: entry.validation }]
+      : [],
+  );
+  const validDepthCandidates = depthPublicationCandidates.flatMap((entry) =>
+    entry.validation?.passed
+      ? [{ ...entry, validation: entry.validation }]
+      : [],
+  );
+
+  const depthValidationResults = await Promise.all(
+    invalidDepthCandidates.map(({ post, validation }) =>
+      context.client
+        .from("signal_posts")
+        .update({
+          editorial_status: "needs_review",
+          ...buildWhyItMattersValidationFields(validation, now),
+          updated_at: now,
+        })
+        .eq("id", post.id),
+    ),
   );
 
   const depthUpdateResults = await Promise.all(
-    depthPosts
-      .map((post) => {
-        const structuredContent =
-          post.editedWhyItMattersStructured ?? post.publishedWhyItMattersStructured;
-        const humanEditorialText = selectApprovedEditorialWhyItMatters(post);
-        const depthText = normalizeEditorialText(
-          humanEditorialText
-            ? buildEditorialWhyItMattersText(
-                structuredContent,
-                humanEditorialText,
-              )
-            : "",
-        );
-
-        return { post, structuredContent, depthText };
-      })
-      .filter((entry) => entry.depthText)
-      .map(({ post, structuredContent, depthText }) =>
-        context.client
-          .from("signal_posts")
-          .update({
-            published_why_it_matters: depthText,
-            published_why_it_matters_payload: structuredContent,
-            editorial_status: "published",
-            is_live: true,
-            published_at: now,
-            updated_at: now,
-          })
-          .eq("id", post.id),
-      ),
+    validDepthCandidates.map(({ post, structuredContent, depthText, validation }) =>
+      context.client
+        .from("signal_posts")
+        .update({
+          published_why_it_matters: depthText,
+          published_why_it_matters_payload: structuredContent,
+          editorial_status: "published",
+          ...buildWhyItMattersValidationFields(validation, now),
+          is_live: true,
+          published_at: now,
+          updated_at: now,
+        })
+        .eq("id", post.id),
+    ),
   );
 
-  if (updateResults.some((result) => result.error) || depthUpdateResults.some((result) => result.error)) {
+  if (
+    updateResults.some((result) => result.error) ||
+    depthUpdateResults.some((result) => result.error) ||
+    depthValidationResults.some((result) => result.error)
+  ) {
     captureRssEditorialStorageFailure({
       failureType: "rss_cache_write_failed",
       phase: "publish",
@@ -1617,12 +1773,40 @@ export async function publishSignalPost(input: {
   }
 
   const now = new Date().toISOString();
+  const validation = validateWhyItMatters(editorialText);
+
+  if (!validation.passed) {
+    const flagResult = await context.client
+      .from("signal_posts")
+      .update({
+        editorial_status: "needs_review",
+        ...buildWhyItMattersValidationFields(validation, now),
+        updated_at: now,
+      })
+      .eq("id", post.id);
+
+    if (flagResult.error) {
+      return {
+        ok: false,
+        code: "storage_error",
+        message: "The signal post could not be flagged for rewrite.",
+      };
+    }
+
+    return {
+      ok: false,
+      code: "publish_blocked",
+      message: getValidationFailureMessage(validation),
+    };
+  }
+
   const updateResult = await context.client
     .from("signal_posts")
     .update({
       published_why_it_matters: editorialText,
       published_why_it_matters_payload: structuredContent,
       editorial_status: "published",
+      ...buildWhyItMattersValidationFields(validation, now),
       published_at: now,
       updated_at: now,
     })
@@ -1684,7 +1868,7 @@ async function loadPublishedSignalPosts(limit: number): Promise<EditorialSignalP
 
   return ((result.data ?? []) as unknown as StoredSignalPost[])
     .map(mapStoredSignalPost)
-    .filter((post) => normalizeEditorialText(post.publishedWhyItMatters));
+    .filter((post) => selectPublishedEditorialWhyItMatters(post));
 }
 
 export async function getPublishedSignalPosts(): Promise<EditorialSignalPost[]> {

--- a/src/lib/why-it-matters-quality-gate.test.ts
+++ b/src/lib/why-it-matters-quality-gate.test.ts
@@ -38,6 +38,22 @@ describe("why-it-matters quality gate", () => {
     );
   });
 
+  it("flags unresolved template variables as placeholder language", () => {
+    const result = validateWhyItMatters(
+      "Google changes the [category] baseline because {actor} can move {{market_structure}} expectations.",
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.failures).toContain("template_placeholder_language");
+    expect(result.failureDetails).toEqual(
+      expect.arrayContaining([
+        'template_placeholder_language: Contains unresolved template variable: "[category]"',
+        'template_placeholder_language: Contains unresolved template variable: "{actor}"',
+        'template_placeholder_language: Contains unresolved template variable: "{{market_structure}}"',
+      ]),
+    );
+  });
+
   it("flags abstract variable lists from homepage audit card #2", () => {
     const result = validateWhyItMatters(AUDIT_CARD_2);
 

--- a/src/lib/why-it-matters-quality-gate.ts
+++ b/src/lib/why-it-matters-quality-gate.ts
@@ -23,6 +23,8 @@ export type FlaggedWhyItMattersCard<T> = T & {
 
 const TERMINAL_PUNCTUATION_PATTERN = /[.!?]$/;
 const SIGNAL_SUFFIX_PATTERN = /\s*\(Signal:\s*[^)]+\)\s*$/i;
+const UNRESOLVED_VARIABLE_PATTERN =
+  /(?:\{\{\s*[^{}]+\s*\}\}|\{[a-z][a-z0-9_\s-]*\}|\[[a-z][a-z0-9_\s-]*\]|\$[a-z][a-z0-9_]*)/gi;
 
 const TRUNCATION_PATTERNS = [
   "so it could raise",
@@ -314,6 +316,15 @@ function detectTemplatePlaceholderLanguage(
         `Contains template placeholder phrase: "${phrase}"`,
       );
     }
+  }
+
+  const unresolvedVariables = value.match(UNRESOLVED_VARIABLE_PATTERN) ?? [];
+  for (const variable of unresolvedVariables) {
+    addFailure(
+      failures,
+      "template_placeholder_language",
+      `Contains unresolved template variable: "${variable}"`,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- Keeps the existing signal_posts schema preflight remediation from this branch.
- Enforces the deterministic why-it-matters validator before approval/publish transitions so invalid copy is flagged as requires_human_rewrite instead of reaching public state.
- Revalidates the exact copy promoted to published_why_it_matters for Top 5 and individual publish paths.
- Surfaces validation failure details in the editorial queue and blocks publish affordances for rows requiring human rewrite.
- Documents the remediation as an engineering change record; no new canonical PRD is required.

## Validation
- npm install
- npm run lint
- npm run test
- npm run build
- npm run governance:coverage
- npm run governance:audit
- python3 scripts/validate-feature-system-csv.py
- python3 scripts/release-governance-gate.py
- npx playwright test --project=chromium
- npx playwright test --project=webkit

## Production schema verification
- Confirmed the four why_it_matters validation columns exist on public.signal_posts.
- Confirmed non-null/default behavior for status, failures, and details.
- Confirmed signal_posts_why_it_matters_validation_status_check exists.
- Found existing published April 26 rows marked passed that fail the current validator; cleanup/regeneration remains a launch-blocking follow-up, not hidden in this PR.

## Scope boundaries
- Does not modify homepage ranking or Action 1 scoring behavior.
- Does not introduce LLM or external API calls.
- Does not modify template generation, clustering, ranking, or generation code.
- Does not treat signal_posts as canonical Signal identity.
- Does not reactivate PersonalizedDashboard or ManualRefreshTrigger.
- Does not create a new canonical PRD.

Do not merge until the Action 2 completion report is reviewed.