### PR TITLE
Remediate homepage ranking to prioritize structural importance

### DIFF
--- a/docs/engineering/change-records/2026-04-27-homepage-structural-importance-ranking-remediation.md
+++ b/docs/engineering/change-records/2026-04-27-homepage-structural-importance-ranking-remediation.md
@@ -1,0 +1,43 @@
+# Homepage Structural Importance Ranking Remediation
+
+Date: 2026-04-27
+
+## Change Type
+
+Remediation / alignment.
+
+## Source Of Truth
+
+- Boot Up Product Position: homepage Top 5 / Core Signals should represent highest structural importance.
+- Boot Up Product Position: returning users should see Signals ranked by structural importance, not recency.
+- Action 1 diagnosis: final homepage selection still preferred legacy `eventIntelligence.rankingScore`, which reflects the old coverage-breadth formula.
+
+No new canonical PRD is required. This change uses an engineering change record because it aligns existing ranking behavior to the already-approved product position.
+
+## Object Level
+
+This change affects final Signal ranking for homepage Surface Placement through the existing `BriefingItem` compatibility object. It does not introduce canonical Signal identity, and it does not change `signal_posts` semantics.
+
+## Implementation Summary
+
+- `compareBriefingItemsByRanking()` now uses the strategic score carried by `BriefingItem.importanceScore` or `BriefingItem.matchScore` before legacy `eventIntelligence.rankingScore`.
+- Legacy `eventIntelligence.rankingScore` remains available only as a fallback for older/demo `BriefingItem` objects without a strategic score.
+- High-signal status, confidence, source diversity, freshness, and title are now explicit tie-breakers after the primary strategic score.
+- `selectPublicBriefingItems()` now delegates to the shared comparator directly, while preserving topic diversity and `non_signal` second-pass constraints.
+
+## Non-Goals
+
+- Does not modify the ranking pipeline or `rankStoryClusters()` scoring rules.
+- Does not modify template generation, why-it-matters validation, homepage rendering, editorial UI, or `signal_posts` schema.
+- Does not reactivate `PersonalizedDashboard` or `ManualRefreshTrigger`.
+- Does not add LLM or external API calls.
+
+## Validation Notes
+
+Unit tests were added or updated for:
+
+- Final selection prefers high strategic importance over high coverage/legacy score.
+- `ranked.score`-derived `importanceScore` takes precedence over `eventIntelligence.rankingScore`.
+- Legacy coverage-breadth scoring cannot dominate final Top 5 ordering when a strategic score exists.
+- Source authority/tier affects strategic score upstream and that score is honored by final selection.
+- `rankNewsClusters()` coverage is labeled as a legacy compatibility path.

--- a/src/lib/data.selection.test.ts
+++ b/src/lib/data.selection.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+
+import { selectPublicBriefingItems } from "@/lib/data";
+import type { BriefingItem, EventIntelligence } from "@/lib/types";
+
+function createIntelligence(overrides: Partial<EventIntelligence> = {}): EventIntelligence {
+  return {
+    id: overrides.id ?? "intel-1",
+    title: overrides.title ?? "Federal Reserve signals rates will stay elevated",
+    summary: overrides.summary ?? "Markets are repricing after a fresh Federal Reserve signal.",
+    primaryChange: overrides.primaryChange ?? "Federal Reserve signaled rates will stay elevated",
+    keyEntities: overrides.keyEntities ?? ["Federal Reserve"],
+    topics: overrides.topics ?? ["finance"],
+    signals: overrides.signals ?? {
+      articleCount: 4,
+      sourceDiversity: 3,
+      recencyScore: 76,
+      velocityScore: 60,
+    },
+    rankingScore: overrides.rankingScore ?? 72,
+    rankingReason: overrides.rankingReason ?? "Legacy event-intelligence coverage score.",
+    confidenceScore: overrides.confidenceScore ?? 70,
+    isHighSignal: overrides.isHighSignal ?? true,
+    createdAt: overrides.createdAt ?? "2026-04-15T08:00:00.000Z",
+    eventType: overrides.eventType ?? "policy_regulation",
+    affectedMarkets: overrides.affectedMarkets ?? ["rates"],
+    primaryImpact: overrides.primaryImpact ?? "The event changes funding and policy assumptions.",
+    timeHorizon: overrides.timeHorizon ?? "medium",
+    entities: overrides.entities ?? ["Federal Reserve"],
+    signalStrength: overrides.signalStrength ?? "strong",
+  };
+}
+
+function createItem(overrides: Partial<BriefingItem>): BriefingItem {
+  return {
+    id: overrides.id ?? "item-1",
+    topicId: overrides.topicId ?? "topic-1",
+    topicName: overrides.topicName ?? "Finance",
+    title: overrides.title ?? "Federal Reserve signals rates will stay elevated",
+    whatHappened: overrides.whatHappened ?? "Markets repriced after a fresh policy signal.",
+    keyPoints: overrides.keyPoints ?? ["Point one", "Point two", "Point three"],
+    whyItMatters: overrides.whyItMatters ?? "It matters because it changes funding assumptions.",
+    sources: overrides.sources ?? [
+      { title: "Reuters", url: "https://www.reuters.com/world/example" },
+      { title: "Associated Press", url: "https://apnews.com/example" },
+    ],
+    estimatedMinutes: overrides.estimatedMinutes ?? 4,
+    read: overrides.read ?? false,
+    priority: overrides.priority ?? "normal",
+    matchedKeywords: overrides.matchedKeywords ?? [],
+    publishedAt: overrides.publishedAt ?? "2026-04-15T08:00:00.000Z",
+    sourceCount: overrides.sourceCount ?? 2,
+    importanceScore: overrides.importanceScore ?? 72,
+    importanceLabel: overrides.importanceLabel ?? "High",
+    rankingSignals: overrides.rankingSignals ?? ["Strategic score from ranked Story Cluster evidence."],
+    eventIntelligence: overrides.eventIntelligence ?? createIntelligence(),
+  };
+}
+
+describe("selectPublicBriefingItems", () => {
+  it("places a high-structural-importance, lower-coverage item above a high-coverage low-importance item", () => {
+    const strategicPolicyShift = createItem({
+      id: "strategic-policy-shift",
+      topicId: "politics",
+      topicName: "Politics",
+      title: "US export-control review changes chip supply assumptions",
+      importanceScore: 88,
+      sourceCount: 1,
+      eventIntelligence: createIntelligence({
+        rankingScore: 48,
+        confidenceScore: 58,
+        isHighSignal: false,
+        signals: {
+          articleCount: 1,
+          sourceDiversity: 1,
+          recencyScore: 45,
+          velocityScore: 20,
+        },
+      }),
+    });
+    const highCoverageTrivial = createItem({
+      id: "high-coverage-trivial",
+      topicId: "tech",
+      topicName: "Tech",
+      title: "Popular app adds a seasonal icon update",
+      importanceScore: 61,
+      sourceCount: 6,
+      eventIntelligence: createIntelligence({
+        rankingScore: 96,
+        confidenceScore: 88,
+        isHighSignal: true,
+        signals: {
+          articleCount: 14,
+          sourceDiversity: 6,
+          recencyScore: 98,
+          velocityScore: 92,
+        },
+      }),
+    });
+
+    const selected = selectPublicBriefingItems([highCoverageTrivial, strategicPolicyShift], 2);
+
+    expect(selected.map((item) => item.id)).toEqual([
+      "strategic-policy-shift",
+      "high-coverage-trivial",
+    ]);
+  });
+
+  it("does not let the legacy 40/30/20/10 coverage formula dominate final Top 5 placement", () => {
+    const oldFormulaWinner = createItem({
+      id: "old-formula-winner",
+      topicName: "Tech",
+      importanceScore: 64,
+      eventIntelligence: createIntelligence({
+        rankingScore: 99,
+        signals: {
+          articleCount: 20,
+          sourceDiversity: 6,
+          recencyScore: 100,
+          velocityScore: 92,
+        },
+      }),
+    });
+    const strategicWinner = createItem({
+      id: "strategic-winner",
+      topicName: "Finance",
+      importanceScore: 84,
+      eventIntelligence: createIntelligence({
+        rankingScore: 52,
+        signals: {
+          articleCount: 1,
+          sourceDiversity: 1,
+          recencyScore: 40,
+          velocityScore: 20,
+        },
+      }),
+    });
+
+    expect(selectPublicBriefingItems([oldFormulaWinner, strategicWinner], 2).map((item) => item.id)).toEqual([
+      "strategic-winner",
+      "old-formula-winner",
+    ]);
+  });
+
+  it("honors source-authority adjusted importance scores in final ordering", () => {
+    const tierOneAdjusted = createItem({
+      id: "tier-one-adjusted",
+      title: "Reuters confirms central-bank liquidity review",
+      sources: [{ title: "Reuters", url: "https://www.reuters.com/world/example" }],
+      sourceCount: 1,
+      importanceScore: 82,
+      eventIntelligence: createIntelligence({
+        rankingScore: 54,
+        confidenceScore: 60,
+      }),
+    });
+    const tierThreeCoverage = createItem({
+      id: "tier-three-coverage",
+      title: "Unvetted blogs repeat a consumer-product rumor",
+      sources: [{ title: "Unknown Blog", url: "https://example-blog.test/story" }],
+      sourceCount: 5,
+      importanceScore: 69,
+      eventIntelligence: createIntelligence({
+        rankingScore: 94,
+        confidenceScore: 82,
+        signals: {
+          articleCount: 10,
+          sourceDiversity: 5,
+          recencyScore: 90,
+          velocityScore: 84,
+        },
+      }),
+    });
+
+    expect(selectPublicBriefingItems([tierThreeCoverage, tierOneAdjusted], 2).map((item) => item.id)).toEqual([
+      "tier-one-adjusted",
+      "tier-three-coverage",
+    ]);
+  });
+
+  it("keeps explicit diversity and non-signal constraints after strategic sorting", () => {
+    const items = [
+      createItem({
+        id: "non-signal-fresh",
+        topicName: "Tech",
+        importanceScore: 99,
+        eventIntelligence: createIntelligence({ eventType: "non_signal", rankingScore: 99 }),
+      }),
+      createItem({ id: "tech-1", topicName: "Tech", importanceScore: 92 }),
+      createItem({ id: "tech-2", topicName: "Tech", importanceScore: 90 }),
+      createItem({ id: "tech-3", topicName: "Tech", importanceScore: 88 }),
+      createItem({ id: "finance-1", topicName: "Finance", importanceScore: 75 }),
+    ];
+
+    const selected = selectPublicBriefingItems(items, 3);
+
+    expect(selected.map((item) => item.id)).toEqual(["tech-1", "tech-2", "finance-1"]);
+    expect(selected.filter((item) => item.topicName === "Tech")).toHaveLength(2);
+    expect(selected.map((item) => item.id)).not.toContain("non-signal-fresh");
+  });
+});

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1341,19 +1341,8 @@ function resolvePipelineTopic(
   return fallbackTopic;
 }
 
-function selectPublicBriefingItems(items: BriefingItem[], limit = 5) {
-  const sorted = items
-    .slice()
-    .sort((left, right) => {
-      const highSignalDelta =
-        Number(Boolean(right.eventIntelligence?.isHighSignal)) -
-        Number(Boolean(left.eventIntelligence?.isHighSignal));
-      if (highSignalDelta !== 0) {
-        return highSignalDelta;
-      }
-
-      return compareBriefingItemsByRanking(left, right);
-    });
+export function selectPublicBriefingItems(items: BriefingItem[], limit = 5) {
+  const sorted = items.slice().sort(compareBriefingItemsByRanking);
   const selected: BriefingItem[] = [];
   const topicCounts = new Map<string, number>();
   const skippedForSecondPass: BriefingItem[] = [];

--- a/src/lib/event-intelligence.test.ts
+++ b/src/lib/event-intelligence.test.ts
@@ -368,7 +368,7 @@ describe("buildEventIntelligence", () => {
   });
 });
 
-describe("rankNewsClusters", () => {
+describe("legacy rankNewsClusters compatibility path", () => {
   it("filters low-signal clusters from ranked output", () => {
     const ranked = rankNewsClusters("Tech", [
       {

--- a/src/lib/ranking.test.ts
+++ b/src/lib/ranking.test.ts
@@ -3,11 +3,39 @@ import { describe, expect, it } from "vitest";
 import {
   buildRankingDisplaySignals,
   compareBriefingItemsByRanking,
+  getBriefingRankSnapshot,
   sortBriefingItemsByRanking,
 } from "@/lib/ranking";
 import type { BriefingItem } from "@/lib/types";
 
+function hasOverride<K extends keyof BriefingItem>(
+  overrides: Partial<BriefingItem>,
+  key: K,
+) {
+  return Object.prototype.hasOwnProperty.call(overrides, key);
+}
+
 function createItem(overrides: Partial<BriefingItem>): BriefingItem {
+  const defaultEventIntelligence = {
+    id: "intel-1",
+    title: "Fed signals rates will stay elevated",
+    summary: "Markets are repricing after a fresh Fed signal.",
+    primaryChange: "Fed signaled rates will stay elevated",
+    keyEntities: ["Federal Reserve"],
+    topics: ["finance"],
+    signals: {
+      articleCount: 5,
+      sourceDiversity: 3,
+      recencyScore: 82,
+      velocityScore: 76,
+    },
+    rankingScore: 78,
+    rankingReason: "Broad coverage around the Federal Reserve across 5 articles from 3 sources.",
+    confidenceScore: 74,
+    isHighSignal: true,
+    createdAt: "2026-04-15T08:00:00.000Z",
+  };
+
   return {
     id: overrides.id ?? "item-1",
     topicId: overrides.topicId ?? "topic-1",
@@ -27,62 +55,61 @@ function createItem(overrides: Partial<BriefingItem>): BriefingItem {
     sourceCount: overrides.sourceCount ?? 2,
     relatedArticles: overrides.relatedArticles,
     timeline: overrides.timeline,
-    importanceScore: overrides.importanceScore ?? 70,
+    importanceScore: hasOverride(overrides, "importanceScore") ? overrides.importanceScore : 70,
     importanceLabel: overrides.importanceLabel ?? "High",
     rankingSignals: overrides.rankingSignals ?? ["Broad coverage across multiple outlets."],
-    eventIntelligence: overrides.eventIntelligence ?? {
-      id: "intel-1",
-      title: "Fed signals rates will stay elevated",
-      summary: "Markets are repricing after a fresh Fed signal.",
-      primaryChange: "Fed signaled rates will stay elevated",
-      keyEntities: ["Federal Reserve"],
-      topics: ["finance"],
-      signals: {
-        articleCount: 5,
-        sourceDiversity: 3,
-        recencyScore: 82,
-        velocityScore: 76,
-      },
-      rankingScore: 78,
-      rankingReason: "Broad coverage around the Federal Reserve across 5 articles from 3 sources.",
-      confidenceScore: 74,
-      isHighSignal: true,
-      createdAt: "2026-04-15T08:00:00.000Z",
-    },
+    eventIntelligence: hasOverride(overrides, "eventIntelligence")
+      ? overrides.eventIntelligence
+      : defaultEventIntelligence,
   };
 }
 
 describe("ranking activation helpers", () => {
-  it("orders high-signal stronger events above manually flagged top items", () => {
-    const highSignal = createItem({
-      id: "high-signal",
+  it("orders by strategic importance before legacy event-intelligence coverage score", () => {
+    const strategicImportant = createItem({
+      id: "strategic-important",
       priority: "normal",
+      importanceScore: 86,
       eventIntelligence: {
         ...createItem({}).eventIntelligence!,
-        rankingScore: 90,
-        confidenceScore: 80,
+        rankingScore: 44,
+        confidenceScore: 58,
+        isHighSignal: false,
       },
     });
-    const weakTop = createItem({
-      id: "weak-top",
+    const highCoverageLegacy = createItem({
+      id: "high-coverage-legacy",
       priority: "top",
+      importanceScore: 62,
       eventIntelligence: {
         ...createItem({}).eventIntelligence!,
-        rankingScore: 52,
-        confidenceScore: 51,
+        signals: {
+          articleCount: 12,
+          sourceDiversity: 6,
+          recencyScore: 94,
+          velocityScore: 88,
+        },
+        rankingScore: 96,
+        confidenceScore: 86,
+        isHighSignal: true,
       },
     });
 
-    expect(compareBriefingItemsByRanking(highSignal, weakTop)).toBeLessThan(0);
-    expect(sortBriefingItemsByRanking([weakTop, highSignal]).map((item) => item.id)).toEqual([
-      "high-signal",
-      "weak-top",
+    expect(compareBriefingItemsByRanking(strategicImportant, highCoverageLegacy)).toBeLessThan(0);
+    expect(sortBriefingItemsByRanking([highCoverageLegacy, strategicImportant]).map((item) => item.id)).toEqual([
+      "strategic-important",
+      "high-coverage-legacy",
     ]);
+    expect(getBriefingRankSnapshot(strategicImportant)).toMatchObject({
+      rankingScore: 86,
+      scoreSource: "strategic",
+    });
   });
 
-  it("pushes low-signal items below high-signal items even when scores are similar", () => {
+  it("uses high-signal state as an explicit tie-breaker only after strategic score ties", () => {
     const strong = createItem({
       id: "strong",
+      importanceScore: 70,
       eventIntelligence: {
         ...createItem({}).eventIntelligence!,
         rankingScore: 61,
@@ -92,6 +119,7 @@ describe("ranking activation helpers", () => {
     });
     const weak = createItem({
       id: "weak",
+      importanceScore: 70,
       eventIntelligence: {
         ...createItem({}).eventIntelligence!,
         rankingScore: 64,
@@ -103,6 +131,74 @@ describe("ranking activation helpers", () => {
     expect(sortBriefingItemsByRanking([weak, strong]).map((item) => item.id)).toEqual([
       "strong",
       "weak",
+    ]);
+  });
+
+  it("falls back to legacy event-intelligence ranking only when no strategic score exists", () => {
+    const legacyHigh = createItem({
+      id: "legacy-high",
+      importanceScore: undefined,
+      eventIntelligence: {
+        ...createItem({}).eventIntelligence!,
+        rankingScore: 82,
+        confidenceScore: 70,
+      },
+    });
+    const legacyLow = createItem({
+      id: "legacy-low",
+      importanceScore: undefined,
+      eventIntelligence: {
+        ...createItem({}).eventIntelligence!,
+        rankingScore: 58,
+        confidenceScore: 70,
+      },
+    });
+
+    expect(sortBriefingItemsByRanking([legacyLow, legacyHigh]).map((item) => item.id)).toEqual([
+      "legacy-high",
+      "legacy-low",
+    ]);
+    expect(getBriefingRankSnapshot(legacyHigh)).toMatchObject({
+      rankingScore: 82,
+      scoreSource: "legacy_event_intelligence",
+    });
+  });
+
+  it("honors source-tier adjusted strategic scores in final ordering", () => {
+    const tierOneAdjusted = createItem({
+      id: "tier-one-adjusted",
+      title: "Reuters confirms export-control shift",
+      sources: [{ title: "Reuters", url: "https://www.reuters.com/world/example" }],
+      importanceScore: 83,
+      rankingSignals: ["Strategic score includes tier_1 source authority."],
+      eventIntelligence: {
+        ...createItem({}).eventIntelligence!,
+        rankingScore: 52,
+        confidenceScore: 60,
+      },
+    });
+    const tierThreeCoverage = createItem({
+      id: "tier-three-coverage",
+      title: "Low-authority blogs amplify gadget launch",
+      sources: [{ title: "Unknown Blog", url: "https://example-blog.test/post" }],
+      importanceScore: 68,
+      rankingSignals: ["Strategic score includes tier_3 source authority."],
+      eventIntelligence: {
+        ...createItem({}).eventIntelligence!,
+        signals: {
+          articleCount: 10,
+          sourceDiversity: 5,
+          recencyScore: 92,
+          velocityScore: 85,
+        },
+        rankingScore: 94,
+        confidenceScore: 82,
+      },
+    });
+
+    expect(sortBriefingItemsByRanking([tierThreeCoverage, tierOneAdjusted]).map((item) => item.id)).toEqual([
+      "tier-one-adjusted",
+      "tier-three-coverage",
     ]);
   });
 

--- a/src/lib/ranking.ts
+++ b/src/lib/ranking.ts
@@ -83,6 +83,7 @@ export function compareRankedClusters(left: RankedArticleCluster, right: RankedA
 type BriefingRankSnapshot = {
   isHighSignal: boolean;
   rankingScore: number;
+  scoreSource: "strategic" | "legacy_event_intelligence" | "none";
   confidenceScore: number;
   freshestTimestamp: number;
   sourceDiversity: number;
@@ -92,13 +93,13 @@ export function compareBriefingItemsByRanking(left: BriefingItem, right: Briefin
   const leftSnapshot = getBriefingRankSnapshot(left);
   const rightSnapshot = getBriefingRankSnapshot(right);
 
-  if (leftSnapshot.isHighSignal !== rightSnapshot.isHighSignal) {
-    return Number(rightSnapshot.isHighSignal) - Number(leftSnapshot.isHighSignal);
-  }
-
   const scoreDelta = rightSnapshot.rankingScore - leftSnapshot.rankingScore;
   if (scoreDelta !== 0) {
     return scoreDelta;
+  }
+
+  if (leftSnapshot.isHighSignal !== rightSnapshot.isHighSignal) {
+    return Number(rightSnapshot.isHighSignal) - Number(leftSnapshot.isHighSignal);
   }
 
   const confidenceDelta = rightSnapshot.confidenceScore - leftSnapshot.confidenceScore;
@@ -106,14 +107,14 @@ export function compareBriefingItemsByRanking(left: BriefingItem, right: Briefin
     return confidenceDelta;
   }
 
-  const freshnessDelta = rightSnapshot.freshestTimestamp - leftSnapshot.freshestTimestamp;
-  if (freshnessDelta !== 0) {
-    return freshnessDelta;
-  }
-
   const sourceDelta = rightSnapshot.sourceDiversity - leftSnapshot.sourceDiversity;
   if (sourceDelta !== 0) {
     return sourceDelta;
+  }
+
+  const freshnessDelta = rightSnapshot.freshestTimestamp - leftSnapshot.freshestTimestamp;
+  if (freshnessDelta !== 0) {
+    return freshnessDelta;
   }
 
   return left.title.localeCompare(right.title);
@@ -125,7 +126,12 @@ export function sortBriefingItemsByRanking(items: BriefingItem[]) {
 
 export function getBriefingRankSnapshot(item: BriefingItem): BriefingRankSnapshot {
   const intelligence = item.eventIntelligence;
-  const rankingScore = intelligence?.rankingScore ?? item.importanceScore ?? 0;
+  const strategicScore = getStrategicImportanceScore(item);
+  // `importanceScore`/`matchScore` carries the active importance-first
+  // `ranked.score` from rankStoryClusters(). The legacy
+  // eventIntelligence.rankingScore remains only for older/demo BriefingItems
+  // that predate the strategic score.
+  const rankingScore = strategicScore.score ?? intelligence?.rankingScore ?? 0;
   const confidenceScore = intelligence?.confidenceScore ?? 0;
   const sourceDiversity =
     intelligence?.signals.sourceDiversity ??
@@ -137,10 +143,23 @@ export function getBriefingRankSnapshot(item: BriefingItem): BriefingRankSnapsho
       intelligence?.isHighSignal ??
       (rankingScore >= 45 && (sourceDiversity >= 2 || (item.relatedArticles?.length ?? 0) >= 2)),
     rankingScore,
+    scoreSource: strategicScore.source ?? (intelligence?.rankingScore !== undefined ? "legacy_event_intelligence" : "none"),
     confidenceScore,
     freshestTimestamp: getTimestamp(item.publishedAt ?? intelligence?.createdAt),
     sourceDiversity,
   };
+}
+
+function getStrategicImportanceScore(item: BriefingItem) {
+  if (Number.isFinite(item.importanceScore)) {
+    return { score: item.importanceScore, source: "strategic" as const };
+  }
+
+  if (Number.isFinite(item.matchScore)) {
+    return { score: item.matchScore, source: "strategic" as const };
+  }
+
+  return { score: null, source: null };
 }
 
 // Returns Card display labels derived from ranking evidence, not canonical

--- a/src/lib/scoring/scoring-engine.test.ts
+++ b/src/lib/scoring/scoring-engine.test.ts
@@ -63,6 +63,22 @@ function createCluster(clusterId: string, title: string, keywords: string[], ent
   };
 }
 
+function withArticleOverrides(
+  cluster: StoryCluster,
+  overrides: Partial<NormalizedArticle>,
+): StoryCluster {
+  const article = {
+    ...cluster.representative_article,
+    ...overrides,
+  };
+
+  return {
+    ...cluster,
+    representative_article: article,
+    articles: [article],
+  };
+}
+
 describe("rankStoryClusters", () => {
   it("builds canonical ranking feature sets with FNS ownership", () => {
     const clusters = [createCluster("cluster-1", "Fed signals rates will stay elevated", ["finance", "rates", "market"], ["Federal Reserve"])];
@@ -120,6 +136,59 @@ describe("rankStoryClusters", () => {
     expect(ranked[0]?.ranked.ranking_debug.grouped_scores.event_importance).toBeGreaterThan(
       ranked[1]?.ranked.ranking_debug.grouped_scores.event_importance ?? 0,
     );
+  });
+
+  it("feeds source authority and trust tier into the strategic score used downstream", () => {
+    const baseCluster = createCluster(
+      "cluster-authority",
+      "Central bank review changes liquidity assumptions for major banks",
+      ["policy", "liquidity", "banks", "market", "rates", "guidance"],
+      ["Federal Reserve"],
+    );
+    const tierOneCluster = withArticleOverrides(baseCluster, {
+      id: "cluster-authority-tier-one",
+      source: "Associated Press",
+      source_metadata: {
+        sourceId: "fns-associated-press",
+        donor: "fns",
+        source: "Associated Press",
+        homepageUrl: "https://apnews.com",
+        topic: "World",
+        credibility: 88,
+        reliability: 0.88,
+        sourceClass: "general_newswire",
+        trustTier: "tier_1",
+        provenance: "aggregated_wire",
+        status: "active",
+        availability: "default",
+      },
+    });
+    const tierTwoCluster = withArticleOverrides(baseCluster, {
+      id: "cluster-authority-tier-two",
+      source: "Unknown Blog",
+      source_metadata: {
+        sourceId: "unknown-blog",
+        donor: "openclaw",
+        source: "Unknown Blog",
+        homepageUrl: "https://example-blog.test",
+        topic: "Tech",
+        credibility: 74,
+        reliability: 0.74,
+        sourceClass: "specialist_press",
+        trustTier: "tier_2",
+        provenance: "specialist_analysis",
+        status: "active",
+        availability: "default",
+      },
+    });
+
+    const [tierOne] = rankStoryClusters([tierOneCluster]);
+    const [tierTwo] = rankStoryClusters([tierTwoCluster]);
+
+    expect(tierOne?.ranked.ranking_debug.features.trust_tier).toBeGreaterThan(
+      tierTwo?.ranked.ranking_debug.features.trust_tier ?? 0,
+    );
+    expect(tierOne?.ranked.score).toBeGreaterThan(tierTwo?.ranked.score ?? 0);
   });
 
   it("keeps a critical overlapping story visible with only a light diversity penalty", () => {


### PR DESCRIPTION
## Change type
remediation / alignment

## Source of truth
Boot Up Product Position + accepted Action 1 diagnosis

## Summary
- Final homepage selection now ranks by strategic score first: importanceScore, then matchScore.
- Legacy eventIntelligence.rankingScore remains only as fallback.
- Source authority/tier now affects final homepage ordering through the upstream strategic score.
- Added final-selector tests preventing legacy 40/30/20/10 coverage scoring from dominating Top 5 ordering.
- Verified preview homepage, admin/editor queue, Supabase ordering, tests, lint, build, Playwright, and governance checks.

## Validation
- npm run test
- npm run lint
- npm run build
- npx playwright test --project=chromium
- npx playwright test --project=webkit
- npm run governance:coverage
- npm run governance:audit
- npm run governance:hotspots
- Vercel preview homepage smoke
- Vercel preview admin/editor queue smoke with dummy admin account
- Supabase read-only ordering inspection

## Notes
Do not proceed to Action 2 until this PR is merged or until Action 2 is explicitly branched from this remediation branch.
