### PR TITLE
Add Sentry RSS monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,17 @@ OPENAI_API_KEY=your_openai_api_key
 OPENAI_MODEL=gpt-4.1-mini
 OPENAI_BASE_URL=https://api.openai.com/v1
 THE_NEWS_API_KEY=your_news_api_key
+
+# Sentry RSS monitoring. Keep real values in deployment secrets/env only.
+SENTRY_DSN=your_sentry_dsn
+SENTRY_ENVIRONMENT=production
+SENTRY_RELEASE=
+SENTRY_TRACES_SAMPLE_RATE=0.05
+SENTRY_REPLAYS_SESSION_SAMPLE_RATE=0
+SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE=0.05
+SENTRY_ORG=your_sentry_org_slug
+SENTRY_PROJECT=your_sentry_project_slug
+SENTRY_AUTH_TOKEN=
+RSS_CRON_MONITOR_SLUG=rss-feed-refresh
+RSS_STALE_THRESHOLD_MS=108000000
+PUBLIC_SITE_URL=https://your-production-domain.example

--- a/docs/engineering/change-records/sentry-rss-monitoring.md
+++ b/docs/engineering/change-records/sentry-rss-monitoring.md
@@ -1,0 +1,197 @@
+# Sentry RSS Monitoring
+
+Date: 2026-04-27
+
+Canonical PRD required: `No`
+
+This is audit/remediation-backed operational monitoring for the existing RSS Article ingestion and daily refresh system. It does not add user-facing product scope, source activation, ranking behavior, Signal interpretation, or editorial UI behavior.
+
+## Scope
+
+- Initialize Sentry for the Next.js App Router runtime with env-only configuration.
+- Capture RSS boot validation failures before RSS runtime paths are used.
+- Classify RSS fetch, parse, store, publish, cache, refresh, stale-health, and unexpected failures with stable failure types.
+- Add one Sentry Cron Monitoring check-in path for the existing daily RSS refresh job.
+- Add one uptime-monitor-compatible health endpoint at `/health/rss`.
+- Keep all Sentry setup compatible with the free Developer tier.
+
+## Required Environment Variables
+
+Set real values only in deployment secrets or environment settings.
+
+```text
+SENTRY_DSN=<masked>
+SENTRY_ENVIRONMENT=production
+SENTRY_TRACES_SAMPLE_RATE=0.05
+RSS_CRON_MONITOR_SLUG=rss-feed-refresh
+PUBLIC_SITE_URL=https://your-production-domain.example
+```
+
+Optional:
+
+```text
+SENTRY_RELEASE=<commit sha or release id>
+SENTRY_REPLAYS_SESSION_SAMPLE_RATE=0
+SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE=0.05
+SENTRY_ORG=<org slug, required only for source map upload>
+SENTRY_PROJECT=<project slug, required only for source map upload>
+SENTRY_AUTH_TOKEN=<CI secret only, required only for source map upload>
+RSS_STALE_THRESHOLD_MS=108000000
+```
+
+## Failure Taxonomy
+
+RSS failures are classified as:
+
+```text
+rss_config_missing
+rss_config_invalid
+rss_boot_init_failed
+rss_fetch_timeout
+rss_fetch_network_error
+rss_fetch_dns_error
+rss_fetch_tls_error
+rss_fetch_http_error
+rss_fetch_rate_limited
+rss_fetch_unexpected_status
+rss_fetch_empty_response
+rss_fetch_invalid_content_type
+rss_parse_invalid_xml
+rss_parse_invalid_feed
+rss_parse_missing_required_fields
+rss_parse_empty_feed
+rss_cache_read_failed
+rss_cache_write_failed
+rss_retry_exhausted
+rss_refresh_job_failed
+rss_feed_stale
+rss_unknown_error
+```
+
+Sentry events are tagged with:
+
+```text
+component=rss
+rss.failure_type=<failure type>
+rss.phase=boot|fetch|parse|store|publish|cache|refresh|healthcheck|render
+rss.feed_host=<host only>
+rss.feed_id=<stable id when available>
+environment=<SENTRY_ENVIRONMENT>
+```
+
+Full feed URLs, query strings, headers, cookies, authorization values, API keys, RSS item bodies, RSS item titles, and user identifiers are not intentionally sent to Sentry.
+
+## Boot Monitoring
+
+Sentry initializes through Next.js instrumentation before RSS boot validation runs. Boot validation resolves configured donor feeds and public surface feeds without fetching network content. If feed configuration is missing or invalid, the app marks RSS health as degraded and captures a boot-phase RSS event; it does not crash the app because persisted read models can still serve the site.
+
+## Scheduled Refresh Monitoring
+
+The existing Vercel Cron route remains:
+
+```text
+/api/cron/fetch-news
+schedule: 0 10 * * *
+```
+
+Sentry Cron Monitoring uses one monitor slug:
+
+```text
+rss-feed-refresh
+```
+
+The cron wrapper sends:
+
+- `in_progress` when the job starts
+- `ok` when RSS-backed editorial persistence succeeds
+- `error` when seed fallback is used, too few items are produced, persistence fails, or the job throws
+
+If Sentry auto-creates the monitor from check-ins, confirm in the Sentry UI that only this one RSS cron monitor exists.
+
+## Uptime Monitoring
+
+Configure exactly one Sentry uptime monitor:
+
+```text
+PUBLIC_SITE_URL + /health/rss
+```
+
+The endpoint returns:
+
+- `200` with `status: "ok"` or `status: "degraded"` when RSS boot is acceptable and a successful RSS-backed run is fresh.
+- `503` with `status: "failed"` when no successful RSS-backed run is known, the persisted read model cannot be read, or RSS health is critically stale.
+
+The endpoint does not expose full feed URLs, headers, cookies, stack traces, internal tokens, or RSS item content.
+
+## Alerts
+
+Free-tier-compatible issue alert:
+
+```text
+New issue where component:rss
+Action: email notification
+```
+
+Suggested metric alert:
+
+```text
+count(errors) where component:rss over 5-15 minutes
+Warning: >= 3
+Critical: >= 10
+Action: email notification
+```
+
+Do not configure Slack, Jira, PagerDuty, GitHub, paid uptime capacity, paid profiling, pay-as-you-go, or paid trials unless explicitly approved later.
+
+## Dashboard Widgets
+
+Recommended Sentry dashboard widgets:
+
+- RSS errors by `rss.failure_type`
+- RSS errors by `rss.feed_host`
+- RSS boot failures over time
+- RSS refresh duration
+- RSS fetch latency p95
+- RSS stale feed count
+- RSS health endpoint failures
+
+If a widget is not available on the current Sentry plan or UI, keep it as a manual follow-up.
+
+## Logs, Traces, And Replay
+
+- RSS boot, fetch, parse, store, publish, cache, refresh, and health operations can emit bounded Sentry logs when `SENTRY_DSN` is present.
+- Tracing uses `SENTRY_TRACES_SAMPLE_RATE` and defaults to `0.05`.
+- Profiling is not enabled.
+- Browser replay is not enabled in this server-side RSS monitoring pass because `NEXT_PUBLIC_SENTRY_DSN` is intentionally not configured yet.
+- Backend RSS failures may correlate with browser errors only in a later browser-monitoring pass.
+
+## Release And Source Maps
+
+Sentry release/source map upload is configured only through env/CI values:
+
+```text
+SENTRY_AUTH_TOKEN
+SENTRY_ORG
+SENTRY_PROJECT
+SENTRY_RELEASE
+```
+
+Local builds must not fail when these are absent. Do not create or commit a Sentry auth token from a developer machine.
+
+## Manual Sentry UI Steps
+
+1. Confirm the Sentry account/project is on the free Developer tier or otherwise does not require paid changes.
+2. Set `SENTRY_DSN` in production deployment env only.
+3. Do not set `NEXT_PUBLIC_SENTRY_DSN` until browser-side monitoring is explicitly approved.
+4. Configure the one uptime monitor for `PUBLIC_SITE_URL + /health/rss`.
+5. Confirm the one cron monitor slug is `rss-feed-refresh`.
+6. Add the email issue alert and metric alert above.
+7. Add dashboard widgets where the current plan/UI supports them.
+
+## Non-Goals
+
+- No deployment in this change.
+- No Sentry plan upgrade, paid add-on, pay-as-you-go, or payment method.
+- No new RSS scheduler.
+- No additional uptime monitors or cron monitors.
+- No source activation, ranking changes, homepage behavior changes, auth changes, or schema migrations.

--- a/docs/engineering/testing/sentry-rss-monitoring.md
+++ b/docs/engineering/testing/sentry-rss-monitoring.md
@@ -1,0 +1,44 @@
+# Sentry RSS Monitoring Test Report
+
+Date: 2026-04-27
+
+Branch: `codex/sentry-rss-monitoring`
+
+## Local Validation
+
+```text
+npm install @sentry/nextjs --save
+npm install
+npm run lint
+npm run test -- src/lib/observability/rss.test.ts src/lib/rss.test.ts src/app/health/rss/route.test.ts src/app/api/cron/fetch-news/route.test.ts src/lib/signals-editorial.test.ts
+npm run test
+npm run build
+git diff --check
+npm run dev
+curl -i http://localhost:3000/
+curl -i http://localhost:3000/health/rss
+PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=chromium
+PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=webkit --workers=1
+python3 scripts/validate-feature-system-csv.py
+python3 scripts/release-governance-gate.py --base-sha origin/main --head-sha HEAD --branch-name codex/sentry-rss-monitoring --pr-title "Sentry RSS monitoring" --diff-mode local
+```
+
+## Results
+
+- Dependency install: up to date; npm audit reports `2 vulnerabilities` (`1 moderate`, `1 high`) pre-existing/not remediated in this scope.
+- Focused RSS/Sentry/editorial tests: `5 passed`, `50 passed`.
+- Full Vitest suite: `67 passed`, `415 passed`.
+- Lint: passed.
+- Build: passed.
+- `git diff --check`: passed.
+- Local URL: `http://localhost:3000`.
+- Home route: `200 OK`.
+- RSS health route: `503 Service Unavailable` locally with safe JSON because no persisted RSS-backed run/Supabase service-role data is configured in this worktree.
+- Chromium Playwright: `33 passed`.
+- WebKit Playwright single-worker rerun: `33 passed`.
+- Feature-system CSV validation: passed with existing slug warnings.
+- Release governance gate: passed as `material-feature-change` with the documented no-PRD remediation exception.
+
+## Preview And Production
+
+Preview `/health/rss` was not run because no preview URL/deployment was available in this local validation step. Production was not deployed or modified. Sentry DSN and Vercel env setup were handled outside this code validation pass; uptime monitor creation remains blocked until production serves `/health/rss`.

--- a/docs/operations/tracker-sync/2026-04-27-sentry-rss-monitoring.md
+++ b/docs/operations/tracker-sync/2026-04-27-sentry-rss-monitoring.md
@@ -1,0 +1,24 @@
+# Tracker Sync Fallback: Sentry RSS Monitoring
+
+Date: 2026-04-27
+
+Direct Google Sheets update: not performed in this Codex run.
+
+Suggested tracker destination: `Intake Queue`, unless an existing governed operations/remediation row already owns production RSS monitoring.
+
+## Manual Payload
+
+| Field | Value |
+| --- | --- |
+| Feature Name | Sentry RSS monitoring |
+| Layer | Data |
+| Feature Type | Remediation / Observability |
+| Parent System | RSS ingestion and daily refresh |
+| Status | In Review |
+| Decision | keep |
+| Owner | Codex |
+| Branch | `codex/sentry-rss-monitoring` |
+| PRD File |  |
+| Supporting Doc | `docs/engineering/change-records/sentry-rss-monitoring.md` |
+| Testing Doc | `docs/engineering/testing/sentry-rss-monitoring.md` |
+| Notes | No new canonical PRD was created. The change record declares `Canonical PRD required: No` because this is audit/remediation-backed production monitoring for existing RSS paths, not a user-facing product feature. |

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
   async redirects() {
@@ -22,4 +23,14 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withSentryConfig(nextConfig, {
+  org: process.env.SENTRY_ORG,
+  project: process.env.SENTRY_PROJECT,
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+  silent: !process.env.CI,
+  webpack: {
+    treeshake: {
+      removeDebugLogging: true,
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "daily-intelligence-aggregator",
       "version": "0.1.0",
       "dependencies": {
+        "@sentry/nextjs": "^10.50.0",
         "@supabase/ssr": "^0.10.0",
         "@supabase/supabase-js": "^2.101.1",
         "@vercel/analytics": "^2.0.1",
@@ -103,7 +104,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -118,7 +118,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -128,7 +127,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -159,7 +157,6 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -176,7 +173,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -193,7 +189,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -203,7 +198,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -217,7 +211,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -235,7 +228,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -245,7 +237,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -255,7 +246,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -265,7 +255,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
       "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -279,7 +268,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -305,7 +293,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -320,7 +307,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -339,7 +325,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -695,6 +680,108 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fastify/otel": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.18.0.tgz",
+      "integrity": "sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "minimatch": "^10.2.4"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/api-logs": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.212.0.tgz",
+      "integrity": "sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz",
+      "integrity": "sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.212.0",
+        "import-in-the-middle": "^2.0.6",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1267,7 +1354,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1278,7 +1364,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1289,24 +1374,32 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1530,6 +1623,473 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
+      "integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-amqplib": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.61.0.tgz",
+      "integrity": "sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-connect": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.57.0.tgz",
+      "integrity": "sha512-FMEBChnI4FLN5TE9DHwfH7QpNir1JzXno1uz/TAucVdLCyrG0jTrKIcNHt/i30A0M2AunNBCkcd8Ei26dIPKdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/connect": "3.4.38"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-dataloader": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.31.0.tgz",
+      "integrity": "sha512-f654tZFQXS5YeLDNb9KySrwtg7SnqZN119FauD7acBoTzuLduaiGTNz88ixcVSOOMGZ+EjJu/RFtx5klObC95g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.33.0.tgz",
+      "integrity": "sha512-sCZWXGalQ01wr3tAhSR9ucqFJ0phidpAle6/17HVjD6gN8FLmZMK/8sKxdXYHy3PbnlV1P4zeiSVFNKpbFMNLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-generic-pool": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.57.0.tgz",
+      "integrity": "sha512-orhmlaK+ZIW9hKU+nHTbXrCSXZcH83AescTqmpamHRobRmYSQwRbD0a1odc0yAzuzOtxYiHiXAnpnIpaSSY7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-graphql": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.62.0.tgz",
+      "integrity": "sha512-3YNuLVPUxafXkH1jBAbGsKNsP3XVzcFDhCDCE3OqBwCwShlqQbLMRMFh1T/d5jaVZiGVmSsfof+ICKD2iOV8xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-hapi": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.60.0.tgz",
+      "integrity": "sha512-aNljZKYrEa7obLAxd1bCEDxF7kzCLGXTuTJZ8lMR9rIVEjmuKBXN1gfqpm/OB//Zc2zP4iIve1jBp7sr3mQV6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.214.0.tgz",
+      "integrity": "sha512-FlkDhZDRjDJDcO2LcSCtjRpkal1NJ8y0fBqBhTvfAR3JSYY2jAIj1kSS5IjmEBt4c3aWv+u/lqLuoCDrrKCSKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/instrumentation": "0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
+        "forwarded-parse": "2.1.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-ioredis": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.62.0.tgz",
+      "integrity": "sha512-ZYt//zcPve8qklaZX+5Z4MkU7UpEkFRrxsf2cnaKYBitqDnsCN69CPAuuMOX6NYdW2rG9sFy7V/QWtBlP5XiNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/redis-common": "^0.38.2",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-kafkajs": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.23.0.tgz",
+      "integrity": "sha512-4K+nVo+zI+aDz0Z85SObwbdixIbzS9moIuKJaYsdlzcHYnKOPtB7ya8r8Ezivy/GVIBHiKJVq4tv+BEkgOMLaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.30.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-knex": {
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.58.0.tgz",
+      "integrity": "sha512-Hc/o8fSsaWxZ8r1Yw4rNDLwTpUopTf4X32y4W6UhlHmW8Wizz8wfhgOKIelSeqFVTKBBPIDUOsQWuIMxBmu8Bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-koa": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.62.0.tgz",
+      "integrity": "sha512-uVip0VuGUQXZ+vFxkKxAUNq8qNl+VFlyHDh/U6IQ8COOEDfbEchdaHnpFrMYF3psZRUuoSIgb7xOeXj00RdwDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.36.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.58.0.tgz",
+      "integrity": "sha512-6grM3TdMyHzlGY1cUA+mwoPueB1F3dYKgKtZIH6jOFXqfHAByyLTc+6PFjGM9tKh52CFBJaDwodNlL/Td39z7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb": {
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.67.0.tgz",
+      "integrity": "sha512-1WJp5N1lYfHq2IhECOTewFs5Tf2NfUOwQRqs/rZdXKTezArMlucxgzAaqcgp3A3YREXopXTpXHsxZTGHjNhMdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongoose": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.60.0.tgz",
+      "integrity": "sha512-8BahAZpKsOoc+lrZGb7Ofn4g3z8qtp5IxDfvAVpKXsEheQN7ONMH5djT5ihy6yf8yyeQJGS0gXFfpEAEeEHqQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.60.0.tgz",
+      "integrity": "sha512-08pO8GFPEIz2zquKDGteBZDNmwketdgH8hTe9rVYgW9kCJXq1Psj3wPQGx+VaX4ZJKCfPeoLMYup9+cxHvZyVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@types/mysql": "2.15.27"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql2": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.60.0.tgz",
+      "integrity": "sha512-m/5d3bxQALllCzezYDk/6vajh0tj5OijMMvOZGr+qN1NMXm1dzMNwyJ0gNZW7Fo3YFRyj/jJMxIw+W7d525dlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@opentelemetry/sql-common": "^0.41.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg": {
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.66.0.tgz",
+      "integrity": "sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
+        "@opentelemetry/sql-common": "^0.41.2",
+        "@types/pg": "8.15.6",
+        "@types/pg-pool": "2.0.7"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.62.0.tgz",
+      "integrity": "sha512-y3pPpot7WzR/8JtHcYlTYsyY8g+pbFhAqbwAuG5bLPnR6v6pt1rQc0DpH0OlGP/9CZbWBP+Zhwp9yFoygf/ZXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/redis-common": "^0.38.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.33.0.tgz",
+      "integrity": "sha512-Q6WQwAD01MMTub31GlejoiFACYNw26J426wyjvU7by7fDIr2nZXNW4vhTGs7i7F0TnXBO3xN688g1tdUgYwJ5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@types/tedious": "^4.0.14"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/redis-common": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.3.tgz",
+      "integrity": "sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.0.tgz",
+      "integrity": "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.0.tgz",
+      "integrity": "sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sql-common": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
+      "integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.124.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
@@ -1554,6 +2114,59 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@prisma/instrumentation": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.6.0.tgz",
+      "integrity": "sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.207.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.8"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz",
+      "integrity": "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz",
+      "integrity": "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.207.0",
+        "import-in-the-middle": "^2.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1857,12 +2470,918 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "28.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.1.tgz",
+      "integrity": "sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "fdir": "^6.2.0",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0 || 14 >= 14.17"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.50.0.tgz",
+      "integrity": "sha512-42bxyRTxnCmYlWnvz4CxikuQNanw8UNma2WJrtxJ0f1MAJV2GhQGSHDLnA+lvFlmiz6qct3pfen/NXGyOTegTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.50.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.50.0.tgz",
+      "integrity": "sha512-0k9XZF0wn86f77mIO2U3gNNyDZooy139CnEanRzHinrN106vVzvBZ6TUEQoHtoO1fqQxr+nWWVrqV/PXUqk47w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.50.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.50.0.tgz",
+      "integrity": "sha512-51FYNfnvVLAWw1rrEWPFfwHuMRb9mkVCFGA4J9/un7SpeGBsQDziGB0Di4fsCxI7+EdSBpfLHPF0csKtCCw0oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.50.0",
+        "@sentry/core": "10.50.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.50.0.tgz",
+      "integrity": "sha512-jx6RKBmcJSWdI92qDGS/sBv1w+7Cww879Z/moX7bw7ipHa/Ts3iDcB3rgZwvhmi17U+mvYsbJeL2DXkPo3TjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.50.0",
+        "@sentry/core": "10.50.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.2.0.tgz",
+      "integrity": "sha512-8LbOI5Kzb5F0+7LVQPi2+zGz1iPiRRFhM+7uZ/ZQ33L9BmDOYNIy3xWxCfMw2JCuMXXaxF47XCjGmR22/B0WPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.50.0.tgz",
+      "integrity": "sha512-1f6rAvET6myiTaSeYqvaaBwvq1LfxqWjAPIoAW/NVC9bPMkeEcuvgDajHrnZMrBeWoJ81NMyoLkyX+iOc7MoFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.50.0",
+        "@sentry-internal/feedback": "10.50.0",
+        "@sentry-internal/replay": "10.50.0",
+        "@sentry-internal/replay-canvas": "10.50.0",
+        "@sentry/core": "10.50.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-5.2.0.tgz",
+      "integrity": "sha512-+C0x4gEIJRgoMwyRFGx+TFiJ1Po2BZlT1v61+PnouiaprKL5qtZG8n5PXx/5LPLDsVjSIcXjnDrTz9aSm8SJ3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.18.5",
+        "@sentry/babel-plugin-component-annotate": "5.2.0",
+        "@sentry/cli": "^2.58.5",
+        "dotenv": "^16.3.1",
+        "find-up": "^5.0.0",
+        "glob": "^13.0.6",
+        "magic-string": "~0.30.8"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.5.tgz",
+      "integrity": "sha512-tavJ7yGUZV+z3Ct2/ZB6mg339i08sAk6HDkgqmSRuQEu2iLS5sl9HIvuXfM6xjv8fwlgFOSy++WNABNAcGHUbg==",
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.58.5",
+        "@sentry/cli-linux-arm": "2.58.5",
+        "@sentry/cli-linux-arm64": "2.58.5",
+        "@sentry/cli-linux-i686": "2.58.5",
+        "@sentry/cli-linux-x64": "2.58.5",
+        "@sentry/cli-win32-arm64": "2.58.5",
+        "@sentry/cli-win32-i686": "2.58.5",
+        "@sentry/cli-win32-x64": "2.58.5"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.5.tgz",
+      "integrity": "sha512-lYrNzenZFJftfwSya7gwrHGxtE+Kob/e1sr9lmHMFOd4utDlmq0XFDllmdZAMf21fxcPRI1GL28ejZ3bId01fQ==",
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.5.tgz",
+      "integrity": "sha512-KtHweSIomYL4WVDrBrYSYJricKAAzxUgX86kc6OnlikbyOhoK6Fy8Vs6vwd52P6dvWPjgrMpUYjW2M5pYXQDUw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.5.tgz",
+      "integrity": "sha512-/4gywFeBqRB6tR/iGMRAJ3HRqY6Z7Yp4l8ZCbl0TDLAfHNxu7schEw4tSnm2/Hh9eNMiOVy4z58uzAWlZXAYBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.5.tgz",
+      "integrity": "sha512-G7261dkmyxqlMdyvyP06b+RTIVzp1gZNgglj5UksxSouSUqRd/46W/2pQeOMPhloDYo9yLtCN2YFb3Mw4aUsWw==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.5.tgz",
+      "integrity": "sha512-rP04494RSmt86xChkQ+ecBNRYSPbyXc4u0IA7R7N1pSLCyO74e5w5Al+LnAq35cMfVbZgz5Sm0iGLjyiUu4I1g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.5.tgz",
+      "integrity": "sha512-AOJ2nCXlQL1KBaCzv38m3i2VmSHNurUpm7xVKd6yAHX+ZoVBI8VT0EgvwmtJR2TY2N2hNCC7UrgRmdUsQ152bA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.5.tgz",
+      "integrity": "sha512-EsuboLSOnlrN7MMPJ1eFvfMDm+BnzOaSWl8eYhNo8W/BIrmNgpRUdBwnWn9Q2UOjJj5ZopukmsiMYtU/D7ml9g==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.5.tgz",
+      "integrity": "sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.50.0.tgz",
+      "integrity": "sha512-J4A+vzUO3adl0TkFCjaN1+4miamrjHiEIYuLHiuu1lmAjq5WIVw32ObvAh4yMwNtxyaEMosTrrh5M6f12XSJFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/nextjs": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-10.50.0.tgz",
+      "integrity": "sha512-IyDaOpbWUzfAqFoTQUSpvmG1fC6GBkCOd6eTYoT8ZNfxXYPBVd4eQFTNNh09CvOkNe1QIVvVshajg1TqUNWK4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@rollup/plugin-commonjs": "28.0.1",
+        "@sentry-internal/browser-utils": "10.50.0",
+        "@sentry/bundler-plugin-core": "^5.2.0",
+        "@sentry/core": "10.50.0",
+        "@sentry/node": "10.50.0",
+        "@sentry/opentelemetry": "10.50.0",
+        "@sentry/react": "10.50.0",
+        "@sentry/vercel-edge": "10.50.0",
+        "@sentry/webpack-plugin": "^5.2.0",
+        "rollup": "^4.35.0",
+        "stacktrace-parser": "^0.1.11"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "next": "^13.2.0 || ^14.0 || ^15.0.0-rc.0 || ^16.0.0-0"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.50.0.tgz",
+      "integrity": "sha512-TvwzFQu8MGKzMQ2/tqxcNzFA8UG2kKTB+GDmA4uOzx3+GT849YZRRSJzEXCmYhk1teVd2fbmgqyYY2nyLF5a+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/otel": "0.18.0",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/core": "^2.6.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/instrumentation-amqplib": "0.61.0",
+        "@opentelemetry/instrumentation-connect": "0.57.0",
+        "@opentelemetry/instrumentation-dataloader": "0.31.0",
+        "@opentelemetry/instrumentation-fs": "0.33.0",
+        "@opentelemetry/instrumentation-generic-pool": "0.57.0",
+        "@opentelemetry/instrumentation-graphql": "0.62.0",
+        "@opentelemetry/instrumentation-hapi": "0.60.0",
+        "@opentelemetry/instrumentation-http": "0.214.0",
+        "@opentelemetry/instrumentation-ioredis": "0.62.0",
+        "@opentelemetry/instrumentation-kafkajs": "0.23.0",
+        "@opentelemetry/instrumentation-knex": "0.58.0",
+        "@opentelemetry/instrumentation-koa": "0.62.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.58.0",
+        "@opentelemetry/instrumentation-mongodb": "0.67.0",
+        "@opentelemetry/instrumentation-mongoose": "0.60.0",
+        "@opentelemetry/instrumentation-mysql": "0.60.0",
+        "@opentelemetry/instrumentation-mysql2": "0.60.0",
+        "@opentelemetry/instrumentation-pg": "0.66.0",
+        "@opentelemetry/instrumentation-redis": "0.62.0",
+        "@opentelemetry/instrumentation-tedious": "0.33.0",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@prisma/instrumentation": "7.6.0",
+        "@sentry/core": "10.50.0",
+        "@sentry/node-core": "10.50.0",
+        "@sentry/opentelemetry": "10.50.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.50.0.tgz",
+      "integrity": "sha512-Eb1BYf4Lc7ZYmdX3acKP6SgyGikrBA370gbGHaWI5jRu7G7vig8sIu1ghPmY5AlvqBPOetado7GniXr6fAXbTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.50.0",
+        "@sentry/opentelemetry": "10.50.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/semantic-conventions": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.50.0.tgz",
+      "integrity": "sha512-axn3pgDPveGdaMUC0abMCmFN7ux2pA5ebPufCef4lMIsyg7BBQvaEJ+vE19wjstMaBCAJGsdZlL3eeP2rtgRMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.50.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.50.0.tgz",
+      "integrity": "sha512-MZHYjEZAtFIa4zPrWS4oXlo+gMppRvfETqUqF920Sj2jN2U7WjboU03lDmjfDqEcH7QiwjQyl13jHd2nwAyrrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.50.0",
+        "@sentry/core": "10.50.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/vercel-edge": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-10.50.0.tgz",
+      "integrity": "sha512-/LGUKF3QycR/qBhJl5EOjk1U1i/TJ3xhjqcPgjyFgIVRRSt0ouvRNFAkGa/Q/MTo5r0gWi+ZxLUwvByOFNfBow==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/resources": "^2.6.1",
+        "@sentry/core": "10.50.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/webpack-plugin": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-5.2.0.tgz",
+      "integrity": "sha512-ssV/uJK3ixf8UHBrNdLBXcnprUwppJNilbFv+19I81KTH4gVwzKXsVTMO91j6lyAXtk2mORwmEFwxZqScFfc7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugin-core": "5.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "webpack": ">=5.0.0"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -2378,6 +3897,15 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2385,11 +3913,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/jsdom": {
@@ -2442,7 +3991,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -2452,6 +4000,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mysql": {
+      "version": "2.15.27",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
+      "integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
@@ -2459,6 +4016,26 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.15.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
+      "integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-pool": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.7.tgz",
+      "integrity": "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "*"
       }
     },
     "node_modules/@types/react": {
@@ -2479,6 +4056,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/tedious": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/tough-cookie": {
@@ -3278,17 +4864,213 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
       }
     },
     "node_modules/acorn-jsx": {
@@ -3299,6 +5081,18 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -3317,6 +5111,48 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -3642,7 +5478,6 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3671,6 +5506,13 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -3779,6 +5621,22 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3814,6 +5672,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3825,7 +5696,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -3973,7 +5843,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4079,6 +5948,18 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4098,7 +5979,6 @@
       "version": "1.5.331",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
       "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -4112,7 +5992,6 @@
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
       "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -4253,7 +6132,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -4320,7 +6198,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4716,7 +6593,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -4729,7 +6605,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -4755,6 +6630,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4769,7 +6654,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -4816,6 +6700,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -4856,7 +6757,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -4906,11 +6806,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4976,7 +6881,6 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -5052,6 +6956,23 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -5063,6 +6984,49 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -5112,7 +7076,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-bigints": {
@@ -5132,7 +7095,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5239,6 +7201,19 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
@@ -5273,6 +7248,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/imurmurhash": {
@@ -5587,6 +7577,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5743,7 +7742,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -5764,6 +7762,37 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -5778,7 +7807,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5849,7 +7877,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -5883,7 +7910,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -6225,11 +8251,24 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/loader-runner": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -6265,7 +8304,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -6295,7 +8333,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -6317,6 +8354,13 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -6340,6 +8384,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/min-indent": {
@@ -6375,11 +8429,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6422,6 +8490,13 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/next": {
       "version": "16.2.2",
@@ -6523,11 +8598,52 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -6725,7 +8841,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -6741,7 +8856,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -6796,7 +8910,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6819,12 +8932,68 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6930,6 +9099,45 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6978,6 +9186,15 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6989,6 +9206,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -7111,10 +9334,22 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/resolve": {
@@ -7204,6 +9439,50 @@
         "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
         "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/rss-parser": {
@@ -7323,11 +9602,67 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7546,6 +9881,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7553,6 +9898,17 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/stable-hash": {
@@ -7568,6 +9924,18 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stacktrace-parser": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
+      "integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/std-env": {
       "version": "4.0.0",
@@ -7816,7 +10184,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
       "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7824,6 +10191,59 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
+      "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.5.0.tgz",
+      "integrity": "sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
       }
     },
     "node_modules/tinybench": {
@@ -8018,6 +10438,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+      "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -8208,7 +10637,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8452,6 +10880,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/watchpack": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -8460,6 +10902,88 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/webpack": {
+      "version": "5.106.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
+      "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.16.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.28.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.20.0",
+        "es-module-lexer": "^2.0.0",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "loader-runner": "^4.3.1",
+        "mime-db": "^1.54.0",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.17",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.3.4"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.0.tgz",
+      "integrity": "sha512-gHwIe1cgBvvfLeu1Yz/dcFpmHfKDVxxyqI+kzqmuxZED81z2ChxpyqPaWcNqigPywhaEke7AjSGga+kxY55gjQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/webpack/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/whatwg-mimetype": {
@@ -8491,7 +11015,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8679,18 +11202,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "release:pr-summary": "node scripts/release/generate-pr-summary.mjs"
   },
   "dependencies": {
+    "@sentry/nextjs": "^10.50.0",
     "@supabase/ssr": "^0.10.0",
     "@supabase/supabase-js": "^2.101.1",
     "@vercel/analytics": "^2.0.1",

--- a/src/adapters/donors/registry.ts
+++ b/src/adapters/donors/registry.ts
@@ -85,6 +85,7 @@ function createRssIngestionAdapter(donor: DonorId): IngestionAdapter<DonorFeed> 
           const articles = await context.fetchFeed(source.fetch.feedUrl, source.source, {
             timeoutMs: source.fetch.timeoutMs ?? context.timeoutMs,
             retryCount: source.fetch.retryCount ?? context.retryCount,
+            feedId: source.id,
           });
 
           return articles.map((article) => ({

--- a/src/app/api/cron/fetch-news/route.test.ts
+++ b/src/app/api/cron/fetch-news/route.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const generateDailyBriefing = vi.fn();
 const persistSignalPostsForBriefing = vi.fn();
 const logServerEvent = vi.fn();
+const captureRssCronCheckIn = vi.fn((status: string) => status === "in_progress" ? "check-in-id" : undefined);
+const captureRssFailure = vi.fn();
 
 vi.mock("@/lib/data", () => ({
   generateDailyBriefing,
@@ -17,6 +19,12 @@ vi.mock("@/lib/observability", () => ({
     errorMessage: error instanceof Error ? error.message : String(error),
   }),
   logServerEvent,
+}));
+
+vi.mock("@/lib/observability/rss", () => ({
+  captureRssCronCheckIn,
+  captureRssFailure,
+  withRssSpan: vi.fn((_name, _phase, _attributes, callback) => callback()),
 }));
 
 function buildRequest(secret?: string) {
@@ -109,6 +117,36 @@ describe("/api/cron/fetch-news", () => {
       briefingDate: "2026-04-27",
       items: expect.any(Array),
     });
+    expect(captureRssCronCheckIn).toHaveBeenCalledWith("in_progress");
+    expect(captureRssCronCheckIn).toHaveBeenCalledWith("ok", "check-in-id", expect.any(Number));
+  });
+
+  it("captures editorial storage failures as RSS store failures", async () => {
+    persistSignalPostsForBriefing.mockResolvedValue({
+      ok: false,
+      briefingDate: "2026-04-27",
+      insertedCount: 0,
+      message: "The current Top 5 could not be persisted for editing.",
+    });
+
+    const { GET } = await import("@/app/api/cron/fetch-news/route");
+    const response = await GET(buildRequest("local-cron-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.success).toBe(false);
+    expect(captureRssFailure).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        failureType: "rss_cache_write_failed",
+        phase: "store",
+        extra: expect.objectContaining({
+          operation: "persist_signal_posts",
+          route: "/api/cron/fetch-news",
+        }),
+      }),
+    );
+    expect(captureRssCronCheckIn).toHaveBeenCalledWith("error", "check-in-id", expect.any(Number));
   });
 
   it("does not persist seed fallback output as editorial signal posts", async () => {
@@ -122,5 +160,13 @@ describe("/api/cron/fetch-news", () => {
     expect(body.summary.usedSeedFallback).toBe(true);
     expect(body.summary.message).toMatch(/seed data/i);
     expect(persistSignalPostsForBriefing).not.toHaveBeenCalled();
+    expect(captureRssFailure).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        failureType: "rss_refresh_job_failed",
+        phase: "refresh",
+      }),
+    );
+    expect(captureRssCronCheckIn).toHaveBeenCalledWith("error", "check-in-id", expect.any(Number));
   });
 });

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as Sentry from "@sentry/nextjs";
 import { AlertTriangle, RotateCcw } from "lucide-react";
 import Link from "next/link";
 import { useEffect } from "react";
@@ -11,6 +12,7 @@ type Props = {
 
 export default function Error({ error, reset }: Props) {
   useEffect(() => {
+    captureRouteError(error);
     console.error("Route error boundary triggered.", error);
   }, [error]);
 
@@ -55,4 +57,19 @@ export default function Error({ error, reset }: Props) {
       </div>
     </div>
   );
+}
+
+function captureRouteError(error: Error) {
+  Sentry.withScope((scope) => {
+    if (isRssRelatedRenderError(error)) {
+      scope.setTag("component", "rss");
+      scope.setTag("rss.phase", "render");
+    }
+
+    Sentry.captureException(error);
+  });
+}
+
+function isRssRelatedRenderError(error: Error) {
+  return /rss|feed|source|ingestion|briefing|signal_posts/i.test(error.message);
 }

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,8 +1,14 @@
 "use client";
 
+import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
+import { useEffect } from "react";
 
-export default function GlobalError() {
+export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
   return (
     <html lang="en">
       <body className="min-h-screen">

--- a/src/app/health/rss/route.test.ts
+++ b/src/app/health/rss/route.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const createSupabaseServiceRoleClient = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServiceRoleClient,
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  addBreadcrumb: vi.fn(),
+  captureCheckIn: vi.fn(),
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  flush: vi.fn(async () => true),
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  startSpan: vi.fn((_options, callback) => callback()),
+  withScope: vi.fn((callback) =>
+    callback({
+      setContext: vi.fn(),
+      setLevel: vi.fn(),
+      setTag: vi.fn(),
+    }),
+  ),
+}));
+
+function buildSignalPostClient(rows: Array<{ created_at: string | null; published_at: string | null }>) {
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        order: vi.fn(() => ({
+          limit: vi.fn(async () => ({
+            data: rows,
+            error: null,
+          })),
+        })),
+      })),
+    })),
+  };
+}
+
+describe("/health/rss", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    delete process.env.SENTRY_DSN;
+    (globalThis as typeof globalThis & { __bootUpRssRuntimeState?: unknown }).__bootUpRssRuntimeState = undefined;
+  });
+
+  it("returns 503 when no RSS fetch has succeeded and no persisted signal snapshot exists", async () => {
+    createSupabaseServiceRoleClient.mockReturnValue(null);
+    const { GET } = await import("@/app/health/rss/route");
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toMatchObject({
+      status: "failed",
+      rssBootOk: true,
+      lastSuccessfulFetchAt: null,
+      criticalFailure: true,
+    });
+  });
+
+  it("returns 200 when persisted cron output proves a recent successful RSS-backed run", async () => {
+    createSupabaseServiceRoleClient.mockReturnValue(buildSignalPostClient([
+      {
+        created_at: new Date().toISOString(),
+        published_at: null,
+      },
+    ]));
+    const { GET } = await import("@/app/health/rss/route");
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      status: "ok",
+      criticalFailure: false,
+      staleFeedsCount: 0,
+    });
+    expect(body.lastSuccessfulFetchAt).toEqual(expect.any(String));
+  });
+});

--- a/src/app/health/rss/route.ts
+++ b/src/app/health/rss/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+
+import {
+  captureRssFailure,
+  captureRssHealthFailureIfNeeded,
+  getRssHealthSnapshot,
+} from "@/lib/observability/rss";
+import { createSupabaseServiceRoleClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+type SignalPostHealthRow = {
+  created_at: string | null;
+  published_at: string | null;
+};
+
+export async function GET() {
+  const persisted = await loadPersistedRssFreshness();
+  const snapshot = getRssHealthSnapshot({
+    persistedLastSuccessfulFetchAt: persisted.lastSuccessfulFetchAt,
+    persistedFailure: persisted.failed,
+  });
+
+  captureRssHealthFailureIfNeeded(snapshot);
+
+  return NextResponse.json(
+    {
+      status: snapshot.status,
+      rssBootOk: snapshot.rssBootOk,
+      lastSuccessfulFetchAt: snapshot.lastSuccessfulFetchAt,
+      staleFeedsCount: snapshot.staleFeedsCount,
+      failedFeedsCount: snapshot.failedFeedsCount,
+      criticalFailure: snapshot.criticalFailure,
+      failures: snapshot.failures,
+    },
+    {
+      status: snapshot.status === "failed" ? 503 : 200,
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+}
+
+async function loadPersistedRssFreshness() {
+  const supabase = createSupabaseServiceRoleClient();
+
+  if (!supabase) {
+    return {
+      lastSuccessfulFetchAt: null,
+      failed: false,
+    };
+  }
+
+  const result = await supabase
+    .from("signal_posts")
+    .select("created_at, published_at")
+    .order("created_at", { ascending: false, nullsFirst: false })
+    .limit(20);
+
+  if (result.error) {
+    captureRssFailure(new Error(result.error.message), {
+      failureType: "rss_cache_read_failed",
+      phase: "healthcheck",
+      level: "error",
+      message: "RSS health endpoint could not read persisted signal post freshness.",
+    });
+
+    return {
+      lastSuccessfulFetchAt: null,
+      failed: true,
+    };
+  }
+
+  const rows = ((result.data ?? []) as SignalPostHealthRow[]);
+  const lastSuccessfulFetchAt = rows
+    .flatMap((row) => [row.created_at, row.published_at])
+    .filter((value): value is string => Boolean(value))
+    .sort((left, right) => Date.parse(right) - Date.parse(left))[0] ?? null;
+
+  return {
+    lastSuccessfulFetchAt,
+    failed: false,
+  };
+}

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,0 +1,43 @@
+import * as Sentry from "@sentry/nextjs";
+
+import {
+  readSentryDsn,
+  readSentryEnvironment,
+  readSentryRelease,
+  readSentryReplaysOnErrorSampleRate,
+  readSentryReplaysSessionSampleRate,
+  readSentryTracesSampleRate,
+  sanitizeBreadcrumb,
+  sanitizeSentryEvent,
+} from "@/lib/sentry-config";
+
+const dsn = readSentryDsn("client");
+
+if (dsn) {
+  Sentry.init({
+    dsn,
+    environment: readSentryEnvironment(),
+    release: readSentryRelease(),
+    sendDefaultPii: false,
+    tracesSampleRate: readSentryTracesSampleRate(),
+    enableLogs: true,
+    maxBreadcrumbs: 50,
+    integrations: [
+      Sentry.replayIntegration({
+        maskAllText: true,
+        maskAllInputs: true,
+        blockAllMedia: true,
+      }),
+    ],
+    replaysSessionSampleRate: readSentryReplaysSessionSampleRate(),
+    replaysOnErrorSampleRate: readSentryReplaysOnErrorSampleRate(),
+    beforeSend(event) {
+      return sanitizeSentryEvent(event);
+    },
+    beforeBreadcrumb(breadcrumb) {
+      return sanitizeBreadcrumb(breadcrumb);
+    },
+  });
+}
+
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,15 @@
+import * as Sentry from "@sentry/nextjs";
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("./sentry.server.config");
+    const { initializeRssMonitoringAtBoot } = await import("./lib/observability/rss");
+    await initializeRssMonitoringAtBoot();
+  }
+
+  if (process.env.NEXT_RUNTIME === "edge") {
+    await import("./sentry.edge.config");
+  }
+}
+
+export const onRequestError = Sentry.captureRequestError;

--- a/src/lib/cron/fetch-news.ts
+++ b/src/lib/cron/fetch-news.ts
@@ -1,5 +1,10 @@
 import { generateDailyBriefing } from "@/lib/data";
 import { errorContext, logServerEvent } from "@/lib/observability";
+import {
+  captureRssCronCheckIn,
+  captureRssFailure,
+  withRssSpan,
+} from "@/lib/observability/rss";
 import { persistSignalPostsForBriefing } from "@/lib/signals-editorial";
 
 export type DailyNewsCronRunSummary = {
@@ -40,6 +45,8 @@ function buildFailureResult(timestamp: string, message: string): DailyNewsCronRu
 
 export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
   const timestamp = new Date().toISOString();
+  const startedAtMs = Date.now();
+  const checkInId = captureRssCronCheckIn("in_progress");
 
   logServerEvent("info", "Daily news cron started", {
     route: "/api/cron/fetch-news",
@@ -47,7 +54,14 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
   });
 
   try {
-    const { briefing, publicRankedItems, pipelineRun } = await generateDailyBriefing();
+    const { briefing, publicRankedItems, pipelineRun } = await withRssSpan(
+      "rss.refresh",
+      "refresh",
+      {
+        route: "/api/cron/fetch-news",
+      },
+      () => generateDailyBriefing(),
+    );
     const briefingDate = briefing.briefingDate.slice(0, 10);
     const baseSummary = {
       briefingDate,
@@ -74,6 +88,20 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
         route: "/api/cron/fetch-news",
         ...result.summary,
       });
+      captureRssFailure(new Error(result.summary.message), {
+        failureType: "rss_refresh_job_failed",
+        phase: "refresh",
+        level: "error",
+        retryCount: pipelineRun.feed_failures.length,
+        message: result.summary.message,
+        extra: {
+          route: "/api/cron/fetch-news",
+          pipelineRunId: pipelineRun.run_id,
+          usedSeedFallback: true,
+          feedFailureCount: pipelineRun.feed_failures.length,
+        },
+      });
+      captureRssCronCheckIn("error", checkInId, durationSeconds(startedAtMs));
 
       return result;
     }
@@ -93,6 +121,19 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
         ...result.summary,
         briefingItemCount: briefing.items.length,
       });
+      captureRssFailure(new Error(result.summary.message), {
+        failureType: "rss_refresh_job_failed",
+        phase: "refresh",
+        level: "error",
+        message: result.summary.message,
+        extra: {
+          route: "/api/cron/fetch-news",
+          pipelineRunId: pipelineRun.run_id,
+          briefingItemCount: briefing.items.length,
+          feedFailureCount: pipelineRun.feed_failures.length,
+        },
+      });
+      captureRssCronCheckIn("error", checkInId, durationSeconds(startedAtMs));
 
       return result;
     }
@@ -116,6 +157,23 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
       ...result.summary,
     });
 
+    if (!snapshot.ok) {
+      captureRssFailure(new Error("RSS signal post persistence failed during daily refresh."), {
+        failureType: "rss_cache_write_failed",
+        phase: "store",
+        level: "error",
+        message: "RSS signal post persistence failed during daily refresh.",
+        extra: {
+          route: "/api/cron/fetch-news",
+          pipelineRunId: pipelineRun.run_id,
+          briefingDate,
+          operation: "persist_signal_posts",
+        },
+      });
+    }
+
+    captureRssCronCheckIn(snapshot.ok ? "ok" : "error", checkInId, durationSeconds(startedAtMs));
+
     return result;
   } catch (error) {
     const result = buildFailureResult(timestamp, "Daily news cron failed before completion.");
@@ -125,7 +183,21 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
       timestamp,
       ...errorContext(error),
     });
+    captureRssFailure(error, {
+      failureType: "rss_refresh_job_failed",
+      phase: "refresh",
+      level: "error",
+      message: result.summary.message,
+      extra: {
+        route: "/api/cron/fetch-news",
+      },
+    });
+    captureRssCronCheckIn("error", checkInId, durationSeconds(startedAtMs));
 
     return result;
   }
+}
+
+function durationSeconds(startedAtMs: number) {
+  return Number(((Date.now() - startedAtMs) / 1000).toFixed(3));
 }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -68,6 +68,7 @@ async function fetchFeedArticlesSafely(
     timeoutMs?: number;
     retryCount?: number;
     headers?: HeadersInit;
+    feedId?: string;
   } = {},
 ): Promise<FeedArticle[]> {
   const { fetchFeedArticles } = await import("@/lib/rss");
@@ -2548,6 +2549,7 @@ async function fetchSourceArticlesWithFallback(source: Source): Promise<SourceFe
         await fetchFeedArticlesSafely(attempt.feedUrl, source.name, {
           timeoutMs: attempt.timeoutMs,
           retryCount: attempt.retryCount,
+          feedId: source.id,
         }),
         attempt,
       );

--- a/src/lib/integration/subsystem-contracts.ts
+++ b/src/lib/integration/subsystem-contracts.ts
@@ -73,6 +73,7 @@ export interface IngestionFetchContext {
       timeoutMs?: number;
       retryCount?: number;
       headers?: HeadersInit;
+      feedId?: string;
     },
   ): Promise<FeedArticle[]>;
   timeoutMs: number;

--- a/src/lib/observability/rss.test.ts
+++ b/src/lib/observability/rss.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const captureException = vi.fn(() => "event-id");
+const captureMessage = vi.fn(() => "message-id");
+const captureCheckIn = vi.fn(() => "check-in-id");
+const addBreadcrumb = vi.fn();
+const flush = vi.fn(async () => true);
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+function createScope() {
+  return {
+    setLevel: vi.fn(),
+    setTag: vi.fn(),
+    setContext: vi.fn(),
+  };
+}
+
+const scope = createScope();
+
+vi.mock("@sentry/nextjs", () => ({
+  addBreadcrumb,
+  captureCheckIn,
+  captureException,
+  captureMessage,
+  flush,
+  logger,
+  startSpan: vi.fn((_options, callback) => callback()),
+  withScope: vi.fn((callback) => callback(scope)),
+}));
+
+describe("RSS Sentry observability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(scope, createScope());
+    delete process.env.SENTRY_DSN;
+    delete process.env.NEXT_PUBLIC_SENTRY_DSN;
+    delete process.env.RSS_CRON_MONITOR_SLUG;
+    (globalThis as typeof globalThis & { __bootUpRssRuntimeState?: unknown }).__bootUpRssRuntimeState = undefined;
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.doUnmock("@/adapters/donors");
+    vi.doUnmock("@/lib/source-manifest");
+    vi.restoreAllMocks();
+  });
+
+  it("does not call Sentry capture when no DSN is configured", async () => {
+    const { captureRssFailure } = await import("@/lib/observability/rss");
+
+    captureRssFailure(new Error("Feed request failed"), {
+      failureType: "rss_fetch_network_error",
+      phase: "fetch",
+      feedUrl: "https://example.com/rss?token=secret",
+      feedName: "Example",
+    });
+
+    expect(captureException).not.toHaveBeenCalled();
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+
+  it("captures classified RSS failures with bounded tags and sanitized context", async () => {
+    process.env.SENTRY_DSN = "https://public@example.ingest.sentry.io/1";
+    const { captureRssFailure } = await import("@/lib/observability/rss");
+
+    captureRssFailure(new Error("Feed request failed with status 429"), {
+      failureType: "rss_fetch_rate_limited",
+      phase: "fetch",
+      feedUrl: "https://feeds.example.com/rss.xml?api_key=secret",
+      feedId: "feed-1",
+      feedName: "Example Feed",
+      statusCode: 429,
+    });
+
+    expect(scope.setTag).toHaveBeenCalledWith("component", "rss");
+    expect(scope.setTag).toHaveBeenCalledWith("rss.failure_type", "rss_fetch_rate_limited");
+    expect(scope.setTag).toHaveBeenCalledWith("rss.phase", "fetch");
+    expect(scope.setTag).toHaveBeenCalledWith("rss.feed_host", "feeds.example.com");
+    expect(scope.setTag).toHaveBeenCalledWith("rss.feed_id", "feed-1");
+    expect(scope.setContext).toHaveBeenCalledWith(
+      "rss",
+      expect.objectContaining({
+        feed_url: "https://feeds.example.com/rss.xml",
+        status_code: 429,
+      }),
+    );
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it("classifies common fetch and parse failure shapes", async () => {
+    const { classifyRssFailure } = await import("@/lib/observability/rss");
+
+    expect(classifyRssFailure(Object.assign(new Error("aborted"), { name: "AbortError" }))).toBe("rss_fetch_timeout");
+    expect(classifyRssFailure(new Error("getaddrinfo ENOTFOUND feeds.example.com"))).toBe("rss_fetch_dns_error");
+    expect(classifyRssFailure(new Error("Feed request failed with status 500"))).toBe("rss_fetch_http_error");
+    expect(classifyRssFailure(new Error("unexpected close tag"))).toBe("rss_parse_invalid_xml");
+  });
+
+  it("reports failed health before any successful RSS fetch and ok after a fresh success", async () => {
+    const { getRssHealthSnapshot, recordRssFetchSuccess } = await import("@/lib/observability/rss");
+    const failed = getRssHealthSnapshot({ now: new Date("2026-04-27T10:00:00.000Z") });
+
+    expect(failed.status).toBe("failed");
+    expect(failed.criticalFailure).toBe(true);
+
+    recordRssFetchSuccess({
+      feedUrl: "https://feeds.example.com/rss.xml?token=secret",
+      feedId: "feed-1",
+      feedName: "Example Feed",
+      fetchedAt: "2026-04-27T09:55:00.000Z",
+    });
+
+    const ok = getRssHealthSnapshot({ now: new Date("2026-04-27T10:00:00.000Z") });
+
+    expect(ok.status).toBe("ok");
+    expect(ok.lastSuccessfulFetchAt).toBe("2026-04-27T09:55:00.000Z");
+    expect(ok.criticalFailure).toBe(false);
+  });
+
+  it("sends the single RSS cron monitor slug check-in when Sentry is configured", async () => {
+    process.env.SENTRY_DSN = "https://public@example.ingest.sentry.io/1";
+    process.env.RSS_CRON_MONITOR_SLUG = "rss-feed-refresh";
+    const { captureRssCronCheckIn } = await import("@/lib/observability/rss");
+
+    const checkInId = captureRssCronCheckIn("in_progress");
+    captureRssCronCheckIn("ok", checkInId, 1.25);
+
+    expect(captureCheckIn).toHaveBeenNthCalledWith(
+      1,
+      {
+        monitorSlug: "rss-feed-refresh",
+        status: "in_progress",
+      },
+      expect.objectContaining({
+        schedule: {
+          type: "crontab",
+          value: "0 10 * * *",
+        },
+      }),
+    );
+    expect(captureCheckIn).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        checkInId: "check-in-id",
+        duration: 1.25,
+        monitorSlug: "rss-feed-refresh",
+        status: "ok",
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("captures boot validation failures with RSS boot tags", async () => {
+    process.env.SENTRY_DSN = "https://public@example.ingest.sentry.io/1";
+    vi.resetModules();
+    vi.doMock("@/adapters/donors", () => ({
+      getDefaultDonorFeeds: () => [],
+      getProbationaryRuntimeFeeds: () => [],
+    }));
+    vi.doMock("@/lib/source-manifest", () => ({
+      getSourcesForPublicSurface: () => [],
+    }));
+    const { initializeRssMonitoringAtBoot, getRssHealthSnapshot } = await import("@/lib/observability/rss");
+
+    await initializeRssMonitoringAtBoot();
+
+    expect(scope.setTag).toHaveBeenCalledWith("component", "rss");
+    expect(scope.setTag).toHaveBeenCalledWith("rss.failure_type", "rss_config_missing");
+    expect(scope.setTag).toHaveBeenCalledWith("rss.phase", "boot");
+    expect(getRssHealthSnapshot({ persistedLastSuccessfulFetchAt: new Date().toISOString() }).bootStatus).toBe("degraded");
+  });
+});

--- a/src/lib/observability/rss.ts
+++ b/src/lib/observability/rss.ts
@@ -1,0 +1,736 @@
+import * as Sentry from "@sentry/nextjs";
+
+import { logServerEvent } from "@/lib/observability";
+import {
+  getUrlHost,
+  isSentryConfigured,
+  readSentryEnvironment,
+  sanitizeUrl,
+} from "@/lib/sentry-config";
+
+export const RSS_FAILURE_TYPES = [
+  "rss_config_missing",
+  "rss_config_invalid",
+  "rss_boot_init_failed",
+  "rss_fetch_timeout",
+  "rss_fetch_network_error",
+  "rss_fetch_dns_error",
+  "rss_fetch_tls_error",
+  "rss_fetch_http_error",
+  "rss_fetch_rate_limited",
+  "rss_fetch_unexpected_status",
+  "rss_fetch_empty_response",
+  "rss_fetch_invalid_content_type",
+  "rss_parse_invalid_xml",
+  "rss_parse_invalid_feed",
+  "rss_parse_missing_required_fields",
+  "rss_parse_empty_feed",
+  "rss_cache_read_failed",
+  "rss_cache_write_failed",
+  "rss_retry_exhausted",
+  "rss_refresh_job_failed",
+  "rss_feed_stale",
+  "rss_unknown_error",
+] as const;
+
+export type RssFailureType = (typeof RSS_FAILURE_TYPES)[number];
+export type RssPhase =
+  | "boot"
+  | "fetch"
+  | "parse"
+  | "cache"
+  | "store"
+  | "publish"
+  | "refresh"
+  | "healthcheck"
+  | "render";
+export type RssCaptureLevel = "warning" | "error" | "fatal";
+
+type RssFailureContext = {
+  failureType?: RssFailureType;
+  phase: RssPhase;
+  feedUrl?: string;
+  feedName?: string;
+  feedId?: string;
+  statusCode?: number;
+  retryCount?: number;
+  retryAttempt?: number;
+  timeoutMs?: number;
+  parser?: string;
+  boot?: boolean;
+  staleThresholdMs?: number;
+  level?: RssCaptureLevel;
+  message?: string;
+  durationMs?: number;
+  extra?: Record<string, unknown>;
+};
+
+type RssFailureSnapshot = {
+  failure_type: RssFailureType;
+  phase: RssPhase;
+  feed_host: string;
+  feed_id: string | null;
+  feed_name: string | null;
+  status_code?: number;
+  retry_count?: number;
+  timeout_ms?: number;
+  level: RssCaptureLevel;
+  last_seen_at: string;
+};
+
+type RssFeedHealth = {
+  feed_host: string;
+  feed_id: string | null;
+  feed_name: string | null;
+  last_successful_fetch_at: string | null;
+  last_failure_at: string | null;
+  last_failure_type: RssFailureType | null;
+  critical: boolean;
+};
+
+type RssRuntimeState = {
+  bootStartedAt: string | null;
+  bootCompletedAt: string | null;
+  bootStatus: "unknown" | "ok" | "degraded" | "failed";
+  criticalFailure: boolean;
+  lastSuccessfulFetchAt: string | null;
+  lastHealthFailureCapturedAt: string | null;
+  failures: RssFailureSnapshot[];
+  feeds: Map<string, RssFeedHealth>;
+};
+
+declare global {
+  var __bootUpRssRuntimeState: RssRuntimeState | undefined;
+}
+
+const CAPTURED_RSS_ERROR = Symbol.for("bootup.rss.sentryCaptured");
+const DEFAULT_STALE_THRESHOLD_MS = 30 * 60 * 60 * 1000;
+const MAX_FAILURES = 25;
+const RSS_CRON_MONITOR_SCHEDULE = "0 10 * * *";
+
+export class RssError extends Error {
+  failureType: RssFailureType;
+  phase: RssPhase;
+  feedUrl?: string;
+  feedName?: string;
+  feedId?: string;
+  statusCode?: number;
+  retryCount?: number;
+  retryAttempt?: number;
+  timeoutMs?: number;
+
+  constructor(message: string, context: RssFailureContext) {
+    super(message);
+    this.name = "RssError";
+    this.failureType = context.failureType ?? "rss_unknown_error";
+    this.phase = context.phase;
+    this.feedUrl = context.feedUrl;
+    this.feedName = context.feedName;
+    this.feedId = context.feedId;
+    this.statusCode = context.statusCode;
+    this.retryCount = context.retryCount;
+    this.retryAttempt = context.retryAttempt;
+    this.timeoutMs = context.timeoutMs;
+  }
+}
+
+export function createRssError(message: string, context: RssFailureContext) {
+  return new RssError(message, context);
+}
+
+function getRuntimeState() {
+  globalThis.__bootUpRssRuntimeState ??= {
+    bootStartedAt: null,
+    bootCompletedAt: null,
+    bootStatus: "unknown",
+    criticalFailure: false,
+    lastSuccessfulFetchAt: null,
+    lastHealthFailureCapturedAt: null,
+    failures: [],
+    feeds: new Map<string, RssFeedHealth>(),
+  };
+
+  return globalThis.__bootUpRssRuntimeState;
+}
+
+function getFeedKey(context: {
+  feedUrl?: string;
+  feedHost?: string;
+  feedName?: string;
+  feedId?: string;
+}) {
+  return context.feedId || context.feedHost || getUrlHost(context.feedUrl) || context.feedName || "rss-feed";
+}
+
+function registerFeed(context: {
+  feedUrl?: string;
+  feedHost?: string;
+  feedName?: string;
+  feedId?: string;
+  critical?: boolean;
+}) {
+  const state = getRuntimeState();
+  const feedHost = context.feedHost || getUrlHost(context.feedUrl) || "unknown";
+  const key = getFeedKey({ ...context, feedHost });
+  const existing = state.feeds.get(key);
+
+  state.feeds.set(key, {
+    feed_host: feedHost,
+    feed_id: context.feedId ?? existing?.feed_id ?? null,
+    feed_name: context.feedName ?? existing?.feed_name ?? null,
+    last_successful_fetch_at: existing?.last_successful_fetch_at ?? null,
+    last_failure_at: existing?.last_failure_at ?? null,
+    last_failure_type: existing?.last_failure_type ?? null,
+    critical: context.critical ?? existing?.critical ?? true,
+  });
+}
+
+export function recordRssFetchSuccess(context: {
+  feedUrl?: string;
+  feedName?: string;
+  feedId?: string;
+  fetchedAt?: string;
+}) {
+  const state = getRuntimeState();
+  const fetchedAt = context.fetchedAt ?? new Date().toISOString();
+  const feedHost = getUrlHost(context.feedUrl) || "unknown";
+  const key = getFeedKey({ ...context, feedHost });
+  const existing = state.feeds.get(key);
+
+  state.lastSuccessfulFetchAt = latestTimestamp(state.lastSuccessfulFetchAt, fetchedAt);
+  state.feeds.set(key, {
+    feed_host: feedHost,
+    feed_id: context.feedId ?? existing?.feed_id ?? null,
+    feed_name: context.feedName ?? existing?.feed_name ?? null,
+    last_successful_fetch_at: fetchedAt,
+    last_failure_at: existing?.last_failure_at ?? null,
+    last_failure_type: existing?.last_failure_type ?? null,
+    critical: existing?.critical ?? true,
+  });
+}
+
+function recordRssFailure(context: Required<Pick<RssFailureContext, "phase">> & RssFailureContext) {
+  const state = getRuntimeState();
+  const failureType = context.failureType ?? "rss_unknown_error";
+  const level = context.level ?? levelForFailure(failureType);
+  const lastSeenAt = new Date().toISOString();
+  const feedHost = getUrlHost(context.feedUrl) || "unknown";
+  const key = getFeedKey({ ...context, feedHost });
+  const existing = state.feeds.get(key);
+  const failure: RssFailureSnapshot = {
+    failure_type: failureType,
+    phase: context.phase,
+    feed_host: feedHost,
+    feed_id: context.feedId ?? existing?.feed_id ?? null,
+    feed_name: context.feedName ?? existing?.feed_name ?? null,
+    level,
+    last_seen_at: lastSeenAt,
+  };
+
+  if (context.statusCode) {
+    failure.status_code = context.statusCode;
+  }
+
+  if (typeof context.retryCount === "number") {
+    failure.retry_count = context.retryCount;
+  }
+
+  if (typeof context.timeoutMs === "number") {
+    failure.timeout_ms = context.timeoutMs;
+  }
+
+  state.failures = [failure, ...state.failures].slice(0, MAX_FAILURES);
+  state.feeds.set(key, {
+    feed_host: feedHost,
+    feed_id: failure.feed_id,
+    feed_name: failure.feed_name,
+    last_successful_fetch_at: existing?.last_successful_fetch_at ?? null,
+    last_failure_at: lastSeenAt,
+    last_failure_type: failureType,
+    critical: existing?.critical ?? true,
+  });
+
+  if (level === "fatal") {
+    state.criticalFailure = true;
+  }
+}
+
+export function classifyRssFailure(error: unknown, fallback: RssFailureType = "rss_unknown_error"): RssFailureType {
+  if (error instanceof RssError) {
+    return error.failureType;
+  }
+
+  if (!(error instanceof Error)) {
+    return fallback;
+  }
+
+  const message = error.message.toLowerCase();
+  const errorWithCause = error as Error & { cause?: { code?: string } };
+  const causeCode = errorWithCause.cause?.code?.toLowerCase() ?? "";
+
+  if (error.name === "AbortError" || /timed out|timeout/.test(message)) {
+    return "rss_fetch_timeout";
+  }
+
+  if (/enotfound|eai_again|getaddrinfo|dns/.test(message) || /enotfound|eai_again/.test(causeCode)) {
+    return "rss_fetch_dns_error";
+  }
+
+  if (/tls|ssl|certificate|cert_has_expired|self[- ]signed/.test(message) || /tls|ssl|cert/.test(causeCode)) {
+    return "rss_fetch_tls_error";
+  }
+
+  if (/status 429|rate limit|too many requests/.test(message)) {
+    return "rss_fetch_rate_limited";
+  }
+
+  if (/status [45]\d\d|http/.test(message)) {
+    return "rss_fetch_http_error";
+  }
+
+  if (/fetch failed|network|econnrefused|econnreset|socket|und_err/.test(message) || causeCode.startsWith("econn")) {
+    return "rss_fetch_network_error";
+  }
+
+  if (/empty response|zero bytes/.test(message)) {
+    return "rss_fetch_empty_response";
+  }
+
+  if (/content-type|content type/.test(message)) {
+    return "rss_fetch_invalid_content_type";
+  }
+
+  if (/xml|non-whitespace before first tag|unexpected close tag|unclosed root tag/.test(message)) {
+    return "rss_parse_invalid_xml";
+  }
+
+  if (/invalid feed|missing channel|missing rss|missing atom/.test(message)) {
+    return "rss_parse_invalid_feed";
+  }
+
+  if (/missing required/.test(message)) {
+    return "rss_parse_missing_required_fields";
+  }
+
+  if (/empty feed|zero articles|no items/.test(message)) {
+    return "rss_parse_empty_feed";
+  }
+
+  return fallback;
+}
+
+export function captureRssFailure(error: unknown, context: RssFailureContext) {
+  const failureType = context.failureType ?? classifyRssFailure(error);
+  const normalizedContext = normalizeRssContext({
+    ...context,
+    failureType,
+    level: context.level ?? levelForFailure(failureType),
+  });
+
+  recordRssFailure(normalizedContext);
+  logRssEvent(
+    normalizedContext.level === "warning" ? "warn" : "error",
+    normalizedContext.message || "RSS failure captured",
+    normalizedContext,
+  );
+
+  if (isMarkedCaptured(error) || !isSentryConfigured("server")) {
+    return null;
+  }
+
+  markCaptured(error);
+
+  return Sentry.withScope((scope) => {
+    scope.setLevel(normalizedContext.level);
+    scope.setTag("component", "rss");
+    scope.setTag("rss.failure_type", failureType);
+    scope.setTag("rss.phase", normalizedContext.phase);
+    scope.setTag("rss.feed_host", normalizedContext.feed_host);
+
+    if (normalizedContext.feed_id) {
+      scope.setTag("rss.feed_id", normalizedContext.feed_id);
+    }
+
+    if (normalizedContext.feed_name) {
+      scope.setTag("rss.feed_name", normalizedContext.feed_name);
+    }
+
+    scope.setTag("environment", readSentryEnvironment());
+    scope.setContext("rss", normalizedContext);
+
+    if (error instanceof Error) {
+      return Sentry.captureException(error);
+    }
+
+    return Sentry.captureMessage(normalizedContext.message || String(error), normalizedContext.level);
+  });
+}
+
+export function addRssBreadcrumb(message: string, context: Record<string, unknown> = {}) {
+  logRssEvent("info", message, context);
+
+  if (!isSentryConfigured("server")) {
+    return;
+  }
+
+  Sentry.addBreadcrumb({
+    category: "rss",
+    level: "info",
+    message,
+    data: context,
+  });
+}
+
+export async function withRssSpan<T>(
+  name: string,
+  phase: RssPhase,
+  attributes: Record<string, string | number | boolean | null | undefined>,
+  callback: () => Promise<T>,
+) {
+  if (!isSentryConfigured("server")) {
+    return callback();
+  }
+
+  return Sentry.startSpan(
+    {
+      name,
+      op: `rss.${phase}`,
+      attributes: Object.fromEntries(
+        Object.entries(attributes).filter((entry): entry is [string, string | number | boolean] => {
+          const value = entry[1];
+          return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+        }),
+      ),
+    },
+    callback,
+  );
+}
+
+export function captureRssCronCheckIn(
+  status: "in_progress" | "ok" | "error",
+  checkInId?: string,
+  duration?: number,
+) {
+  if (!isSentryConfigured("server")) {
+    return undefined;
+  }
+
+  const monitorSlug = process.env.RSS_CRON_MONITOR_SLUG?.trim() || "rss-feed-refresh";
+  const checkIn: Parameters<typeof Sentry.captureCheckIn>[0] =
+    status === "in_progress"
+      ? {
+          monitorSlug,
+          status,
+        }
+      : checkInId
+        ? {
+            monitorSlug,
+            status,
+            checkInId,
+            ...(typeof duration === "number" ? { duration } : {}),
+          }
+        : {
+            monitorSlug,
+            status,
+          };
+
+  return Sentry.captureCheckIn(
+    checkIn,
+    {
+      schedule: {
+        type: "crontab",
+        value: RSS_CRON_MONITOR_SCHEDULE,
+      },
+      checkinMargin: 10,
+      maxRuntime: 20,
+      timezone: "UTC",
+      failureIssueThreshold: 1,
+      recoveryThreshold: 1,
+    },
+  );
+}
+
+export async function flushRssTelemetry(timeoutMs = 2000) {
+  if (!isSentryConfigured("server")) {
+    return true;
+  }
+
+  return Sentry.flush(timeoutMs);
+}
+
+export async function initializeRssMonitoringAtBoot() {
+  const state = getRuntimeState();
+  const startedAt = new Date().toISOString();
+  state.bootStartedAt = startedAt;
+  addRssBreadcrumb("rss boot started", { phase: "boot", bootStartedAt: startedAt });
+
+  try {
+    await withRssSpan("rss.boot", "boot", { "rss.boot": true }, async () => {
+      const [{ getDefaultDonorFeeds, getProbationaryRuntimeFeeds }, { getSourcesForPublicSurface }] =
+        await Promise.all([
+          import("@/adapters/donors"),
+          import("@/lib/source-manifest"),
+        ]);
+      const feeds = [
+        ...getDefaultDonorFeeds().map((feed) => ({
+          feedId: feed.id,
+          feedName: feed.source,
+          feedUrl: feed.fetch.feedUrl,
+        })),
+        ...getProbationaryRuntimeFeeds().map((feed) => ({
+          feedId: feed.id,
+          feedName: feed.source,
+          feedUrl: feed.fetch.feedUrl,
+        })),
+        ...getSourcesForPublicSurface("public.home").map((source) => ({
+          feedId: source.id,
+          feedName: source.name,
+          feedUrl: source.feedUrl,
+        })),
+      ];
+
+      if (feeds.length === 0) {
+        throw createRssError("RSS boot validation found no configured feeds.", {
+          failureType: "rss_config_missing",
+          phase: "boot",
+          boot: true,
+          level: "error",
+        });
+      }
+
+      const invalidFeeds = feeds.filter((feed) => !isValidFeedUrl(feed.feedUrl));
+
+      feeds.forEach((feed) => registerFeed({ ...feed, critical: true }));
+
+      if (invalidFeeds.length > 0) {
+        throw createRssError("RSS boot validation found invalid feed configuration.", {
+          failureType: "rss_config_invalid",
+          phase: "boot",
+          boot: true,
+          feedId: invalidFeeds[0]?.feedId,
+          feedName: invalidFeeds[0]?.feedName,
+          feedUrl: invalidFeeds[0]?.feedUrl,
+          level: "error",
+          extra: {
+            invalidFeedCount: invalidFeeds.length,
+          },
+        });
+      }
+    });
+
+    const completedAt = new Date().toISOString();
+    state.bootCompletedAt = completedAt;
+    state.bootStatus = "ok";
+    addRssBreadcrumb("rss boot succeeded", { phase: "boot", bootCompletedAt: completedAt });
+  } catch (error) {
+    const completedAt = new Date().toISOString();
+    state.bootCompletedAt = completedAt;
+    state.bootStatus = "degraded";
+    captureRssFailure(error, {
+      failureType: classifyRssFailure(error, "rss_boot_init_failed"),
+      phase: "boot",
+      boot: true,
+      level: "error",
+      message: "RSS boot failed; app will continue with persisted or fallback data where available.",
+    });
+    addRssBreadcrumb("rss boot failed", { phase: "boot", bootCompletedAt: completedAt });
+  }
+}
+
+export function getRssHealthSnapshot(input: {
+  now?: Date;
+  persistedLastSuccessfulFetchAt?: string | null;
+  persistedFailure?: boolean;
+} = {}) {
+  const state = getRuntimeState();
+  const now = input.now ?? new Date();
+  const staleThresholdMs = readStaleThresholdMs();
+  const effectiveLastSuccessfulFetchAt = latestTimestamp(
+    state.lastSuccessfulFetchAt,
+    input.persistedLastSuccessfulFetchAt ?? null,
+  );
+  const effectiveLastSuccessMs = Date.parse(effectiveLastSuccessfulFetchAt ?? "");
+  const hasSuccessfulFetch = Number.isFinite(effectiveLastSuccessMs);
+  const isGloballyStale = !hasSuccessfulFetch || now.getTime() - effectiveLastSuccessMs > staleThresholdMs;
+  const feeds = [...state.feeds.values()];
+  const staleFeeds = feeds.filter((feed) => {
+    if (!feed.last_successful_fetch_at && hasSuccessfulFetch && !isGloballyStale) {
+      return false;
+    }
+
+    const timestamp = Date.parse(feed.last_successful_fetch_at ?? "");
+    return !Number.isFinite(timestamp) || now.getTime() - timestamp > staleThresholdMs;
+  });
+  const recentFailedFeeds = new Set(
+    state.failures
+      .filter((failure) => now.getTime() - Date.parse(failure.last_seen_at) <= staleThresholdMs)
+      .map((failure) => getFeedKey({ feedHost: failure.feed_host, feedId: failure.feed_id ?? undefined })),
+  );
+  const criticalFailure =
+    state.criticalFailure ||
+    Boolean(input.persistedFailure) ||
+    !hasSuccessfulFetch ||
+    (isGloballyStale && (feeds.length === 0 || staleFeeds.length === feeds.length));
+  const status = criticalFailure ? "failed" : staleFeeds.length > 0 || recentFailedFeeds.size > 0 ? "degraded" : "ok";
+
+  return {
+    status,
+    rssBootOk: state.bootStatus !== "failed",
+    bootStatus: state.bootStatus,
+    bootStartedAt: state.bootStartedAt,
+    bootCompletedAt: state.bootCompletedAt,
+    lastSuccessfulFetchAt: effectiveLastSuccessfulFetchAt,
+    staleFeedsCount: isGloballyStale && staleFeeds.length === 0 ? 1 : staleFeeds.length,
+    failedFeedsCount: recentFailedFeeds.size,
+    criticalFailure,
+    staleThresholdMs,
+    failures: state.failures.slice(0, 10).map((failure) => ({
+      failure_type: failure.failure_type,
+      phase: failure.phase,
+      feed_host: failure.feed_host,
+      feed_id: failure.feed_id,
+      feed_name: failure.feed_name,
+      status_code: failure.status_code,
+      retry_count: failure.retry_count,
+      timeout_ms: failure.timeout_ms,
+      last_seen_at: failure.last_seen_at,
+    })),
+  };
+}
+
+export function captureRssHealthFailureIfNeeded(snapshot: ReturnType<typeof getRssHealthSnapshot>) {
+  if (snapshot.status !== "failed") {
+    return;
+  }
+
+  const state = getRuntimeState();
+  const nowMs = Date.now();
+  const lastCapturedMs = Date.parse(state.lastHealthFailureCapturedAt ?? "");
+
+  if (Number.isFinite(lastCapturedMs) && nowMs - lastCapturedMs < 15 * 60 * 1000) {
+    return;
+  }
+
+  state.lastHealthFailureCapturedAt = new Date(nowMs).toISOString();
+  captureRssFailure(new Error("RSS health endpoint reports failed feed health."), {
+    failureType: "rss_feed_stale",
+    phase: "healthcheck",
+    level: "error",
+    staleThresholdMs: snapshot.staleThresholdMs,
+    message: "RSS health endpoint reports failed feed health.",
+    extra: {
+      lastSuccessfulFetchAt: snapshot.lastSuccessfulFetchAt,
+      staleFeedsCount: snapshot.staleFeedsCount,
+      failedFeedsCount: snapshot.failedFeedsCount,
+      criticalFailure: snapshot.criticalFailure,
+    },
+  });
+}
+
+function normalizeRssContext(context: RssFailureContext & { failureType: RssFailureType; level: RssCaptureLevel }) {
+  const feedHost = getUrlHost(context.feedUrl) || "unknown";
+
+  return {
+    component: "rss",
+    phase: context.phase,
+    failureType: context.failureType,
+    failure_type: context.failureType,
+    feed_host: feedHost,
+    feed_url: context.feedUrl ? sanitizeUrl(context.feedUrl) : undefined,
+    feed_id: context.feedId,
+    feed_name: context.feedName,
+    status_code: context.statusCode,
+    retry_count: context.retryCount,
+    retry_attempt: context.retryAttempt,
+    timeout_ms: context.timeoutMs,
+    parser: context.parser,
+    boot: context.boot,
+    stale_threshold_ms: context.staleThresholdMs,
+    duration_ms: context.durationMs,
+    level: context.level,
+    message: context.message,
+    environment: readSentryEnvironment(),
+    ...context.extra,
+  };
+}
+
+function levelForFailure(failureType: RssFailureType): RssCaptureLevel {
+  if (failureType === "rss_boot_init_failed") {
+    return "error";
+  }
+
+  if (
+    failureType === "rss_retry_exhausted" ||
+    failureType === "rss_refresh_job_failed" ||
+    failureType === "rss_feed_stale" ||
+    failureType.startsWith("rss_parse") ||
+    failureType.startsWith("rss_cache")
+  ) {
+    return "error";
+  }
+
+  return "warning";
+}
+
+function logRssEvent(level: "info" | "warn" | "error", message: string, context: Record<string, unknown>) {
+  logServerEvent(level, message, context);
+
+  if (!isSentryConfigured("server")) {
+    return;
+  }
+
+  if (level === "error") {
+    Sentry.logger.error(message, context);
+    return;
+  }
+
+  if (level === "warn") {
+    Sentry.logger.warn(message, context);
+    return;
+  }
+
+  Sentry.logger.info(message, context);
+}
+
+function isMarkedCaptured(error: unknown) {
+  return typeof error === "object" && error !== null && Boolean((error as Record<symbol, unknown>)[CAPTURED_RSS_ERROR]);
+}
+
+function markCaptured(error: unknown) {
+  if (typeof error === "object" && error !== null) {
+    Object.defineProperty(error, CAPTURED_RSS_ERROR, {
+      value: true,
+      enumerable: false,
+    });
+  }
+}
+
+function latestTimestamp(left: string | null, right: string | null) {
+  if (!left) {
+    return right;
+  }
+
+  if (!right) {
+    return left;
+  }
+
+  return Date.parse(right) > Date.parse(left) ? right : left;
+}
+
+function readStaleThresholdMs() {
+  const parsed = Number.parseInt(process.env.RSS_STALE_THRESHOLD_MS ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_STALE_THRESHOLD_MS;
+}
+
+function isValidFeedUrl(feedUrl: string | undefined) {
+  if (!feedUrl?.trim()) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(feedUrl);
+    return ["http:", "https:", "newsapi:", "thenewsapi:"].includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/pipeline/ingestion/index.ts
+++ b/src/lib/pipeline/ingestion/index.ts
@@ -9,11 +9,13 @@ import {
 import type { SourceDefinition } from "@/lib/integration/subsystem-contracts";
 import type { RawItem } from "@/lib/models/raw-item";
 import { logPipelineEvent } from "@/lib/observability/logger";
+import { captureRssFailure, classifyRssFailure } from "@/lib/observability/rss";
 import {
   buildRuntimeSourceResolutionSnapshot,
   type RuntimeSourceResolutionSnapshot,
 } from "@/lib/observability/pipeline-run";
 import { fetchFeedArticles } from "@/lib/rss";
+import { sanitizeUrl } from "@/lib/sentry-config";
 import { cleanText, stableId } from "@/lib/pipeline/shared/text";
 
 import { seedRawItems } from "./seed-items";
@@ -217,10 +219,21 @@ export async function ingestRawItems(options: {
       } catch (error) {
         const failure = {
           source: source.source,
-          feedUrl: source.fetch.feedUrl,
+          feedUrl: sanitizeUrl(source.fetch.feedUrl),
           error: error instanceof Error ? error.message : String(error),
         };
         failures.push(failure);
+        captureRssFailure(error, {
+          failureType: classifyRssFailure(error),
+          phase: "fetch",
+          feedUrl: source.fetch.feedUrl,
+          feedName: source.source,
+          feedId: source.sourceId,
+          retryCount: source.fetch.retryCount,
+          timeoutMs: source.fetch.timeoutMs,
+          level: "warning",
+          message: "RSS source ingestion failed; pipeline will continue when other sources succeed.",
+        });
         logPipelineEvent("warn", "Feed ingestion failed", failure);
         return [];
       }

--- a/src/lib/rss.test.ts
+++ b/src/lib/rss.test.ts
@@ -76,6 +76,119 @@ describe("fetchFeedArticles", () => {
     );
   });
 
+  it("classifies HTTP 500 as an RSS fetch HTTP error", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("server error", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchFeedArticles("https://example.com/feed.xml", "Broken Feed", { retryCount: 0 }),
+    ).rejects.toMatchObject({
+      failureType: "rss_fetch_http_error",
+    });
+  });
+
+  it("classifies HTTP 404 as an RSS fetch HTTP error", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("not found", { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchFeedArticles("https://example.com/feed.xml", "Missing Feed", { retryCount: 0 }),
+    ).rejects.toMatchObject({
+      failureType: "rss_fetch_http_error",
+    });
+  });
+
+  it("classifies HTTP 429 as an RSS fetch rate-limit error", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("rate limited", { status: 429 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchFeedArticles("https://example.com/feed.xml", "Limited Feed", { retryCount: 0 }),
+    ).rejects.toMatchObject({
+      failureType: "rss_fetch_rate_limited",
+    });
+  });
+
+  it("classifies retry exhaustion after retryable failures", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("busy", { status: 503 }))
+      .mockResolvedValueOnce(new Response("still busy", { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchFeedArticles("https://example.com/feed.xml", "Busy Feed", { retryCount: 1 }),
+    ).rejects.toMatchObject({
+      failureType: "rss_retry_exhausted",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("classifies an empty response body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchFeedArticles("https://example.com/feed.xml", "Empty Feed")).rejects.toMatchObject({
+      failureType: "rss_fetch_empty_response",
+    });
+  });
+
+  it("classifies invalid XML", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("<rss><channel>", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchFeedArticles("https://example.com/feed.xml", "Invalid XML Feed")).rejects.toMatchObject({
+      failureType: "rss_parse_invalid_xml",
+    });
+  });
+
+  it("classifies an empty RSS feed", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(`
+      <rss version="2.0">
+        <channel>
+          <title>Empty Feed</title>
+        </channel>
+      </rss>
+    `, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchFeedArticles("https://example.com/feed.xml", "Empty RSS Feed")).rejects.toMatchObject({
+      failureType: "rss_parse_empty_feed",
+    });
+  });
+
+  it("classifies feeds where items are missing required fields", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(`
+      <rss version="2.0">
+        <channel>
+          <title>Invalid Feed</title>
+          <item>
+            <description>No title or link</description>
+          </item>
+        </channel>
+      </rss>
+    `, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchFeedArticles("https://example.com/feed.xml", "Invalid Feed")).rejects.toMatchObject({
+      failureType: "rss_parse_missing_required_fields",
+    });
+  });
+
+  it("classifies invalid RSS content types", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+      },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchFeedArticles("https://example.com/feed.xml", "JSON Feed")).rejects.toMatchObject({
+      failureType: "rss_fetch_invalid_content_type",
+    });
+  });
+
   it("expands non-tech TLDR digest feeds into discovery candidates", async () => {
     const fetchMock = vi
       .fn()

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -1,6 +1,16 @@
 import Parser from "rss-parser";
 
 import { env } from "@/lib/env";
+import {
+  captureRssFailure,
+  classifyRssFailure,
+  createRssError,
+  recordRssFetchSuccess,
+  withRssSpan,
+  type RssFailureType,
+  type RssPhase,
+} from "@/lib/observability/rss";
+import { getUrlHost } from "@/lib/sentry-config";
 import { fetchTldrFeed, isTldrFeedUrl, type TldrDiscoveryMetadata } from "@/lib/tldr";
 import { stripHtml } from "@/lib/utils";
 
@@ -23,9 +33,58 @@ type FeedRequestOptions = {
   timeoutMs?: number;
   retryCount?: number;
   headers?: HeadersInit;
+  feedId?: string;
 };
 
 export async function fetchFeedArticles(
+  feedUrl: string,
+  sourceName: string,
+  requestOptions: FeedRequestOptions = {},
+) {
+  return withRssSpan(
+    "rss.fetch",
+    "fetch",
+    {
+      "rss.feed_host": getUrlHost(feedUrl),
+      "rss.feed_name": sourceName,
+    },
+    async () => {
+      try {
+        const articles = await fetchFeedArticlesUnchecked(feedUrl, sourceName, requestOptions);
+
+        if (articles.length === 0) {
+          throw createRssError(`Feed returned zero articles for ${sourceName}`, {
+            failureType: "rss_parse_empty_feed",
+            phase: "parse",
+            feedUrl,
+            feedName: sourceName,
+            feedId: requestOptions.feedId,
+            parser: "rss-parser",
+          });
+        }
+
+        recordRssFetchSuccess({ feedUrl, feedName: sourceName, feedId: requestOptions.feedId });
+        return articles;
+      } catch (error) {
+        captureRssFailure(error, {
+          failureType: classifyRssFailure(error),
+          phase: error instanceof Error && error.name === "RssError" && "phase" in error
+            ? error.phase as RssPhase
+            : "fetch",
+          feedUrl,
+          feedName: sourceName,
+          feedId: requestOptions.feedId,
+          retryCount: requestOptions.retryCount,
+          timeoutMs: requestOptions.timeoutMs,
+          parser: "rss-parser",
+        });
+        throw error;
+      }
+    },
+  );
+}
+
+async function fetchFeedArticlesUnchecked(
   feedUrl: string,
   sourceName: string,
   requestOptions: FeedRequestOptions = {},
@@ -50,18 +109,84 @@ export async function fetchFeedArticles(
     },
   }, sourceName);
 
+  assertRssContentType(response, feedUrl, sourceName);
+
   const xml = await response.text();
+
+  if (!xml.trim()) {
+    throw createRssError(`Feed returned an empty response for ${sourceName}`, {
+      failureType: "rss_fetch_empty_response",
+      phase: "fetch",
+      feedUrl,
+      feedName: sourceName,
+      feedId: requestOptions.feedId,
+    });
+  }
+
   let feed;
 
   try {
-    feed = await parser.parseString(xml);
+    feed = await withRssSpan(
+      "rss.parse",
+      "parse",
+      {
+        "rss.feed_host": getUrlHost(feedUrl),
+        "rss.feed_name": sourceName,
+      },
+      () => parser.parseString(xml),
+    );
   } catch (error) {
-    throw new Error(
+    throw createRssError(
       `Feed parsing failed for ${sourceName}: ${error instanceof Error ? error.message : String(error)}`,
+      {
+        failureType: "rss_parse_invalid_xml",
+        phase: "parse",
+        feedUrl,
+        feedName: sourceName,
+        feedId: requestOptions.feedId,
+        parser: "rss-parser",
+      },
     );
   }
 
-  return (feed.items ?? []).slice(0, 15).map<FeedArticle>((item, index) => ({
+  const items = feed.items ?? [];
+
+  if (!Array.isArray(items)) {
+    throw createRssError(`Feed parsing failed for ${sourceName}: invalid feed item structure`, {
+      failureType: "rss_parse_invalid_feed",
+      phase: "parse",
+      feedUrl,
+      feedName: sourceName,
+      feedId: requestOptions.feedId,
+      parser: "rss-parser",
+    });
+  }
+
+  if (items.length === 0) {
+    throw createRssError(`Feed parsing failed for ${sourceName}: empty feed`, {
+      failureType: "rss_parse_empty_feed",
+      phase: "parse",
+      feedUrl,
+      feedName: sourceName,
+      feedId: requestOptions.feedId,
+      parser: "rss-parser",
+    });
+  }
+
+  const selectedItems = items.slice(0, 15);
+
+  if (selectedItems.every((item) => !item.title?.trim() && !item.link?.trim())) {
+    throw createRssError(`Feed parsing failed for ${sourceName}: missing required item fields`, {
+      failureType: "rss_parse_missing_required_fields",
+      phase: "parse",
+      feedUrl,
+      feedName: sourceName,
+      feedId: requestOptions.feedId,
+      parser: "rss-parser",
+    });
+  }
+
+  return selectedItems.map<FeedArticle>((item, index) => ({
     title: item.title?.trim() || `Untitled article ${index + 1}`,
     url: item.link?.trim() || feedUrl,
     summaryText: stripHtml(
@@ -244,8 +369,18 @@ export async function fetchWithRetry(
       const response = await fetchWithTimeout(url, init, options.timeoutMs);
 
       if (!response.ok) {
-        const error = new Error(
+        const error = createRssError(
           `Feed request failed for ${options.sourceName} with status ${response.status}`,
+          {
+            failureType: classifyHttpStatus(response.status),
+            phase: "fetch",
+            feedUrl: url,
+            feedName: options.sourceName,
+            statusCode: response.status,
+            retryAttempt: attempt,
+            retryCount: options.retryCount,
+            timeoutMs: options.timeoutMs,
+          },
         );
 
         if (attempt < options.retryCount && isRetryableStatus(response.status)) {
@@ -253,23 +388,36 @@ export async function fetchWithRetry(
           continue;
         }
 
-        throw error;
+        throw attempt > 0 && isRetryableStatus(response.status)
+          ? createRetryExhaustedError(url, options, error)
+          : error;
       }
 
       return response;
     } catch (error) {
-      const normalized = normalizeFeedRequestError(error, options.sourceName, options.timeoutMs);
+      const normalized = normalizeFeedRequestError(error, url, options.sourceName, options.timeoutMs);
       lastError = normalized;
 
       if (attempt < options.retryCount && isRetryableFetchError(error)) {
         continue;
       }
 
-      throw normalized;
+      throw attempt > 0 && isRetryableFetchError(error)
+        ? createRetryExhaustedError(url, options, normalized)
+        : normalized;
     }
   }
 
-  throw lastError ?? new Error(`Feed request failed for ${options.sourceName}`);
+  throw lastError
+    ? createRetryExhaustedError(url, options, lastError)
+    : createRssError(`Feed request failed for ${options.sourceName}`, {
+      failureType: "rss_unknown_error",
+      phase: "fetch",
+      feedUrl: url,
+      feedName: options.sourceName,
+      retryCount: options.retryCount,
+      timeoutMs: options.timeoutMs,
+    });
 }
 
 async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number) {
@@ -298,14 +446,86 @@ function isRetryableFetchError(error: unknown) {
   return false;
 }
 
-function normalizeFeedRequestError(error: unknown, sourceName: string, timeoutMs: number) {
+function normalizeFeedRequestError(error: unknown, feedUrl: string, sourceName: string, timeoutMs: number) {
   if (error instanceof Error && error.name === "AbortError") {
-    return new Error(`Feed request timed out for ${sourceName} after ${timeoutMs}ms`);
+    return createRssError(`Feed request timed out for ${sourceName} after ${timeoutMs}ms`, {
+      failureType: "rss_fetch_timeout",
+      phase: "fetch",
+      feedUrl,
+      feedName: sourceName,
+      timeoutMs,
+    });
   }
 
-  if (error instanceof Error) {
+  if (error instanceof Error && error.name === "RssError") {
     return error;
   }
 
-  return new Error(`Feed request failed for ${sourceName}: ${String(error)}`);
+  if (error instanceof Error) {
+    return createRssError(error.message, {
+      failureType: classifyRssFailure(error, "rss_fetch_network_error"),
+      phase: "fetch",
+      feedUrl,
+      feedName: sourceName,
+      timeoutMs,
+    });
+  }
+
+  return createRssError(`Feed request failed for ${sourceName}: ${String(error)}`, {
+    failureType: "rss_unknown_error",
+    phase: "fetch",
+    feedUrl,
+    feedName: sourceName,
+    timeoutMs,
+  });
+}
+
+function classifyHttpStatus(status: number): RssFailureType {
+  if (status === 429) {
+    return "rss_fetch_rate_limited";
+  }
+
+  if (status >= 400) {
+    return "rss_fetch_http_error";
+  }
+
+  return "rss_fetch_unexpected_status";
+}
+
+function createRetryExhaustedError(
+  feedUrl: string,
+  options: {
+    timeoutMs: number;
+    retryCount: number;
+    sourceName: string;
+  },
+  lastError: Error,
+) {
+  return createRssError(
+    `Feed request retry exhausted for ${options.sourceName}: ${lastError.message}`,
+    {
+      failureType: "rss_retry_exhausted",
+      phase: "fetch",
+      feedUrl,
+      feedName: options.sourceName,
+      retryCount: options.retryCount,
+      timeoutMs: options.timeoutMs,
+    },
+  );
+}
+
+function assertRssContentType(response: Response, feedUrl: string, sourceName: string) {
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+
+  if (
+    contentType &&
+    !/(xml|rss|atom|text\/plain|text\/html|application\/xhtml)/i.test(contentType)
+  ) {
+    throw createRssError(`Feed response for ${sourceName} had invalid content type ${contentType}`, {
+      failureType: "rss_fetch_invalid_content_type",
+      phase: "fetch",
+      feedUrl,
+      feedName: sourceName,
+    });
+  }
 }

--- a/src/lib/sentry-config.ts
+++ b/src/lib/sentry-config.ts
@@ -1,0 +1,222 @@
+const DEFAULT_TRACES_SAMPLE_RATE = 0.05;
+const DEFAULT_REPLAYS_SESSION_SAMPLE_RATE = 0;
+const DEFAULT_REPLAYS_ON_ERROR_SAMPLE_RATE = 0.05;
+
+const SECRET_FIELD_PATTERN =
+  /(authorization|cookie|set-cookie|token|secret|password|passwd|api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|session|signature|sig|code)/i;
+
+type MutableSentryEvent = {
+  request?: {
+    url?: string;
+    headers?: Record<string, unknown>;
+    cookies?: unknown;
+    query_string?: unknown;
+  };
+  contexts?: Record<string, unknown>;
+  extra?: Record<string, unknown>;
+  tags?: Record<string, string>;
+  breadcrumbs?: Array<{
+    data?: Record<string, unknown>;
+  }>;
+  user?: unknown;
+};
+
+type MutableBreadcrumb = {
+  data?: Record<string, unknown>;
+};
+
+export function readSentryDsn(runtime: "server" | "client" = "server") {
+  if (runtime === "client") {
+    return process.env.NEXT_PUBLIC_SENTRY_DSN?.trim() || "";
+  }
+
+  return process.env.SENTRY_DSN?.trim() || process.env.NEXT_PUBLIC_SENTRY_DSN?.trim() || "";
+}
+
+export function isSentryConfigured(runtime: "server" | "client" = "server") {
+  return Boolean(readSentryDsn(runtime));
+}
+
+export function readSentryEnvironment() {
+  return (
+    process.env.SENTRY_ENVIRONMENT?.trim() ||
+    process.env.VERCEL_ENV?.trim() ||
+    process.env.NODE_ENV ||
+    "development"
+  );
+}
+
+export function readSentryRelease() {
+  return (
+    process.env.SENTRY_RELEASE?.trim() ||
+    process.env.VERCEL_GIT_COMMIT_SHA?.trim() ||
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.trim() ||
+    undefined
+  );
+}
+
+export function readSampleRate(name: string, fallback: number) {
+  const rawValue = process.env[name]?.trim();
+
+  if (!rawValue) {
+    return fallback;
+  }
+
+  const parsed = Number.parseFloat(rawValue);
+
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  return Math.max(0, Math.min(parsed, 1));
+}
+
+export function readSentryTracesSampleRate() {
+  return readSampleRate("SENTRY_TRACES_SAMPLE_RATE", DEFAULT_TRACES_SAMPLE_RATE);
+}
+
+export function readSentryReplaysSessionSampleRate() {
+  return readSampleRate("SENTRY_REPLAYS_SESSION_SAMPLE_RATE", DEFAULT_REPLAYS_SESSION_SAMPLE_RATE);
+}
+
+export function readSentryReplaysOnErrorSampleRate() {
+  return readSampleRate("SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE", DEFAULT_REPLAYS_ON_ERROR_SAMPLE_RATE);
+}
+
+export function sanitizeUrl(value: string) {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return "";
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    parsed.username = "";
+    parsed.password = "";
+    parsed.search = "";
+    parsed.hash = "";
+
+    if (parsed.origin === "null") {
+      return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+    }
+
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return trimmed.split("?")[0]?.split("#")[0] ?? "";
+  }
+}
+
+export function getUrlHost(value: string | undefined) {
+  if (!value) {
+    return "";
+  }
+
+  try {
+    return new URL(value).hostname.replace(/^www\./, "").toLowerCase();
+  } catch {
+    const withoutQuery = value.split("?")[0] ?? value;
+    const match = withoutQuery.match(/^[a-z]+:\/\/([^/]+)/i);
+    return match?.[1]?.replace(/^www\./, "").toLowerCase() ?? "";
+  }
+}
+
+function sanitizeRecord(input: Record<string, unknown>, depth = 0): Record<string, unknown> {
+  if (depth > 4) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(input).map(([key, value]) => {
+      if (SECRET_FIELD_PATTERN.test(key)) {
+        return [key, "[Filtered]"];
+      }
+
+      if (typeof value === "string") {
+        return [key, sanitizeMaybeUrl(value)];
+      }
+
+      if (Array.isArray(value)) {
+        return [
+          key,
+          value.slice(0, 20).map((entry) =>
+            typeof entry === "string"
+              ? sanitizeMaybeUrl(entry)
+              : isRecord(entry)
+                ? sanitizeRecord(entry, depth + 1)
+                : entry,
+          ),
+        ];
+      }
+
+      if (isRecord(value)) {
+        return [key, sanitizeRecord(value, depth + 1)];
+      }
+
+      return [key, value];
+    }),
+  );
+}
+
+function sanitizeMaybeUrl(value: string) {
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) {
+    return sanitizeUrl(value);
+  }
+
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function sanitizeSentryEvent<T>(event: T): T {
+  if (!isRecord(event)) {
+    return event;
+  }
+
+  const mutableEvent = event as MutableSentryEvent;
+
+  if (mutableEvent.request) {
+    if (mutableEvent.request.url) {
+      mutableEvent.request.url = sanitizeUrl(mutableEvent.request.url);
+    }
+
+    if (mutableEvent.request.headers) {
+      mutableEvent.request.headers = sanitizeRecord(mutableEvent.request.headers);
+    }
+
+    delete mutableEvent.request.cookies;
+    delete mutableEvent.request.query_string;
+  }
+
+  if (mutableEvent.contexts) {
+    mutableEvent.contexts = sanitizeRecord(mutableEvent.contexts);
+  }
+
+  if (mutableEvent.extra) {
+    mutableEvent.extra = sanitizeRecord(mutableEvent.extra);
+  }
+
+  if (mutableEvent.breadcrumbs) {
+    mutableEvent.breadcrumbs = mutableEvent.breadcrumbs.map((breadcrumb) => sanitizeBreadcrumb(breadcrumb));
+  }
+
+  delete mutableEvent.user;
+
+  return event;
+}
+
+export function sanitizeBreadcrumb<T>(breadcrumb: T): T {
+  if (!isRecord(breadcrumb)) {
+    return breadcrumb;
+  }
+
+  const mutableBreadcrumb = breadcrumb as MutableBreadcrumb;
+
+  if (mutableBreadcrumb.data) {
+    mutableBreadcrumb.data = sanitizeRecord(mutableBreadcrumb.data);
+  }
+
+  return breadcrumb;
+}

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -35,6 +35,7 @@ const safeGetUser = vi.fn();
 const createSupabaseServiceRoleClient = vi.fn();
 const createSupabaseServerClient = vi.fn();
 const generateDailyBriefing = vi.fn();
+const captureRssFailure = vi.fn();
 
 vi.mock("@/lib/supabase/server", () => ({
   safeGetUser,
@@ -44,6 +45,10 @@ vi.mock("@/lib/supabase/server", () => ({
 
 vi.mock("@/lib/data", () => ({
   generateDailyBriefing,
+}));
+
+vi.mock("@/lib/observability/rss", () => ({
+  captureRssFailure,
 }));
 
 function createRow(overrides: Partial<SignalPostRow> = {}): SignalPostRow {
@@ -255,6 +260,7 @@ describe("signals editorial workflow", () => {
     createSupabaseServiceRoleClient.mockReset();
     createSupabaseServerClient.mockReset();
     generateDailyBriefing.mockReset();
+    captureRssFailure.mockReset();
   });
 
   it("withholds editorial review state from non-admin users", async () => {
@@ -736,6 +742,65 @@ describe("signals editorial workflow", () => {
     expect(result.message).toBe("Signal post published.");
     expect(rows[0].editorial_status).toBe("published");
     expect(rows[0].published_why_it_matters).toBe("Approved historical editorial update.");
+  });
+
+  it("captures individual publish storage failures as RSS publish failures", async () => {
+    const row = createRow({
+      id: "signal-1",
+      rank: 1,
+      briefing_date: "2026-04-20",
+      edited_why_it_matters: "Approved historical editorial update.",
+      editorial_status: "approved",
+    });
+    createSupabaseServiceRoleClient.mockReturnValue({
+      from() {
+        let operation: "select" | "update" | null = null;
+        const builder = {
+          select() {
+            operation = "select";
+            return builder;
+          },
+          update() {
+            operation = "update";
+            return builder;
+          },
+          eq() {
+            if (operation === "update") {
+              return Promise.resolve({ error: { message: "write failed" } });
+            }
+
+            return builder;
+          },
+          maybeSingle() {
+            return Promise.resolve({ data: row, error: null });
+          },
+        };
+
+        return builder;
+      },
+    });
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { publishSignalPost } = await loadEditorialModule();
+    const result = await publishSignalPost({ postId: "signal-1" });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("storage_error");
+    expect(captureRssFailure).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        failureType: "rss_cache_write_failed",
+        phase: "publish",
+        extra: expect.objectContaining({
+          operation: "publish_signal_post",
+          postId: "signal-1",
+        }),
+      }),
+    );
   });
 
   it("publishes structured approved signal post payloads for homepage rendering", async () => {

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -12,6 +12,7 @@ import {
   createSupabaseServiceRoleClient,
   safeGetUser,
 } from "@/lib/supabase/server";
+import { captureRssFailure, type RssFailureType, type RssPhase } from "@/lib/observability/rss";
 import type { BriefingItem, EditorialStatus } from "@/lib/types";
 import {
   flagCardForRewrite,
@@ -209,6 +210,31 @@ function normalizeSearchQuery(value: string | null | undefined) {
 
 function normalizePageNumber(page?: number) {
   return Number.isFinite(page) && page && page > 0 ? Math.floor(page) : 1;
+}
+
+function captureRssEditorialStorageFailure(input: {
+  failureType: Extract<RssFailureType, "rss_cache_read_failed" | "rss_cache_write_failed">;
+  phase: Extract<RssPhase, "store" | "publish">;
+  operation: string;
+  message: string;
+  route?: string;
+  briefingDate?: string | null;
+  postId?: string;
+  postCount?: number;
+}) {
+  captureRssFailure(new Error(input.message), {
+    failureType: input.failureType,
+    phase: input.phase,
+    level: "error",
+    message: input.message,
+    extra: {
+      operation: input.operation,
+      route: input.route ?? SIGNALS_EDITORIAL_ROUTE,
+      briefingDate: input.briefingDate ?? undefined,
+      postId: input.postId,
+      postCount: input.postCount,
+    },
+  });
 }
 
 function mapStoredSignalPost(row: StoredSignalPost): EditorialSignalPost {
@@ -466,6 +492,14 @@ async function persistSignalPostCandidates(
     .eq("briefing_date", briefingDate);
 
   if (existingResult.error) {
+    captureRssEditorialStorageFailure({
+      failureType: "rss_cache_read_failed",
+      phase: "store",
+      operation: "check_existing_signal_snapshot",
+      briefingDate,
+      message: "RSS signal snapshot storage could not be checked before persistence.",
+    });
+
     return {
       ok: false,
       briefingDate,
@@ -505,6 +539,14 @@ async function persistSignalPostCandidates(
       .eq("is_live", true);
 
     if (deactivateOldLiveSet.error) {
+      captureRssEditorialStorageFailure({
+        failureType: "rss_cache_write_failed",
+        phase: "store",
+        operation: "archive_previous_live_signal_set",
+        briefingDate,
+        message: "Previous live RSS signal set could not be archived before persistence.",
+      });
+
       return {
         ok: false,
         briefingDate,
@@ -541,6 +583,15 @@ async function persistSignalPostCandidates(
   );
 
   if (insertResult.error) {
+    captureRssEditorialStorageFailure({
+      failureType: "rss_cache_write_failed",
+      phase: "store",
+      operation: "insert_signal_snapshot",
+      briefingDate,
+      postCount: flaggedCandidates.length,
+      message: "Current RSS Top 5 snapshot could not be persisted for editing.",
+    });
+
     return {
       ok: false,
       briefingDate,
@@ -1212,6 +1263,14 @@ export async function publishApprovedSignals(input: {
   );
 
   if (latest.errorMessage) {
+    captureRssEditorialStorageFailure({
+      failureType: "rss_cache_read_failed",
+      phase: "publish",
+      operation: "load_latest_signal_snapshot_for_publish",
+      route: input.route ?? SIGNALS_EDITORIAL_ROUTE,
+      message: "RSS signal set could not be loaded for publishing.",
+    });
+
     return {
       ok: false,
       code: "storage_error",
@@ -1261,6 +1320,15 @@ export async function publishApprovedSignals(input: {
     .eq("is_live", true);
 
   if (deactivateOldLiveSet.error) {
+    captureRssEditorialStorageFailure({
+      failureType: "rss_cache_write_failed",
+      phase: "publish",
+      operation: "archive_previous_live_signal_set_for_publish",
+      route: input.route ?? SIGNALS_EDITORIAL_ROUTE,
+      briefingDate: latest.latestBriefingDate,
+      message: "Previous live RSS signal set could not be archived before publishing.",
+    });
+
     return {
       ok: false,
       code: "storage_error",
@@ -1326,6 +1394,16 @@ export async function publishApprovedSignals(input: {
   );
 
   if (updateResults.some((result) => result.error) || depthUpdateResults.some((result) => result.error)) {
+    captureRssEditorialStorageFailure({
+      failureType: "rss_cache_write_failed",
+      phase: "publish",
+      operation: "publish_signal_set",
+      route: input.route ?? SIGNALS_EDITORIAL_ROUTE,
+      briefingDate: latest.latestBriefingDate,
+      postCount: topFivePosts.length + depthPosts.length,
+      message: "RSS signal set could not be published completely.",
+    });
+
     return {
       ok: false,
       code: "storage_error",
@@ -1360,7 +1438,24 @@ export async function publishSignalPost(input: {
     .eq("id", input.postId)
     .maybeSingle();
 
-  if (lookup.error || !lookup.data) {
+  if (lookup.error) {
+    captureRssEditorialStorageFailure({
+      failureType: "rss_cache_read_failed",
+      phase: "publish",
+      operation: "load_signal_post_for_publish",
+      route: input.route ?? SIGNALS_EDITORIAL_ROUTE,
+      postId: input.postId,
+      message: "RSS signal post could not be loaded for publishing.",
+    });
+
+    return {
+      ok: false,
+      code: "not_found",
+      message: "The signal post could not be found.",
+    };
+  }
+
+  if (!lookup.data) {
     return {
       ok: false,
       code: "not_found",
@@ -1404,6 +1499,16 @@ export async function publishSignalPost(input: {
     .eq("id", post.id);
 
   if (updateResult.error) {
+    captureRssEditorialStorageFailure({
+      failureType: "rss_cache_write_failed",
+      phase: "publish",
+      operation: "publish_signal_post",
+      route: input.route ?? SIGNALS_EDITORIAL_ROUTE,
+      briefingDate: post.briefingDate,
+      postId: post.id,
+      message: "RSS signal post could not be published.",
+    });
+
     return {
       ok: false,
       code: "storage_error",

--- a/src/sentry.edge.config.ts
+++ b/src/sentry.edge.config.ts
@@ -1,0 +1,30 @@
+import * as Sentry from "@sentry/nextjs";
+
+import {
+  readSentryDsn,
+  readSentryEnvironment,
+  readSentryRelease,
+  readSentryTracesSampleRate,
+  sanitizeBreadcrumb,
+  sanitizeSentryEvent,
+} from "@/lib/sentry-config";
+
+const dsn = readSentryDsn("server");
+
+if (dsn) {
+  Sentry.init({
+    dsn,
+    environment: readSentryEnvironment(),
+    release: readSentryRelease(),
+    sendDefaultPii: false,
+    tracesSampleRate: readSentryTracesSampleRate(),
+    enableLogs: true,
+    maxBreadcrumbs: 50,
+    beforeSend(event) {
+      return sanitizeSentryEvent(event);
+    },
+    beforeBreadcrumb(breadcrumb) {
+      return sanitizeBreadcrumb(breadcrumb);
+    },
+  });
+}

--- a/src/sentry.server.config.ts
+++ b/src/sentry.server.config.ts
@@ -1,0 +1,30 @@
+import * as Sentry from "@sentry/nextjs";
+
+import {
+  readSentryDsn,
+  readSentryEnvironment,
+  readSentryRelease,
+  readSentryTracesSampleRate,
+  sanitizeBreadcrumb,
+  sanitizeSentryEvent,
+} from "@/lib/sentry-config";
+
+const dsn = readSentryDsn("server");
+
+if (dsn) {
+  Sentry.init({
+    dsn,
+    environment: readSentryEnvironment(),
+    release: readSentryRelease(),
+    sendDefaultPii: false,
+    tracesSampleRate: readSentryTracesSampleRate(),
+    enableLogs: true,
+    maxBreadcrumbs: 50,
+    beforeSend(event) {
+      return sanitizeSentryEvent(event);
+    },
+    beforeBreadcrumb(breadcrumb) {
+      return sanitizeBreadcrumb(breadcrumb);
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Adds server-side Sentry initialization for the Next.js runtime before RSS boot validation.
- Adds RSS failure taxonomy, sanitized Sentry capture, RSS boot breadcrumbs/spans, cron check-ins, and `/health/rss` safe JSON health output.
- Captures RSS fetch, parse, store, publish, refresh, and health failures with `component=rss`, `rss.phase`, `rss.failure_type`, and host-only feed tags.
- Documents free-tier Sentry setup, cron/uptime monitor setup, alert/dashboard recommendations, and tracker fallback notes.

## Validation
- `npm install`
- `npm run lint`
- `npm run build`
- `npm run test -- src/lib/observability/rss.test.ts src/lib/rss.test.ts src/app/health/rss/route.test.ts src/app/api/cron/fetch-news/route.test.ts src/lib/signals-editorial.test.ts`
- `npm run test`
- `git diff --check`
- `python3 scripts/validate-feature-system-csv.py`
- `python3 scripts/release-governance-gate.py --base-sha origin/main --head-sha HEAD --branch-name codex/sentry-rss-monitoring --pr-title "Sentry RSS monitoring" --diff-mode local`
- `curl -i http://localhost:3000/health/rss` returned safe JSON locally with expected 503 when no persisted RSS run exists
- `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=chromium`
- `PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test --project=webkit --workers=1`

## Notes
- No production deployment was triggered.
- `NEXT_PUBLIC_SENTRY_DSN` is intentionally not added in this server-side RSS monitoring pass.
- Preview `/health/rss` still needs validation once Vercel generates the PR preview URL.
- Sentry uptime monitor creation remains blocked until production serves `/health/rss` after an approved production deploy.
