### PR TITLE
Temporary cron debug bypass

### DIFF
--- a/docs/engineering/bug-fixes/temporary-cron-debug-bypass.md
+++ b/docs/engineering/bug-fixes/temporary-cron-debug-bypass.md
@@ -1,0 +1,17 @@
+# Temporary Cron Debug Bypass
+
+## Summary
+
+Adds a temporary browser-trigger helper for `GET /api/cron/fetch-news` so the daily news cron can be exercised without a bearer token in local development and Vercel preview debug sessions.
+
+## Guardrails
+
+- Existing `Authorization: Bearer <CRON_SECRET>` logic remains intact.
+- Real production runtime still requires the existing authorization header.
+- `?debug=true` is accepted only outside real production runtime, such as Vercel preview.
+- Bypass use is logged with route, `NODE_ENV`, `VERCEL_ENV`, and whether `debug=true` was present.
+- No secrets, request headers, cookies, or feed URLs are logged.
+
+## Removal
+
+This is intentionally temporary. Remove `isTemporaryCronDebugBypassAllowed` and the unauthenticated branch in `src/app/api/cron/fetch-news/route.ts` once browser-triggered cron debugging is no longer needed.

--- a/src/app/api/cron/fetch-news/route.test.ts
+++ b/src/app/api/cron/fetch-news/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const generateDailyBriefing = vi.fn();
 const persistSignalPostsForBriefing = vi.fn();
@@ -27,8 +27,11 @@ vi.mock("@/lib/observability/rss", () => ({
   withRssSpan: vi.fn((_name, _phase, _attributes, callback) => callback()),
 }));
 
-function buildRequest(secret?: string) {
-  return new Request("http://localhost:3000/api/cron/fetch-news", {
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const ORIGINAL_VERCEL_ENV = process.env.VERCEL_ENV;
+
+function buildRequest(secret?: string, url = "http://localhost:3000/api/cron/fetch-news") {
+  return new Request(url, {
     headers: secret ? { authorization: `Bearer ${secret}` } : undefined,
   });
 }
@@ -63,6 +66,8 @@ function buildBriefingResult(overrides: {
 describe("/api/cron/fetch-news", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    process.env.NODE_ENV = "production";
+    process.env.VERCEL_ENV = "production";
     process.env.CRON_SECRET = "local-cron-secret";
     generateDailyBriefing.mockResolvedValue(buildBriefingResult());
     persistSignalPostsForBriefing.mockResolvedValue({
@@ -71,6 +76,20 @@ describe("/api/cron/fetch-news", () => {
       insertedCount: 5,
       message: "Persisted a new daily Top 5 snapshot.",
     });
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_NODE_ENV === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+    }
+
+    if (ORIGINAL_VERCEL_ENV === undefined) {
+      delete process.env.VERCEL_ENV;
+    } else {
+      process.env.VERCEL_ENV = ORIGINAL_VERCEL_ENV;
+    }
   });
 
   it("rejects unauthorized requests without triggering the pipeline", async () => {
@@ -89,6 +108,48 @@ describe("/api/cron/fetch-news", () => {
 
     const { GET } = await import("@/app/api/cron/fetch-news/route");
     const response = await GET(buildRequest("local-cron-secret"));
+
+    expect(response.status).toBe(401);
+    expect(generateDailyBriefing).not.toHaveBeenCalled();
+  });
+
+  it("allows the temporary bypass outside production and logs its use", async () => {
+    process.env.NODE_ENV = "development";
+    process.env.VERCEL_ENV = "development";
+
+    const { GET } = await import("@/app/api/cron/fetch-news/route");
+    const response = await GET(buildRequest());
+
+    expect(response.status).toBe(200);
+    expect(generateDailyBriefing).toHaveBeenCalledTimes(1);
+    expect(logServerEvent).toHaveBeenCalledWith("warn", "Temporary daily news cron auth bypass used", {
+      route: "/api/cron/fetch-news",
+      nodeEnv: "development",
+      vercelEnv: "development",
+      debugParam: false,
+    });
+  });
+
+  it("allows the temporary debug query bypass in Vercel preview", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.VERCEL_ENV = "preview";
+
+    const { GET } = await import("@/app/api/cron/fetch-news/route");
+    const response = await GET(buildRequest(undefined, "http://localhost:3000/api/cron/fetch-news?debug=true"));
+
+    expect(response.status).toBe(200);
+    expect(generateDailyBriefing).toHaveBeenCalledTimes(1);
+    expect(logServerEvent).toHaveBeenCalledWith("warn", "Temporary daily news cron auth bypass used", {
+      route: "/api/cron/fetch-news",
+      nodeEnv: "production",
+      vercelEnv: "preview",
+      debugParam: true,
+    });
+  });
+
+  it("does not allow the debug query bypass in production", async () => {
+    const { GET } = await import("@/app/api/cron/fetch-news/route");
+    const response = await GET(buildRequest(undefined, "http://localhost:3000/api/cron/fetch-news?debug=true"));
 
     expect(response.status).toBe(401);
     expect(generateDailyBriefing).not.toHaveBeenCalled();

--- a/src/app/api/cron/fetch-news/route.test.ts
+++ b/src/app/api/cron/fetch-news/route.test.ts
@@ -5,6 +5,7 @@ const persistSignalPostsForBriefing = vi.fn();
 const logServerEvent = vi.fn();
 const captureRssCronCheckIn = vi.fn((status: string) => status === "in_progress" ? "check-in-id" : undefined);
 const captureRssFailure = vi.fn();
+const flushRssTelemetry = vi.fn(async () => true);
 
 vi.mock("@/lib/data", () => ({
   generateDailyBriefing,
@@ -24,6 +25,7 @@ vi.mock("@/lib/observability", () => ({
 vi.mock("@/lib/observability/rss", () => ({
   captureRssCronCheckIn,
   captureRssFailure,
+  flushRssTelemetry,
   withRssSpan: vi.fn((_name, _phase, _attributes, callback) => callback()),
 }));
 
@@ -229,5 +231,88 @@ describe("/api/cron/fetch-news", () => {
       }),
     );
     expect(captureRssCronCheckIn).toHaveBeenCalledWith("error", "check-in-id", expect.any(Number));
+  });
+
+  it("reports briefing generation failures before a pipeline run exists", async () => {
+    const generationError = new Error("Preview RSS source configuration failed before fetch");
+    generateDailyBriefing.mockRejectedValue(generationError);
+
+    const { GET } = await import("@/app/api/cron/fetch-news/route");
+    const response = await GET(buildRequest("local-cron-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toMatchObject({
+      success: false,
+      summary: {
+        pipelineRunId: null,
+        rawItemCount: 0,
+        feedFailureCount: 0,
+        failureStage: "briefing_generation",
+        message: "Daily news cron failed before completion.",
+      },
+    });
+    expect(persistSignalPostsForBriefing).not.toHaveBeenCalled();
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "error",
+      "Daily news cron failed",
+      expect.objectContaining({
+        route: "/api/cron/fetch-news",
+        failureStage: "briefing_generation",
+        pipelineRunId: null,
+        rawItemCount: 0,
+        feedFailureCount: 0,
+        errorMessage: "Preview RSS source configuration failed before fetch",
+      }),
+    );
+    expect(captureRssFailure).toHaveBeenCalledWith(
+      generationError,
+      expect.objectContaining({
+        failureType: "rss_refresh_job_failed",
+        phase: "refresh",
+        extra: expect.objectContaining({
+          route: "/api/cron/fetch-news",
+          failureStage: "briefing_generation",
+          pipelineRunId: null,
+          rawItemCount: 0,
+          feedFailureCount: 0,
+        }),
+      }),
+    );
+    expect(captureRssCronCheckIn).toHaveBeenCalledWith("error", "check-in-id", expect.any(Number));
+    expect(flushRssTelemetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves pipeline counts when a later cron stage throws", async () => {
+    const persistenceError = new Error("Preview editorial persistence threw");
+    persistSignalPostsForBriefing.mockRejectedValue(persistenceError);
+
+    const { GET } = await import("@/app/api/cron/fetch-news/route");
+    const response = await GET(buildRequest("local-cron-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.summary).toMatchObject({
+      pipelineRunId: "pipeline-test",
+      rawItemCount: 12,
+      clusterCount: 5,
+      rankedClusterCount: 5,
+      feedFailureCount: 0,
+      failureStage: "editorial_persistence",
+      message: "Daily news cron failed before completion.",
+    });
+    expect(captureRssFailure).toHaveBeenCalledWith(
+      persistenceError,
+      expect.objectContaining({
+        failureType: "rss_refresh_job_failed",
+        phase: "refresh",
+        extra: expect.objectContaining({
+          failureStage: "editorial_persistence",
+          pipelineRunId: "pipeline-test",
+          rawItemCount: 12,
+        }),
+      }),
+    );
+    expect(flushRssTelemetry).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/api/cron/fetch-news/route.ts
+++ b/src/app/api/cron/fetch-news/route.ts
@@ -6,6 +6,8 @@ import { logServerEvent } from "@/lib/observability";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+const CRON_ROUTE = "/api/cron/fetch-news";
+
 function isAuthorized(request: Request) {
   const cronSecret = process.env.CRON_SECRET?.trim();
   const authHeader = request.headers.get("authorization")?.trim() ?? "";
@@ -13,10 +15,26 @@ function isAuthorized(request: Request) {
   return Boolean(cronSecret) && authHeader === `Bearer ${cronSecret}`;
 }
 
+function isProductionRuntime() {
+  const vercelEnv = process.env.VERCEL_ENV;
+
+  return process.env.NODE_ENV === "production" && vercelEnv !== "preview" && vercelEnv !== "development";
+}
+
+function isTemporaryCronDebugBypassAllowed(request: Request) {
+  const url = new URL(request.url);
+  const debugRequested = url.searchParams.get("debug") === "true";
+  const nodeEnvAllowsBypass = process.env.NODE_ENV !== "production";
+
+  // Temporary browser-trigger helper. Remove this helper and the GET branch below
+  // once cron debugging no longer needs an unauthenticated local/preview path.
+  return !isProductionRuntime() && (nodeEnvAllowsBypass || debugRequested);
+}
+
 export async function GET(request: Request) {
-  if (!isAuthorized(request)) {
+  if (!isAuthorized(request) && !isTemporaryCronDebugBypassAllowed(request)) {
     logServerEvent("warn", "Unauthorized daily news cron request rejected", {
-      route: "/api/cron/fetch-news",
+      route: CRON_ROUTE,
       hasCronSecret: Boolean(process.env.CRON_SECRET?.trim()),
     });
 
@@ -30,6 +48,17 @@ export async function GET(request: Request) {
       },
       { status: 401 },
     );
+  }
+
+  if (!isAuthorized(request)) {
+    const url = new URL(request.url);
+
+    logServerEvent("warn", "Temporary daily news cron auth bypass used", {
+      route: CRON_ROUTE,
+      nodeEnv: process.env.NODE_ENV ?? null,
+      vercelEnv: process.env.VERCEL_ENV ?? null,
+      debugParam: url.searchParams.get("debug") === "true",
+    });
   }
 
   const result = await runDailyNewsCron();

--- a/src/lib/cron/fetch-news.ts
+++ b/src/lib/cron/fetch-news.ts
@@ -3,9 +3,18 @@ import { errorContext, logServerEvent } from "@/lib/observability";
 import {
   captureRssCronCheckIn,
   captureRssFailure,
+  flushRssTelemetry,
   withRssSpan,
 } from "@/lib/observability/rss";
 import { persistSignalPostsForBriefing } from "@/lib/signals-editorial";
+
+type DailyNewsCronFailureStage =
+  | "cron_start"
+  | "briefing_generation"
+  | "briefing_summary"
+  | "seed_fallback_guard"
+  | "minimum_item_guard"
+  | "editorial_persistence";
 
 export type DailyNewsCronRunSummary = {
   briefingDate: string | null;
@@ -16,6 +25,7 @@ export type DailyNewsCronRunSummary = {
   rankedClusterCount: number;
   usedSeedFallback: boolean;
   feedFailureCount: number;
+  failureStage?: DailyNewsCronFailureStage;
   message: string;
 };
 
@@ -25,19 +35,29 @@ export type DailyNewsCronRunResult = {
   summary: DailyNewsCronRunSummary;
 };
 
-function buildFailureResult(timestamp: string, message: string): DailyNewsCronRunResult {
+function buildEmptySummary(): Omit<DailyNewsCronRunSummary, "message"> {
+  return {
+    briefingDate: null,
+    insertedSignalPostCount: 0,
+    pipelineRunId: null,
+    rawItemCount: 0,
+    clusterCount: 0,
+    rankedClusterCount: 0,
+    usedSeedFallback: false,
+    feedFailureCount: 0,
+  };
+}
+
+function buildFailureResult(
+  timestamp: string,
+  message: string,
+  partialSummary: Omit<DailyNewsCronRunSummary, "message"> = buildEmptySummary(),
+): DailyNewsCronRunResult {
   return {
     success: false,
     timestamp,
     summary: {
-      briefingDate: null,
-      insertedSignalPostCount: 0,
-      pipelineRunId: null,
-      rawItemCount: 0,
-      clusterCount: 0,
-      rankedClusterCount: 0,
-      usedSeedFallback: false,
-      feedFailureCount: 0,
+      ...partialSummary,
       message,
     },
   };
@@ -47,6 +67,8 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
   const timestamp = new Date().toISOString();
   const startedAtMs = Date.now();
   const checkInId = captureRssCronCheckIn("in_progress");
+  let failureStage: DailyNewsCronFailureStage = "cron_start";
+  let partialSummary = buildEmptySummary();
 
   logServerEvent("info", "Daily news cron started", {
     route: "/api/cron/fetch-news",
@@ -54,6 +76,7 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
   });
 
   try {
+    failureStage = "briefing_generation";
     const { briefing, publicRankedItems, pipelineRun } = await withRssSpan(
       "rss.refresh",
       "refresh",
@@ -62,6 +85,7 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
       },
       () => generateDailyBriefing(),
     );
+    failureStage = "briefing_summary";
     const briefingDate = briefing.briefingDate.slice(0, 10);
     const baseSummary = {
       briefingDate,
@@ -73,7 +97,9 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
       usedSeedFallback: pipelineRun.used_seed_fallback,
       feedFailureCount: pipelineRun.feed_failures.length,
     };
+    partialSummary = baseSummary;
 
+    failureStage = "seed_fallback_guard";
     if (pipelineRun.used_seed_fallback) {
       const result = {
         success: false,
@@ -106,6 +132,7 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
       return result;
     }
 
+    failureStage = "minimum_item_guard";
     if (briefing.items.length < 5) {
       const result = {
         success: false,
@@ -138,6 +165,7 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
       return result;
     }
 
+    failureStage = "editorial_persistence";
     const snapshot = await persistSignalPostsForBriefing({
       briefingDate,
       items: briefing.items,
@@ -176,11 +204,20 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
 
     return result;
   } catch (error) {
-    const result = buildFailureResult(timestamp, "Daily news cron failed before completion.");
+    const failureSummary = {
+      ...partialSummary,
+      failureStage,
+    };
+    const result = buildFailureResult(
+      timestamp,
+      "Daily news cron failed before completion.",
+      failureSummary,
+    );
 
     logServerEvent("error", "Daily news cron failed", {
       route: "/api/cron/fetch-news",
       timestamp,
+      ...result.summary,
       ...errorContext(error),
     });
     captureRssFailure(error, {
@@ -190,9 +227,11 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
       message: result.summary.message,
       extra: {
         route: "/api/cron/fetch-news",
+        ...failureSummary,
       },
     });
     captureRssCronCheckIn("error", checkInId, durationSeconds(startedAtMs));
+    await flushRssTelemetry();
 
     return result;
   }


### PR DESCRIPTION
## Summary
- Adds a temporary unauthenticated cron trigger path for local development and Vercel preview debugging.
- Preserves the existing CRON_SECRET bearer-token authorization path.
- Blocks the debug bypass in real production runtime and logs bypass usage clearly.

## Validation
- npm install
- npm run lint
- npm run build
- npm run test
- npm run test -- src/app/api/cron/fetch-news/route.test.ts
- python3 scripts/validate-feature-system-csv.py
- python3 scripts/release-governance-gate.py --base-sha origin/main --head-sha HEAD --branch-name codex/cron-debug-bypass --pr-title "Temporary cron debug bypass" --diff-mode local
- git diff --check

## Notes
- Do not merge until the temporary bypass is explicitly approved for the next deployment.
- I did not trigger the cron endpoint from preview or production because that can mutate editorial/RSS state.