### PR TITLE
Add controlled pipeline safety modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ project.md
 
 # local remediation evidence
 /recovery-audit-*/
+
+# controlled pipeline run artifacts
+/.pipeline-runs/

--- a/docs/engineering/change-records/2026-04-27-controlled-pipeline-safety-remediation.md
+++ b/docs/engineering/change-records/2026-04-27-controlled-pipeline-safety-remediation.md
@@ -1,0 +1,107 @@
+# Controlled Pipeline Safety Remediation
+
+Date: 2026-04-27
+
+## Change Type
+
+Remediation / alignment.
+
+Canonical PRD required: No.
+
+## Source of Truth
+
+- Product Position: Boot Up is a curated briefing, not a feed.
+- Product Position: Top 5 Core Signals require structural importance and explicit why-it-matters reasoning.
+- Product Position: no false freshness.
+- PRD-35 Why it matters quality framework.
+- PRD-37 pipeline processing.
+- PRD-53 Signals admin editorial layer.
+- PRD-57 Homepage volume layers.
+- Final Launch Content QA PASS report.
+- Controlled Pipeline Test Plan: BLOCKED because no safe dry-run/draft-only execution mode existed.
+
+No new canonical PRD is required because this is a remediation to make the existing pipeline and editorial publication contract safe to test.
+
+## Object Level
+
+- Article and Story Cluster: generation and scoring inputs.
+- Signal: interpreted ranked output from generation.
+- Surface Placement plus Card copy: `public.signal_posts` rows.
+
+`signal_posts` remains a Surface Placement and Card copy read model, not canonical Signal identity.
+
+## Pre-Change Write Path
+
+The scheduled fetch route used this sequence:
+
+1. `/api/cron/fetch-news` authorized the request with `CRON_SECRET`.
+2. `runDailyNewsCron()` called `generateDailyBriefing()`.
+3. `generateDailyBriefing()` called `runClusterFirstPipeline()`.
+4. `runClusterFirstPipeline()` fetched source Articles, normalized/deduped them, formed Story Clusters, scored ranked outputs, and wrote `pipeline_article_candidates`.
+5. `runDailyNewsCron()` called `persistSignalPostsForBriefing()`.
+6. `persistSignalPostsForBriefing()` mapped briefing items to `signal_posts` rows and validated why-it-matters copy.
+7. The persistence path could deactivate existing `is_live = true` rows and insert newly generated rows with `is_live = true` before editorial approval.
+
+That violated the launch safety invariant: generation must not equal public activation.
+
+## New Execution Modes
+
+`PIPELINE_RUN_MODE` supports:
+
+- `normal`: existing generation path, with the safety invariant enforced. Generation can write editorial review rows, but cannot activate public rows.
+- `dry_run`: runs generation, scoring, and why-it-matters validation reporting without writing `pipeline_article_candidates` or `signal_posts`.
+- `draft_only`: runs generation and inserts `signal_posts` review rows only. Rows are `editorial_status = needs_review`, `is_live = false`, and `published_at = null`.
+
+The local script entrypoint is:
+
+```bash
+npm run pipeline:controlled-test
+```
+
+The controlled script intentionally supports only `dry_run` and `draft_only`; normal scheduled execution remains owned by `/api/cron/fetch-news` after explicit re-enable approval.
+
+## Production Guardrails
+
+Production `draft_only` refuses to run unless all of the following are present:
+
+- `PIPELINE_RUN_MODE=draft_only`
+- `PIPELINE_TARGET_ENV=production`
+- `ALLOW_PRODUCTION_PIPELINE_TEST=true`
+- `BRIEFING_DATE_OVERRIDE=YYYY-MM-DD`
+- `PIPELINE_TEST_RUN_ID=<explicit id>`
+- `PIPELINE_CRON_DISABLED_CONFIRMED=true`
+
+`dry_run` does not require write credentials and disables pipeline candidate persistence.
+
+## Public Activation Invariant
+
+Pipeline generation no longer deactivates the current live set and no longer inserts generated rows as live.
+
+Only the explicit editorial publish workflow may:
+
+- set old live rows to `is_live = false`
+- set new approved rows to `is_live = true`
+- set `published_at`
+- publish public why-it-matters copy
+
+## Run Identification
+
+No schema migration was added. `signal_posts` has no safe existing pipeline-run metadata field, and adding one is unnecessary for the controlled test.
+
+For controlled runs, the script writes a local JSON artifact under `.pipeline-runs/` with:
+
+- run id
+- test run id
+- generated briefing date
+- proposed Top 5 and depth rows
+- validation status and failure details
+- persistence result and exact inserted row IDs for rollback
+
+## Non-Goals
+
+- Does not re-enable the scheduled Vercel cron.
+- Does not run the pipeline.
+- Does not write production data.
+- Does not modify Action 1 ranking behavior.
+- Does not change cleaned April 26 public content.
+- Does not introduce a new canonical PRD.

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "eslint-config-next": "16.2.2",
         "jsdom": "^29.0.2",
         "tailwindcss": "^4",
+        "tsx": "^4.21.0",
         "typescript": "^5",
         "vitest": "^4.1.4"
       }
@@ -518,6 +519,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -6194,6 +6637,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -10424,6 +10909,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:e2e:report": "playwright show-report",
     "test:e2e:audit": "playwright test tests/smoke tests/routes tests/navigation tests/responsive tests/audit",
     "test:e2e:audit:chromium": "playwright test tests/smoke tests/routes tests/navigation tests/responsive tests/audit --project=chromium",
+    "pipeline:controlled-test": "tsx scripts/pipeline-controlled-test.ts",
     "audit:ui:report": "node scripts/playwright-ui-audit-report.mjs",
     "governance:coverage": "python3 scripts/validate-documentation-coverage.py",
     "governance:audit": "python3 scripts/pr-governance-audit.py",
@@ -55,6 +56,7 @@
     "eslint-config-next": "16.2.2",
     "jsdom": "^29.0.2",
     "tailwindcss": "^4",
+    "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "^4.1.4"
   }

--- a/scripts/pipeline-controlled-test.ts
+++ b/scripts/pipeline-controlled-test.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  resolveControlledPipelineConfig,
+} from "@/lib/pipeline/controlled-execution";
+import { runControlledPipeline } from "@/lib/pipeline/controlled-runner";
+
+function buildArtifactPath(artifactDir: string, mode: string, testRunId: string | null) {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const suffix = testRunId ? `-${testRunId.replace(/[^a-z0-9_-]/gi, "-")}` : "";
+
+  return path.resolve(
+    process.cwd(),
+    artifactDir,
+    `controlled-pipeline-${mode}${suffix}-${timestamp}.json`,
+  );
+}
+
+async function writeReportArtifact(
+  artifactDir: string,
+  mode: string,
+  testRunId: string | null,
+  report: unknown,
+) {
+  const artifactPath = buildArtifactPath(artifactDir, mode, testRunId);
+
+  await mkdir(path.dirname(artifactPath), { recursive: true });
+  await writeFile(artifactPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+
+  return artifactPath;
+}
+
+async function main() {
+  const config = resolveControlledPipelineConfig();
+  const report = await runControlledPipeline(config);
+  const persistence = report.persistence;
+  const briefingDate = report.generatedBriefingDate;
+  const artifactPath = await writeReportArtifact(
+    config.artifactDir,
+    config.mode,
+    config.testRunId,
+    report,
+  );
+
+  console.log(JSON.stringify({
+    ok: persistence ? persistence.ok : true,
+    mode: config.mode,
+    artifactPath,
+    runId: report.runId,
+    briefingDate,
+    candidateCount: report.candidateCount,
+    insertedCount: persistence?.insertedCount ?? 0,
+    insertedPostIds: persistence?.insertedPostIds ?? [],
+    message: persistence?.message ?? "Dry run completed without Supabase writes.",
+  }, null, 2));
+
+  if (persistence && !persistence.ok) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/pr-governance-audit.py
+++ b/scripts/pr-governance-audit.py
@@ -34,7 +34,7 @@ def main() -> int:
         print(f"PR governance audit failed to inspect repo state.\n{exc}")
         return 0
 
-    context = classify_changes(changes, branch, args.pr_title)
+    context = classify_changes(changes, branch, args.pr_title, repo_root)
     missing_groups = find_missing_doc_groups(context)
 
     print("## PR Governance Audit")

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -56,6 +56,7 @@ type SupabaseServerClient = NonNullable<Awaited<ReturnType<typeof createSupabase
 async function runClusterFirstPipelineSafely(options: {
   sources?: Source[];
   suppliedByManifest?: boolean;
+  persistArticleCandidates?: boolean;
 } = {}): Promise<ClusterFirstPipelineResult> {
   const { runClusterFirstPipeline } = await import("@/lib/pipeline");
   return runClusterFirstPipeline(options);
@@ -1175,7 +1176,7 @@ export async function getBriefingDetailPageState(dateKey: string, route = `/brie
 export async function generateDailyBriefing(
   topics: Topic[] = demoTopics,
   sources: Source[] = getMvpDefaultPublicSources(),
-  options: { suppliedByManifest?: boolean } = {},
+  options: { suppliedByManifest?: boolean; persistPipelineCandidates?: boolean } = {},
 ): Promise<{
   briefing: DailyBriefing;
   publicRankedItems: BriefingItem[];
@@ -1184,6 +1185,7 @@ export async function generateDailyBriefing(
   const pipelineOptions: Parameters<typeof runClusterFirstPipelineSafely>[0] = {
     sources,
     suppliedByManifest: options.suppliedByManifest,
+    persistArticleCandidates: options.persistPipelineCandidates,
   };
   const { run, ranked_clusters } = await runClusterFirstPipelineSafely(pipelineOptions);
   const topicFallback = topics[0] ?? demoTopics[0];

--- a/src/lib/pipeline/controlled-execution.test.ts
+++ b/src/lib/pipeline/controlled-execution.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertControlledPipelineCanExecute,
+  buildControlledPipelineReport,
+  resolveControlledPipelineConfig,
+  type ControlledPipelineConfig,
+} from "@/lib/pipeline/controlled-execution";
+import type { DailyBriefing } from "@/lib/types";
+
+function buildConfig(overrides: Partial<ControlledPipelineConfig> = {}): ControlledPipelineConfig {
+  return {
+    mode: "dry_run",
+    briefingDateOverride: null,
+    testRunId: null,
+    targetEnvironment: "local",
+    allowProductionPipelineTest: false,
+    cronDisabledConfirmed: false,
+    artifactDir: ".pipeline-runs",
+    ...overrides,
+  };
+}
+
+function buildBriefing(): DailyBriefing {
+  return {
+    id: "briefing-test",
+    briefingDate: "2026-04-27T12:00:00.000Z",
+    title: "Daily Executive Briefing",
+    intro: "Controlled test briefing.",
+    readingWindow: "10 minutes",
+    items: [],
+  };
+}
+
+function buildItem(index: number, whyItMatters: string) {
+  return {
+    id: `candidate-${index}`,
+    topicId: "topic-tech",
+    topicName: "Tech",
+    title: `Candidate ${index}`,
+    whatHappened: `Candidate ${index} summary`,
+    keyPoints: [`Candidate ${index} point`],
+    whyItMatters,
+    aiWhyItMatters: whyItMatters,
+    sources: [{ title: "Source", url: `https://example.com/${index}` }],
+    sourceCount: 1,
+    estimatedMinutes: 4,
+    read: false,
+    priority: "normal" as const,
+    matchedKeywords: ["tech"],
+    importanceScore: 70 - index,
+    rankingSignals: [`Ranking signal ${index}`],
+  };
+}
+
+describe("controlled pipeline execution config", () => {
+  it("resolves dry_run as a write-safe run mode", () => {
+    const config = resolveControlledPipelineConfig({
+      PIPELINE_RUN_MODE: "dry_run",
+    } as NodeJS.ProcessEnv);
+
+    expect(config.mode).toBe("dry_run");
+    expect(config.targetEnvironment).toBe("local");
+    expect(() => assertControlledPipelineCanExecute(config)).not.toThrow();
+  });
+
+  it("refuses production draft_only runs without explicit safety guards", () => {
+    const config = buildConfig({
+      mode: "draft_only",
+      briefingDateOverride: "2026-04-27",
+      testRunId: "controlled-test",
+      targetEnvironment: "production",
+    });
+
+    expect(() => assertControlledPipelineCanExecute(config)).toThrow(/ALLOW_PRODUCTION_PIPELINE_TEST/);
+  });
+
+  it("requires a briefing date, test run id, and cron-disabled confirmation for production draft_only", () => {
+    const missingDate = buildConfig({
+      mode: "draft_only",
+      testRunId: "controlled-test",
+      targetEnvironment: "production",
+      allowProductionPipelineTest: true,
+      cronDisabledConfirmed: true,
+    });
+    const missingRunId = buildConfig({
+      mode: "draft_only",
+      briefingDateOverride: "2026-04-27",
+      targetEnvironment: "production",
+      allowProductionPipelineTest: true,
+      cronDisabledConfirmed: true,
+    });
+    const missingCronConfirmation = buildConfig({
+      mode: "draft_only",
+      briefingDateOverride: "2026-04-27",
+      testRunId: "controlled-test",
+      targetEnvironment: "production",
+      allowProductionPipelineTest: true,
+      cronDisabledConfirmed: false,
+    });
+
+    expect(() => assertControlledPipelineCanExecute(missingDate)).toThrow(/BRIEFING_DATE_OVERRIDE/);
+    expect(() => assertControlledPipelineCanExecute(missingRunId)).toThrow(/PIPELINE_TEST_RUN_ID/);
+    expect(() => assertControlledPipelineCanExecute(missingCronConfirmation)).toThrow(/PIPELINE_CRON_DISABLED_CONFIRMED/);
+  });
+
+  it("allows production draft_only only when every safety guard is present", () => {
+    const config = buildConfig({
+      mode: "draft_only",
+      briefingDateOverride: "2026-04-27",
+      testRunId: "controlled-test",
+      targetEnvironment: "production",
+      allowProductionPipelineTest: true,
+      cronDisabledConfirmed: true,
+    });
+
+    expect(() => assertControlledPipelineCanExecute(config)).not.toThrow();
+  });
+
+  it("does not allow normal mode to accept test-run overrides", () => {
+    const config = buildConfig({
+      mode: "normal",
+      briefingDateOverride: "2026-04-27",
+      testRunId: "controlled-test",
+    });
+
+    expect(() => assertControlledPipelineCanExecute(config)).toThrow(/BRIEFING_DATE_OVERRIDE/);
+  });
+});
+
+describe("controlled pipeline report", () => {
+  it("reports validation status and failure reasons for proposed generated signals", () => {
+    const valid =
+      "Anthropic's growth is now structurally tied to Google and Amazon's infrastructure, not independent of it. At scale, that's a dependency, not just a partnership.";
+    const invalid = "This changes how investors price rates, demand, or risk in rates and equities over";
+    const publicRankedItems = [
+      buildItem(1, invalid),
+      buildItem(2, valid),
+      buildItem(3, valid),
+      buildItem(4, valid),
+      buildItem(5, valid),
+      buildItem(6, invalid),
+    ];
+    const report = buildControlledPipelineReport({
+      mode: "dry_run",
+      testRunId: "report-test",
+      briefing: {
+        ...buildBriefing(),
+        items: publicRankedItems.slice(0, 5),
+      },
+      publicRankedItems,
+      pipelineRun: {
+        run_id: "pipeline-test",
+        num_clusters: 6,
+      } as never,
+    });
+
+    expect(report.mode).toBe("dry_run");
+    expect(report.runId).toBe("pipeline-test");
+    expect(report.candidateCount).toBe(6);
+    expect(report.proposedTopFive).toHaveLength(5);
+    expect(report.proposedDepthRows).toHaveLength(1);
+    expect(report.proposedTopFive[0]).toMatchObject({
+      validationStatus: "requires_human_rewrite",
+      validationFailures: expect.arrayContaining(["incomplete_sentence", "template_placeholder_language"]),
+    });
+    expect(report.proposedTopFive[1]).toMatchObject({
+      validationStatus: "passed",
+      validationFailures: [],
+      validationDetails: [],
+    });
+    expect(report.proposedDepthRows[0].validationStatus).toBe("requires_human_rewrite");
+  });
+});

--- a/src/lib/pipeline/controlled-execution.ts
+++ b/src/lib/pipeline/controlled-execution.ts
@@ -1,0 +1,199 @@
+import type { ClusterFirstPipelineResult } from "@/lib/pipeline";
+import type { SignalSnapshotPersistenceResult } from "@/lib/signals-editorial";
+import type { BriefingItem, DailyBriefing } from "@/lib/types";
+import { validateWhyItMatters } from "@/lib/why-it-matters-quality-gate";
+
+export type PipelineRunMode = "normal" | "dry_run" | "draft_only";
+export type PipelineTargetEnvironment = "local" | "preview" | "staging" | "production";
+
+export type ControlledPipelineConfig = {
+  mode: PipelineRunMode;
+  briefingDateOverride: string | null;
+  testRunId: string | null;
+  targetEnvironment: PipelineTargetEnvironment;
+  allowProductionPipelineTest: boolean;
+  cronDisabledConfirmed: boolean;
+  artifactDir: string;
+};
+
+export type ControlledPipelineSignalReport = {
+  id: string;
+  rank: number;
+  title: string;
+  sourceName: string | null;
+  sourceUrl: string | null;
+  whyItMatters: string;
+  validationStatus: "passed" | "requires_human_rewrite";
+  validationFailures: string[];
+  validationDetails: string[];
+};
+
+export type ControlledPipelineReport = {
+  mode: PipelineRunMode;
+  testRunId: string | null;
+  runId: string;
+  generatedBriefingDate: string;
+  candidateCount: number;
+  clusterCount: number;
+  signalCount: number;
+  proposedTopFive: ControlledPipelineSignalReport[];
+  proposedDepthRows: ControlledPipelineSignalReport[];
+  persistence: SignalSnapshotPersistenceResult | null;
+};
+
+const VALID_RUN_MODES = new Set<PipelineRunMode>(["normal", "dry_run", "draft_only"]);
+const VALID_TARGET_ENVIRONMENTS = new Set<PipelineTargetEnvironment>([
+  "local",
+  "preview",
+  "staging",
+  "production",
+]);
+
+function normalizeEnv(value: string | undefined) {
+  return value?.trim() ?? "";
+}
+
+function parseBooleanEnv(value: string | undefined) {
+  return /^(1|true|yes|on)$/i.test(normalizeEnv(value));
+}
+
+function parseRunMode(value: string | undefined): PipelineRunMode {
+  const normalized = normalizeEnv(value) || "normal";
+
+  if (VALID_RUN_MODES.has(normalized as PipelineRunMode)) {
+    return normalized as PipelineRunMode;
+  }
+
+  throw new Error(
+    `Invalid PIPELINE_RUN_MODE "${normalized}". Expected one of: normal, dry_run, draft_only.`,
+  );
+}
+
+function parseTargetEnvironment(env: NodeJS.ProcessEnv): PipelineTargetEnvironment {
+  const explicitTarget = normalizeEnv(env.PIPELINE_TARGET_ENV);
+  const vercelTarget = normalizeEnv(env.VERCEL_ENV);
+  const nodeTarget = normalizeEnv(env.NODE_ENV);
+  const normalized = (explicitTarget || vercelTarget || (nodeTarget === "production" ? "production" : "local"))
+    .toLowerCase();
+
+  if (VALID_TARGET_ENVIRONMENTS.has(normalized as PipelineTargetEnvironment)) {
+    return normalized as PipelineTargetEnvironment;
+  }
+
+  throw new Error(
+    `Invalid pipeline target environment "${normalized}". Expected one of: local, preview, staging, production.`,
+  );
+}
+
+function parseBriefingDateOverride(value: string | undefined) {
+  const normalized = normalizeEnv(value);
+
+  if (!normalized) {
+    return null;
+  }
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(normalized)) {
+    throw new Error("BRIEFING_DATE_OVERRIDE must use YYYY-MM-DD format.");
+  }
+
+  return normalized;
+}
+
+export function resolveControlledPipelineConfig(env: NodeJS.ProcessEnv = process.env): ControlledPipelineConfig {
+  return {
+    mode: parseRunMode(env.PIPELINE_RUN_MODE),
+    briefingDateOverride: parseBriefingDateOverride(env.BRIEFING_DATE_OVERRIDE),
+    testRunId: normalizeEnv(env.PIPELINE_TEST_RUN_ID) || null,
+    targetEnvironment: parseTargetEnvironment(env),
+    allowProductionPipelineTest: parseBooleanEnv(env.ALLOW_PRODUCTION_PIPELINE_TEST),
+    cronDisabledConfirmed: parseBooleanEnv(env.PIPELINE_CRON_DISABLED_CONFIRMED),
+    artifactDir: normalizeEnv(env.PIPELINE_RUN_ARTIFACT_DIR) || ".pipeline-runs",
+  };
+}
+
+export function assertControlledPipelineCanExecute(config: ControlledPipelineConfig) {
+  if (config.mode === "normal" && config.briefingDateOverride) {
+    throw new Error("BRIEFING_DATE_OVERRIDE is not allowed for normal pipeline runs.");
+  }
+
+  if (config.mode === "normal" && config.testRunId) {
+    throw new Error("PIPELINE_TEST_RUN_ID is not allowed for normal pipeline runs.");
+  }
+
+  if (config.mode !== "draft_only") {
+    return;
+  }
+
+  if (!config.briefingDateOverride) {
+    throw new Error("draft_only mode requires BRIEFING_DATE_OVERRIDE=YYYY-MM-DD.");
+  }
+
+  if (!config.testRunId) {
+    throw new Error("draft_only mode requires PIPELINE_TEST_RUN_ID.");
+  }
+
+  if (config.targetEnvironment !== "production") {
+    return;
+  }
+
+  if (!config.allowProductionPipelineTest) {
+    throw new Error("production draft_only mode requires ALLOW_PRODUCTION_PIPELINE_TEST=true.");
+  }
+
+  if (!config.cronDisabledConfirmed) {
+    throw new Error("production draft_only mode requires PIPELINE_CRON_DISABLED_CONFIRMED=true.");
+  }
+}
+
+function selectSignalText(item: BriefingItem) {
+  return (item.aiWhyItMatters ?? item.whyItMatters ?? "").trim();
+}
+
+function mapSignalReport(item: BriefingItem, rank: number): ControlledPipelineSignalReport {
+  const source = item.sources[0] ?? item.relatedArticles?.[0] ?? null;
+  const whyItMatters = selectSignalText(item);
+  const validation = validateWhyItMatters(whyItMatters);
+  const sourceName = source
+    ? "sourceName" in source && typeof source.sourceName === "string"
+      ? source.sourceName
+      : source.title
+    : null;
+
+  return {
+    id: item.id,
+    rank,
+    title: item.title,
+    sourceName: sourceName ?? null,
+    sourceUrl: source?.url ?? null,
+    whyItMatters,
+    validationStatus: validation.passed ? "passed" : "requires_human_rewrite",
+    validationFailures: validation.failures,
+    validationDetails: validation.failureDetails,
+  };
+}
+
+export function buildControlledPipelineReport(input: {
+  mode: PipelineRunMode;
+  testRunId?: string | null;
+  briefing: DailyBriefing;
+  publicRankedItems: BriefingItem[];
+  pipelineRun: ClusterFirstPipelineResult["run"];
+  persistence?: SignalSnapshotPersistenceResult | null;
+}): ControlledPipelineReport {
+  const candidates = input.publicRankedItems.length > 0
+    ? input.publicRankedItems
+    : input.briefing.items;
+
+  return {
+    mode: input.mode,
+    testRunId: input.testRunId ?? null,
+    runId: input.pipelineRun.run_id,
+    generatedBriefingDate: input.briefing.briefingDate.slice(0, 10),
+    candidateCount: candidates.length,
+    clusterCount: input.pipelineRun.num_clusters,
+    signalCount: input.briefing.items.length,
+    proposedTopFive: candidates.slice(0, 5).map((item, index) => mapSignalReport(item, index + 1)),
+    proposedDepthRows: candidates.slice(5, 20).map((item, index) => mapSignalReport(item, index + 6)),
+    persistence: input.persistence ?? null,
+  };
+}

--- a/src/lib/pipeline/controlled-persistence.test.ts
+++ b/src/lib/pipeline/controlled-persistence.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const persistNormalizedArticleCandidates = vi.fn();
+const updateArticleCandidateClusters = vi.fn();
+const updateArticleCandidateRankingOutcomes = vi.fn();
+
+vi.mock("@/lib/rss", () => ({
+  fetchFeedArticles: vi.fn(async () => {
+    throw new Error("network blocked");
+  }),
+}));
+
+vi.mock("@/lib/pipeline/article-candidates", () => ({
+  persistNormalizedArticleCandidates,
+  updateArticleCandidateClusters,
+  updateArticleCandidateRankingOutcomes,
+}));
+
+describe("controlled pipeline candidate persistence", () => {
+  beforeEach(() => {
+    persistNormalizedArticleCandidates.mockClear();
+    updateArticleCandidateClusters.mockClear();
+    updateArticleCandidateRankingOutcomes.mockClear();
+  });
+
+  it("dry-run pipeline execution can disable all pipeline_article_candidates writes", async () => {
+    const { runClusterFirstPipeline } = await import("@/lib/pipeline");
+
+    const result = await runClusterFirstPipeline({ persistArticleCandidates: false });
+
+    expect(result.run.used_seed_fallback).toBe(true);
+    expect(result.ranked_clusters.length).toBeGreaterThan(0);
+    expect(persistNormalizedArticleCandidates).not.toHaveBeenCalled();
+    expect(updateArticleCandidateClusters).not.toHaveBeenCalled();
+    expect(updateArticleCandidateRankingOutcomes).not.toHaveBeenCalled();
+  }, 15_000);
+
+  it("normal pipeline execution still records article-candidate stages", async () => {
+    const { runClusterFirstPipeline } = await import("@/lib/pipeline");
+
+    await runClusterFirstPipeline();
+
+    expect(persistNormalizedArticleCandidates).toHaveBeenCalledTimes(1);
+    expect(updateArticleCandidateClusters).toHaveBeenCalledTimes(1);
+    expect(updateArticleCandidateRankingOutcomes).toHaveBeenCalledTimes(1);
+  }, 15_000);
+});

--- a/src/lib/pipeline/controlled-runner.test.ts
+++ b/src/lib/pipeline/controlled-runner.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ControlledPipelineConfig } from "@/lib/pipeline/controlled-execution";
+
+const generateDailyBriefing = vi.fn();
+const persistSignalPostsForBriefing = vi.fn();
+
+vi.mock("@/lib/data", () => ({
+  generateDailyBriefing,
+}));
+
+vi.mock("@/lib/signals-editorial", () => ({
+  persistSignalPostsForBriefing,
+}));
+
+function buildConfig(overrides: Partial<ControlledPipelineConfig> = {}): ControlledPipelineConfig {
+  return {
+    mode: "dry_run",
+    briefingDateOverride: null,
+    testRunId: "controlled-test",
+    targetEnvironment: "local",
+    allowProductionPipelineTest: false,
+    cronDisabledConfirmed: false,
+    artifactDir: ".pipeline-runs",
+    ...overrides,
+  };
+}
+
+function buildItem(index: number) {
+  const whyItMatters =
+    index === 1
+      ? "This changes how investors price rates, demand, or risk in rates and equities over"
+      : "Anthropic's growth is now structurally tied to Google and Amazon's infrastructure, not independent of it. At scale, that's a dependency, not just a partnership.";
+
+  return {
+    id: `item-${index}`,
+    topicId: "topic-tech",
+    topicName: "Tech",
+    title: `Generated signal ${index}`,
+    whatHappened: `Generated summary ${index}`,
+    keyPoints: [`Point ${index}`],
+    whyItMatters,
+    aiWhyItMatters: whyItMatters,
+    sources: [{ title: "Source", url: `https://example.com/${index}` }],
+    sourceCount: 1,
+    estimatedMinutes: 4,
+    read: false,
+    priority: "normal" as const,
+    matchedKeywords: ["tech"],
+    importanceScore: 80 - index,
+    rankingSignals: [`Ranking signal ${index}`],
+  };
+}
+
+describe("runControlledPipeline", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    const items = Array.from({ length: 6 }, (_, index) => buildItem(index + 1));
+    generateDailyBriefing.mockResolvedValue({
+      briefing: {
+        id: "briefing-test",
+        briefingDate: "2026-04-27T12:00:00.000Z",
+        title: "Daily Executive Briefing",
+        intro: "Controlled test briefing.",
+        readingWindow: "20 minutes",
+        items: items.slice(0, 5),
+      },
+      publicRankedItems: items,
+      pipelineRun: {
+        run_id: "pipeline-test",
+        num_clusters: 6,
+      },
+    });
+    persistSignalPostsForBriefing.mockResolvedValue({
+      ok: true,
+      briefingDate: "2026-04-28",
+      insertedCount: 5,
+      insertedPostIds: ["row-1", "row-2", "row-3", "row-4", "row-5"],
+      mode: "draft_only",
+      message: "Persisted a new daily Top 5 snapshot for editorial review.",
+    });
+  });
+
+  it("dry_run generates a validation report without writing signal_posts", async () => {
+    const { runControlledPipeline } = await import("@/lib/pipeline/controlled-runner");
+    const report = await runControlledPipeline(buildConfig({ mode: "dry_run" }));
+
+    expect(generateDailyBriefing).toHaveBeenCalledWith(
+      undefined,
+      undefined,
+      { persistPipelineCandidates: false },
+    );
+    expect(persistSignalPostsForBriefing).not.toHaveBeenCalled();
+    expect(report.persistence).toBeNull();
+    expect(report.proposedTopFive[0]).toMatchObject({
+      validationStatus: "requires_human_rewrite",
+      validationFailures: expect.arrayContaining(["template_placeholder_language"]),
+    });
+  });
+
+  it("draft_only writes only review candidates for the override briefing date", async () => {
+    const { runControlledPipeline } = await import("@/lib/pipeline/controlled-runner");
+    const report = await runControlledPipeline(buildConfig({
+      mode: "draft_only",
+      briefingDateOverride: "2026-04-28",
+      testRunId: "draft-test",
+    }));
+
+    expect(persistSignalPostsForBriefing).toHaveBeenCalledWith({
+      briefingDate: "2026-04-28",
+      items: expect.arrayContaining([
+        expect.objectContaining({ id: "item-1" }),
+      ]),
+      mode: "draft_only",
+    });
+    expect(report.generatedBriefingDate).toBe("2026-04-28");
+    expect(report.persistence).toMatchObject({
+      ok: true,
+      insertedCount: 5,
+      insertedPostIds: ["row-1", "row-2", "row-3", "row-4", "row-5"],
+      mode: "draft_only",
+    });
+  });
+
+  it("refuses normal mode from the controlled test runner", async () => {
+    const { runControlledPipeline } = await import("@/lib/pipeline/controlled-runner");
+
+    await expect(runControlledPipeline(buildConfig({ mode: "normal", testRunId: null }))).rejects.toThrow(
+      /limited to dry_run and draft_only/i,
+    );
+  });
+});

--- a/src/lib/pipeline/controlled-runner.ts
+++ b/src/lib/pipeline/controlled-runner.ts
@@ -1,0 +1,48 @@
+import { generateDailyBriefing } from "@/lib/data";
+import {
+  assertControlledPipelineCanExecute,
+  buildControlledPipelineReport,
+  type ControlledPipelineConfig,
+  type ControlledPipelineReport,
+} from "@/lib/pipeline/controlled-execution";
+import { persistSignalPostsForBriefing } from "@/lib/signals-editorial";
+
+export async function runControlledPipeline(
+  config: ControlledPipelineConfig,
+): Promise<ControlledPipelineReport> {
+  assertControlledPipelineCanExecute(config);
+
+  if (config.mode === "normal") {
+    throw new Error(
+      "Controlled pipeline execution is limited to dry_run and draft_only. Normal scheduled execution remains owned by /api/cron/fetch-news after re-enable approval.",
+    );
+  }
+
+  const { briefing, publicRankedItems, pipelineRun } = await generateDailyBriefing(
+    undefined,
+    undefined,
+    {
+      persistPipelineCandidates: false,
+    },
+  );
+  const briefingDate = config.briefingDateOverride ?? briefing.briefingDate.slice(0, 10);
+  const persistence = config.mode === "draft_only"
+    ? await persistSignalPostsForBriefing({
+        briefingDate,
+        items: briefing.items,
+        mode: "draft_only",
+      })
+    : null;
+
+  return buildControlledPipelineReport({
+    mode: config.mode,
+    testRunId: config.testRunId,
+    briefing: {
+      ...briefing,
+      briefingDate: `${briefingDate}T12:00:00.000Z`,
+    },
+    publicRankedItems,
+    pipelineRun,
+    persistence,
+  });
+}

--- a/src/lib/pipeline/index.ts
+++ b/src/lib/pipeline/index.ts
@@ -24,10 +24,12 @@ export type ClusterFirstPipelineResult = {
 export async function runClusterFirstPipeline(options: {
   sources?: Source[];
   suppliedByManifest?: boolean;
+  persistArticleCandidates?: boolean;
 } = {}): Promise<ClusterFirstPipelineResult> {
   const runId = `pipeline-${Date.now()}`;
   const run = createEmptyPipelineRun(runId);
   const integrationSnapshot = getPipelineIntegrationSnapshot();
+  const shouldPersistArticleCandidates = options.persistArticleCandidates ?? true;
 
   logPipelineEvent("info", "Pipeline integration snapshot", integrationSnapshot);
 
@@ -45,17 +47,25 @@ export async function runClusterFirstPipeline(options: {
   run.used_seed_fallback = ingestion.usedSeedFallback;
 
   const normalized = normalizeRawItems(ingestion.items);
-  persistNormalizedArticleCandidates({ runId: run.run_id, articles: normalized });
   const deduped = deduplicateArticles(normalized);
   const clusters = clusterNormalizedArticles(deduped);
-  updateArticleCandidateClusters({ runId: run.run_id, clusters });
   const rankedStoryClusters = rankStoryClusters(clusters);
-  updateArticleCandidateRankingOutcomes({
-    runId: run.run_id,
-    normalizedArticles: normalized,
-    dedupedArticles: deduped,
-    rankedClusters: rankedStoryClusters,
-  });
+
+  if (shouldPersistArticleCandidates) {
+    persistNormalizedArticleCandidates({ runId: run.run_id, articles: normalized });
+    updateArticleCandidateClusters({ runId: run.run_id, clusters });
+    updateArticleCandidateRankingOutcomes({
+      runId: run.run_id,
+      normalizedArticles: normalized,
+      dedupedArticles: deduped,
+      rankedClusters: rankedStoryClusters,
+    });
+  } else {
+    logPipelineEvent("info", "Pipeline article candidate persistence skipped by run mode", {
+      run_id: run.run_id,
+    });
+  }
+
   const digest = buildDigestOutput(rankedStoryClusters);
   const singletonCount = clusters.filter((cluster) => cluster.cluster_size === 1).length;
   const preventedMergeCount = clusters.reduce(

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -125,8 +125,9 @@ function createSupabaseMock(
     from(tableName: string) {
       expect(tableName).toBe("signal_posts");
 
-      let operation: "select" | "update" | null = null;
+      let operation: "select" | "update" | "insert" | null = null;
       let updateValues: Partial<SignalPostRow> = {};
+      let insertedRows: SignalPostRow[] = [];
       let selectError: { message: string } | null = null;
       let selectedColumns: string[] = [];
       const filters: Array<{ column: keyof SignalPostRow; value: unknown }> = [];
@@ -191,7 +192,9 @@ function createSupabaseMock(
 
       const builder = {
         select(columns?: string) {
-          operation = "select";
+          if (operation !== "insert") {
+            operation = "select";
+          }
           selectedColumns = String(columns ?? "")
             .split(",")
             .map((column) => column.trim().split(/\s+/)[0])
@@ -236,11 +239,15 @@ function createSupabaseMock(
           });
         },
         insert(values: Partial<SignalPostRow>[]) {
+          operation = "insert";
+          insertedRows = [];
           values.forEach((value, index) => {
-            rows.push(createRow({ id: `inserted-${index + 1}`, ...value }));
+            const row = createRow({ id: `inserted-${index + 1}`, ...value });
+            rows.push(row);
+            insertedRows.push(row);
           });
 
-          return Promise.resolve({ error: null });
+          return builder;
         },
         update(values: Partial<SignalPostRow>) {
           operation = "update";
@@ -279,6 +286,14 @@ function createSupabaseMock(
         ) {
           if (operation === "select" || operation === null) {
             return selectResult().then(onfulfilled, onrejected);
+          }
+
+          if (operation === "insert") {
+            return Promise.resolve({
+              data: insertedRows,
+              error: null,
+              count: insertedRows.length,
+            }).then(onfulfilled, onrejected);
           }
 
           return Promise.resolve({ data: [], error: null, count: 0 }).then(onfulfilled, onrejected);
@@ -785,7 +800,48 @@ describe("signals editorial workflow", () => {
     expect(rows[6].is_live).toBe(false);
   });
 
-  it("persists a new daily Top 5 snapshot with bounded public depth and archives the previous live set", async () => {
+  it("keeps live-set replacement inside the explicit publish workflow", async () => {
+    const oldLiveRows = Array.from({ length: 5 }, (_, index) =>
+      createRow({
+        id: `old-live-${index + 1}`,
+        briefing_date: "2026-04-26",
+        rank: index + 1,
+        editorial_status: "published",
+        published_why_it_matters: createValidWhyItMatters(`Old Google ${index + 1}`),
+        is_live: true,
+        published_at: "2026-04-26T10:00:00.000Z",
+      }),
+    );
+    const approvedRows = Array.from({ length: 5 }, (_, index) =>
+      createRow({
+        id: `approved-${index + 1}`,
+        briefing_date: "2026-04-27",
+        rank: index + 1,
+        edited_why_it_matters: createValidWhyItMatters(`New Google ${index + 1}`),
+        editorial_status: "approved",
+        is_live: false,
+      }),
+    );
+    const rows = [...oldLiveRows, ...approvedRows];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { publishApprovedSignals } = await loadEditorialModule();
+    const result = await publishApprovedSignals();
+
+    expect(result.ok).toBe(true);
+    expect(oldLiveRows.every((row) => row.is_live === false)).toBe(true);
+    expect(approvedRows.every((row) => row.editorial_status === "published")).toBe(true);
+    expect(approvedRows.every((row) => row.is_live === true)).toBe(true);
+    expect(approvedRows.every((row) => row.published_at !== null)).toBe(true);
+    expect(approvedRows[0].published_why_it_matters).toBe(createValidWhyItMatters("New Google 1"));
+  });
+
+  it("persists generated signal posts for editorial review without changing the live public set", async () => {
     const rows = Array.from({ length: 5 }, (_, index) =>
       createRow({
         id: `live-${index + 1}`,
@@ -806,12 +862,60 @@ describe("signals editorial workflow", () => {
 
     expect(result.ok).toBe(true);
     expect(result.insertedCount).toBe(8);
-    expect(rows.filter((row) => row.briefing_date === "2026-04-24").every((row) => row.is_live === false)).toBe(true);
+    expect(result.insertedPostIds).toEqual([
+      "inserted-1",
+      "inserted-2",
+      "inserted-3",
+      "inserted-4",
+      "inserted-5",
+      "inserted-6",
+      "inserted-7",
+      "inserted-8",
+    ]);
+    expect(rows.filter((row) => row.briefing_date === "2026-04-24").every((row) => row.is_live === true)).toBe(true);
 
     const insertedRows = rows.filter((row) => row.briefing_date === "2026-04-25");
     expect(insertedRows).toHaveLength(8);
-    expect(insertedRows.every((row) => row.is_live === true)).toBe(true);
+    expect(insertedRows.every((row) => row.editorial_status === "needs_review")).toBe(true);
+    expect(insertedRows.every((row) => row.is_live === false)).toBe(true);
+    expect(insertedRows.every((row) => row.published_at === null)).toBe(true);
     expect(insertedRows.map((row) => row.rank)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+
+  it("draft_only mode persists only review rows with validation details", async () => {
+    const rows: SignalPostRow[] = [];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+
+    const { persistSignalPostsForBriefing } = await loadEditorialModule();
+    const result = await persistSignalPostsForBriefing({
+      briefingDate: "2026-04-27",
+      mode: "draft_only",
+      items: Array.from({ length: 5 }, (_, index) => ({
+        ...createBriefingItem(index + 1),
+        aiWhyItMatters:
+          index === 0
+            ? "This changes how investors price rates, demand, or risk in rates and equities over"
+            : createValidWhyItMatters(`Google ${index + 1}`),
+      })),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.mode).toBe("draft_only");
+    expect(result.insertedCount).toBe(5);
+    expect(result.insertedPostIds).toEqual([
+      "inserted-1",
+      "inserted-2",
+      "inserted-3",
+      "inserted-4",
+      "inserted-5",
+    ]);
+    expect(rows).toHaveLength(5);
+    expect(rows.every((row) => row.editorial_status === "needs_review")).toBe(true);
+    expect(rows.every((row) => row.is_live === false)).toBe(true);
+    expect(rows.every((row) => row.published_at === null)).toBe(true);
+    expect(rows[0].why_it_matters_validation_status).toBe("requires_human_rewrite");
+    expect(rows[0].why_it_matters_validation_failures).toContain("template_placeholder_language");
+    expect(rows[1].why_it_matters_validation_status).toBe("passed");
   });
 
   it("flags malformed why-it-matters drafts without blocking signal snapshot persistence", async () => {

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -188,8 +188,12 @@ export type SignalSnapshotPersistenceResult = {
   ok: boolean;
   briefingDate: string;
   insertedCount: number;
+  insertedPostIds?: string[];
+  mode?: SignalPostPersistenceMode;
   message: string;
 };
+
+export type SignalPostPersistenceMode = "normal" | "draft_only";
 
 export type HomepageSignalSnapshot = {
   source: "published_live" | "recent_published" | "none";
@@ -587,9 +591,11 @@ async function persistSignalPostCandidates(
   input: {
     briefingDate: string;
     candidates: EditorialSignalPost[];
+    mode?: SignalPostPersistenceMode;
   },
 ): Promise<SignalSnapshotPersistenceResult> {
   const briefingDate = normalizeDateValue(input.briefingDate) ?? new Date().toISOString().slice(0, 10);
+  const mode = input.mode ?? "normal";
 
   if (input.candidates.length < TOP_SIGNAL_SET_SIZE) {
     return {
@@ -602,7 +608,7 @@ async function persistSignalPostCandidates(
 
   const existingResult = await client
     .from("signal_posts")
-    .select("id, rank, is_live")
+    .select("id, rank")
     .eq("briefing_date", briefingDate);
 
   if (existingResult.error) {
@@ -622,7 +628,7 @@ async function persistSignalPostCandidates(
     };
   }
 
-  const existingRows = ((existingResult.data ?? []) as Array<{ id: string; rank: number | null; is_live: boolean | null }>);
+  const existingRows = ((existingResult.data ?? []) as Array<{ id: string; rank: number | null }>);
   const existingRanks = new Set(
     existingRows
       .map((row) => row.rank)
@@ -635,40 +641,13 @@ async function persistSignalPostCandidates(
       ok: true,
       briefingDate,
       insertedCount: 0,
+      insertedPostIds: [],
+      mode,
       message: "The daily signal snapshot already exists for this briefing date.",
     };
   }
 
-  const shouldActivateInsertedRows =
-    existingRows.length > 0 ? existingRows.some((row) => Boolean(row.is_live)) : true;
   const now = new Date().toISOString();
-
-  if (existingRows.length === 0 && shouldActivateInsertedRows) {
-    const deactivateOldLiveSet = await client
-      .from("signal_posts")
-      .update({
-        is_live: false,
-        updated_at: now,
-      })
-      .eq("is_live", true);
-
-    if (deactivateOldLiveSet.error) {
-      captureRssEditorialStorageFailure({
-        failureType: "rss_cache_write_failed",
-        phase: "store",
-        operation: "archive_previous_live_signal_set",
-        briefingDate,
-        message: "Previous live RSS signal set could not be archived before persistence.",
-      });
-
-      return {
-        ok: false,
-        briefingDate,
-        insertedCount: 0,
-        message: `The previous live signal set could not be archived before the new daily snapshot was inserted: ${deactivateOldLiveSet.error.message}`,
-      };
-    }
-  }
 
   const flaggedCandidates = missingCandidates.map(flagCardForRewrite);
   const insertResult = await client.from("signal_posts").insert(
@@ -690,11 +669,12 @@ async function persistSignalPostCandidates(
       why_it_matters_validation_details: post.whyItMattersValidation.failureDetails,
       why_it_matters_validated_at: now,
       editorial_status: "needs_review",
-      is_live: shouldActivateInsertedRows,
+      published_at: null,
+      is_live: false,
       created_at: now,
       updated_at: now,
     })),
-  );
+  ).select("id");
 
   if (insertResult.error) {
     captureRssEditorialStorageFailure({
@@ -718,16 +698,21 @@ async function persistSignalPostCandidates(
     ok: true,
     briefingDate,
     insertedCount: missingCandidates.length,
+    insertedPostIds: ((insertResult.data ?? []) as Array<{ id: string | null }>)
+      .map((row) => row.id)
+      .filter((id): id is string => Boolean(id)),
+    mode,
     message:
       missingCandidates.length === TOP_SIGNAL_SET_SIZE
-        ? "Persisted a new daily Top 5 snapshot."
-        : `Persisted ${missingCandidates.length} missing signal snapshot rows.`,
+        ? "Persisted a new daily Top 5 snapshot for editorial review."
+        : `Persisted ${missingCandidates.length} missing signal snapshot rows for editorial review.`,
   };
 }
 
 export async function persistSignalPostsForBriefing(input: {
   briefingDate: string;
   items: BriefingItem[];
+  mode?: SignalPostPersistenceMode;
 }): Promise<SignalSnapshotPersistenceResult> {
   const client = createSupabaseServiceRoleClient();
   const briefingDate = normalizeDateValue(input.briefingDate) ?? new Date().toISOString().slice(0, 10);
@@ -755,6 +740,7 @@ export async function persistSignalPostsForBriefing(input: {
   return persistSignalPostCandidates(client, {
     briefingDate: input.briefingDate,
     candidates: buildSignalPostCandidates(input.items),
+    mode: input.mode,
   });
 }
 


### PR DESCRIPTION

<img width="775" height="694" alt="Screenshot 2026-04-27 at 8 47 50 PM" src="https://github.com/user-attachments/assets/89bc0655-6d38-42c8-be3a-adead265bf74" />
## Change type
remediation / alignment

## Source of truth
- Product Position: curated briefing, explicit structural why-it-matters, no false freshness
- PRD-35, PRD-37, PRD-53, PRD-57
- Final Launch Content QA PASS report
- Controlled Pipeline Test Plan: BLOCKED because no safe dry-run/draft-only execution mode existed

## Summary
- Adds `PIPELINE_RUN_MODE=dry_run|draft_only|normal` support for controlled pipeline execution.
- Adds `npm run pipeline:controlled-test` as a local/server-side script, not a public route.
- Ensures dry runs skip `pipeline_article_candidates` and `signal_posts` writes.
- Ensures draft-only writes create `needs_review`, `is_live=false`, `published_at=null` rows with why-it-matters validation status and failure details.
- Removes generation-time public activation; only explicit editorial publish can deactivate/activate live rows.
- Adds production guardrails requiring explicit env confirmation before production draft-only writes.
- Adds an engineering change record; no new canonical PRD is required for this remediation.

## Validation
- `npm install`
- `npm run lint`
- `npm run test`
- `npm run build`
- `npm run governance:coverage`
- `npm run governance:audit`
- `npm run governance:hotspots`
- `python3 scripts/validate-feature-system-csv.py`
- `python3 scripts/release-governance-gate.py`
- `PLAYWRIGHT_MANAGED_WEBSERVER=1 npm run test:e2e:chromium`
- `PLAYWRIGHT_MANAGED_WEBSERVER=1 npm run test:e2e:webkit`

## Non-goals
- Does not run the pipeline.
- Does not re-enable `/api/cron/fetch-news`.
- Does not modify production `signal_posts` data.
- Does not change Action 1 ranking behavior.
- Does not change cleaned April 26 public content.
- Does not remove `newsweb2026@gmail.com` from Production `ADMIN_EMAILS`.
