### PR TITLE
Remediate controlled Phase B draft selector

### DIFF
--- a/docs/engineering/change-records/phase-b-core-context-draft-selector.md
+++ b/docs/engineering/change-records/phase-b-core-context-draft-selector.md
@@ -1,0 +1,31 @@
+# Phase B Core/Context Draft Selector
+
+## Summary
+
+This remediation adds a tightly scoped controlled-pipeline selector for a limited Phase B `draft_only` run. The default `draft_only` behavior remains Core-only. Context rows are included only when explicitly enabled through controlled-test environment configuration.
+
+## Controlled Configuration
+
+- `PIPELINE_DRAFT_TIER_ALLOWLIST=core,context`
+- `PIPELINE_DRAFT_MAX_ROWS=3`
+
+The selector accepts only Core and Context tiers for this path. Depth and excluded rows fail closed by configuration or selection filtering.
+
+## Safety Boundaries
+
+- Existing production draft gating is preserved.
+- `ALLOW_PRODUCTION_PIPELINE_TEST=true` is still required for production `draft_only`.
+- `PIPELINE_RUN_MODE=draft_only` is still required for writes.
+- `PIPELINE_CRON_DISABLED_CONFIRMED=true` is still required for production `draft_only`.
+- `PIPELINE_DRAFT_MAX_ROWS` is capped at three rows.
+- No cron settings, public publish behavior, source manifests, ranking calibration, or why-it-matters templates are changed.
+
+## Persistence Behavior
+
+Rows inserted through `persistSignalPostsForBriefing` remain editorial review candidates:
+
+- `editorial_status = needs_review`
+- `is_live = false`
+- `published_at = null`
+
+This change does not execute `draft_only` and does not write production data.

--- a/src/lib/pipeline/controlled-execution.test.ts
+++ b/src/lib/pipeline/controlled-execution.test.ts
@@ -16,6 +16,8 @@ function buildConfig(overrides: Partial<ControlledPipelineConfig> = {}): Control
     targetEnvironment: "local",
     allowProductionPipelineTest: false,
     cronDisabledConfirmed: false,
+    draftTierAllowlist: null,
+    draftMaxRows: null,
     artifactDir: ".pipeline-runs",
     ...overrides,
   };
@@ -88,7 +90,62 @@ describe("controlled pipeline execution config", () => {
 
     expect(config.mode).toBe("dry_run");
     expect(config.targetEnvironment).toBe("local");
+    expect(config.draftTierAllowlist).toBeNull();
+    expect(config.draftMaxRows).toBeNull();
     expect(() => assertControlledPipelineCanExecute(config)).not.toThrow();
+  });
+
+  it("resolves explicit Core and Context draft selection controls for controlled runs", () => {
+    const config = resolveControlledPipelineConfig({
+      PIPELINE_RUN_MODE: "dry_run",
+      PIPELINE_DRAFT_TIER_ALLOWLIST: "core,context",
+      PIPELINE_DRAFT_MAX_ROWS: "3",
+    } as NodeJS.ProcessEnv);
+
+    expect(config.draftTierAllowlist).toEqual(["core_signal_eligible", "context_signal_eligible"]);
+    expect(config.draftMaxRows).toBe(3);
+    expect(() => assertControlledPipelineCanExecute(config)).not.toThrow();
+  });
+
+  it("fails closed for unsupported draft tiers", () => {
+    expect(() =>
+      resolveControlledPipelineConfig({
+        PIPELINE_RUN_MODE: "dry_run",
+        PIPELINE_DRAFT_TIER_ALLOWLIST: "core,depth",
+      } as NodeJS.ProcessEnv),
+    ).toThrow(/PIPELINE_DRAFT_TIER_ALLOWLIST/);
+  });
+
+  it("fails closed for invalid draft max rows", () => {
+    expect(() =>
+      resolveControlledPipelineConfig({
+        PIPELINE_RUN_MODE: "dry_run",
+        PIPELINE_DRAFT_MAX_ROWS: "0",
+      } as NodeJS.ProcessEnv),
+    ).toThrow(/PIPELINE_DRAFT_MAX_ROWS/);
+
+    expect(() =>
+      resolveControlledPipelineConfig({
+        PIPELINE_RUN_MODE: "dry_run",
+        PIPELINE_DRAFT_MAX_ROWS: "3.5",
+      } as NodeJS.ProcessEnv),
+    ).toThrow(/PIPELINE_DRAFT_MAX_ROWS/);
+
+    expect(() =>
+      resolveControlledPipelineConfig({
+        PIPELINE_RUN_MODE: "dry_run",
+        PIPELINE_DRAFT_MAX_ROWS: "4",
+      } as NodeJS.ProcessEnv),
+    ).toThrow(/PIPELINE_DRAFT_MAX_ROWS/);
+  });
+
+  it("requires an explicit max-row cap when a draft tier allowlist is set", () => {
+    const config = buildConfig({
+      mode: "dry_run",
+      draftTierAllowlist: ["core_signal_eligible", "context_signal_eligible"],
+    });
+
+    expect(() => assertControlledPipelineCanExecute(config)).toThrow(/PIPELINE_DRAFT_MAX_ROWS/);
   });
 
   it("refuses production draft_only runs without explicit safety guards", () => {
@@ -152,6 +209,16 @@ describe("controlled pipeline execution config", () => {
     });
 
     expect(() => assertControlledPipelineCanExecute(config)).toThrow(/BRIEFING_DATE_OVERRIDE/);
+  });
+
+  it("does not allow normal mode to accept draft selection controls", () => {
+    const config = buildConfig({
+      mode: "normal",
+      draftTierAllowlist: ["core_signal_eligible", "context_signal_eligible"],
+      draftMaxRows: 3,
+    });
+
+    expect(() => assertControlledPipelineCanExecute(config)).toThrow(/PIPELINE_DRAFT_\*/);
   });
 });
 

--- a/src/lib/pipeline/controlled-execution.ts
+++ b/src/lib/pipeline/controlled-execution.ts
@@ -8,6 +8,7 @@ import { summarizeSourceDistribution } from "@/lib/signal-selection-eligibility"
 
 export type PipelineRunMode = "normal" | "dry_run" | "draft_only";
 export type PipelineTargetEnvironment = "local" | "preview" | "staging" | "production";
+export type ControlledPipelineDraftTier = "core_signal_eligible" | "context_signal_eligible";
 
 export type ControlledPipelineConfig = {
   mode: PipelineRunMode;
@@ -16,6 +17,8 @@ export type ControlledPipelineConfig = {
   targetEnvironment: PipelineTargetEnvironment;
   allowProductionPipelineTest: boolean;
   cronDisabledConfirmed: boolean;
+  draftTierAllowlist: ControlledPipelineDraftTier[] | null;
+  draftMaxRows: number | null;
   artifactDir: string;
 };
 
@@ -209,6 +212,58 @@ function parseBriefingDateOverride(value: string | undefined) {
   return normalized;
 }
 
+function parseDraftTierAllowlist(value: string | undefined): ControlledPipelineDraftTier[] | null {
+  const normalized = normalizeEnv(value);
+
+  if (!normalized) {
+    return null;
+  }
+
+  const parsed = normalized
+    .split(",")
+    .map((tier) => tier.trim().toLowerCase())
+    .filter(Boolean)
+    .map((tier) => {
+      if (tier === "core" || tier === "core_signal_eligible") {
+        return "core_signal_eligible";
+      }
+
+      if (tier === "context" || tier === "context_signal_eligible") {
+        return "context_signal_eligible";
+      }
+
+      throw new Error(
+        `Invalid PIPELINE_DRAFT_TIER_ALLOWLIST tier "${tier}". Expected only core,context for the controlled Phase B draft path.`,
+      );
+    });
+
+  if (parsed.length === 0) {
+    throw new Error("PIPELINE_DRAFT_TIER_ALLOWLIST must include core, context, or both.");
+  }
+
+  return [...new Set(parsed)];
+}
+
+function parseDraftMaxRows(value: string | undefined) {
+  const normalized = normalizeEnv(value);
+
+  if (!normalized) {
+    return null;
+  }
+
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error("PIPELINE_DRAFT_MAX_ROWS must be a positive integer.");
+  }
+
+  const maxRows = Number(normalized);
+
+  if (!Number.isSafeInteger(maxRows) || maxRows < 1 || maxRows > 3) {
+    throw new Error("PIPELINE_DRAFT_MAX_ROWS must be an integer from 1 through 3.");
+  }
+
+  return maxRows;
+}
+
 export function resolveControlledPipelineConfig(env: NodeJS.ProcessEnv = process.env): ControlledPipelineConfig {
   return {
     mode: parseRunMode(env.PIPELINE_RUN_MODE),
@@ -217,6 +272,8 @@ export function resolveControlledPipelineConfig(env: NodeJS.ProcessEnv = process
     targetEnvironment: parseTargetEnvironment(env),
     allowProductionPipelineTest: parseBooleanEnv(env.ALLOW_PRODUCTION_PIPELINE_TEST),
     cronDisabledConfirmed: parseBooleanEnv(env.PIPELINE_CRON_DISABLED_CONFIRMED),
+    draftTierAllowlist: parseDraftTierAllowlist(env.PIPELINE_DRAFT_TIER_ALLOWLIST),
+    draftMaxRows: parseDraftMaxRows(env.PIPELINE_DRAFT_MAX_ROWS),
     artifactDir: normalizeEnv(env.PIPELINE_RUN_ARTIFACT_DIR) || ".pipeline-runs",
   };
 }
@@ -228,6 +285,14 @@ export function assertControlledPipelineCanExecute(config: ControlledPipelineCon
 
   if (config.mode === "normal" && config.testRunId) {
     throw new Error("PIPELINE_TEST_RUN_ID is not allowed for normal pipeline runs.");
+  }
+
+  if (config.mode === "normal" && (config.draftTierAllowlist || config.draftMaxRows !== null)) {
+    throw new Error("PIPELINE_DRAFT_* controls are allowed only for controlled dry_run or draft_only runs.");
+  }
+
+  if (config.draftTierAllowlist && config.draftMaxRows === null) {
+    throw new Error("PIPELINE_DRAFT_TIER_ALLOWLIST requires PIPELINE_DRAFT_MAX_ROWS=1, 2, or 3.");
   }
 
   if (config.mode !== "draft_only") {

--- a/src/lib/pipeline/controlled-runner.test.ts
+++ b/src/lib/pipeline/controlled-runner.test.ts
@@ -23,6 +23,8 @@ function buildConfig(overrides: Partial<ControlledPipelineConfig> = {}): Control
     targetEnvironment: "local",
     allowProductionPipelineTest: false,
     cronDisabledConfirmed: false,
+    draftTierAllowlist: null,
+    draftMaxRows: null,
     artifactDir: ".pipeline-runs",
     ...overrides,
   };
@@ -70,6 +72,12 @@ function buildItem(index: number, tier: SignalSelectionEligibilityTier = "core_s
   };
 }
 
+function getPersistedItemIds() {
+  const input = persistSignalPostsForBriefing.mock.calls[0]?.[0] as { items: Array<{ id: string }> } | undefined;
+
+  return input?.items.map((item) => item.id) ?? [];
+}
+
 describe("runControlledPipeline", () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -79,7 +87,8 @@ describe("runControlledPipeline", () => {
       buildItem(3, "exclude_from_public_candidates"),
       buildItem(4),
       buildItem(5),
-      buildItem(6, "depth_only"),
+      buildItem(6, "context_signal_eligible"),
+      buildItem(7, "depth_only"),
     ];
     generateDailyBriefing.mockResolvedValue({
       briefing: {
@@ -93,7 +102,7 @@ describe("runControlledPipeline", () => {
       publicRankedItems: items,
       pipelineRun: {
         run_id: "pipeline-test",
-        num_clusters: 6,
+        num_clusters: 7,
       },
     });
     persistSignalPostsForBriefing.mockImplementation(async (input: { items: Array<{ id: string }> }) => ({
@@ -133,7 +142,7 @@ describe("runControlledPipeline", () => {
     });
   });
 
-  it("draft_only writes only review candidates for the override briefing date", async () => {
+  it("draft_only keeps the default Core-only selection for the override briefing date", async () => {
     const { runControlledPipeline } = await import("@/lib/pipeline/controlled-runner");
     const report = await runControlledPipeline(buildConfig({
       mode: "draft_only",
@@ -151,13 +160,12 @@ describe("runControlledPipeline", () => {
       ],
       mode: "draft_only",
     });
-    expect(persistSignalPostsForBriefing).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        items: expect.arrayContaining([
-          expect.objectContaining({ id: "item-3" }),
-        ]),
-      }),
-    );
+    expect(getPersistedItemIds()).toEqual([
+      "item-1",
+      "item-2",
+      "item-4",
+      "item-5",
+    ]);
     expect(report.generatedBriefingDate).toBe("2026-04-28");
     expect(report.persistence).toMatchObject({
       ok: true,
@@ -165,6 +173,100 @@ describe("runControlledPipeline", () => {
       insertedPostIds: ["row-1", "row-2", "row-3", "row-4"],
       mode: "draft_only",
     });
+  });
+
+  it("draft_only can explicitly select Core and Context rows with a max-row cap", async () => {
+    const items = [
+      buildItem(1),
+      buildItem(2, "context_signal_eligible"),
+      buildItem(3, "context_signal_eligible"),
+      buildItem(4, "depth_only"),
+      buildItem(5, "exclude_from_public_candidates"),
+    ];
+    generateDailyBriefing.mockResolvedValueOnce({
+      briefing: {
+        id: "briefing-phase-b",
+        briefingDate: "2026-04-27T12:00:00.000Z",
+        title: "Daily Executive Briefing",
+        intro: "Controlled test briefing.",
+        readingWindow: "20 minutes",
+        items: [items[0]],
+      },
+      publicRankedItems: items,
+      pipelineRun: {
+        run_id: "pipeline-phase-b",
+        num_clusters: 5,
+      },
+    });
+
+    const { runControlledPipeline } = await import("@/lib/pipeline/controlled-runner");
+    await runControlledPipeline(buildConfig({
+      mode: "draft_only",
+      briefingDateOverride: "2026-04-28",
+      testRunId: "phase-b-draft-test",
+      draftTierAllowlist: ["core_signal_eligible", "context_signal_eligible"],
+      draftMaxRows: 3,
+    }));
+
+    expect(persistSignalPostsForBriefing).toHaveBeenCalledWith({
+      briefingDate: "2026-04-28",
+      items: [
+        expect.objectContaining({ id: "item-1" }),
+        expect.objectContaining({ id: "item-2" }),
+        expect.objectContaining({ id: "item-3" }),
+      ],
+      mode: "draft_only",
+    });
+    expect(getPersistedItemIds()).toEqual([
+      "item-1",
+      "item-2",
+      "item-3",
+    ]);
+  });
+
+  it("draft_only max rows cap limits the explicit Core and Context selection", async () => {
+    const items = [
+      buildItem(1),
+      buildItem(2, "context_signal_eligible"),
+      buildItem(3, "context_signal_eligible"),
+    ];
+    generateDailyBriefing.mockResolvedValueOnce({
+      briefing: {
+        id: "briefing-capped",
+        briefingDate: "2026-04-27T12:00:00.000Z",
+        title: "Daily Executive Briefing",
+        intro: "Controlled test briefing.",
+        readingWindow: "20 minutes",
+        items: [items[0]],
+      },
+      publicRankedItems: items,
+      pipelineRun: {
+        run_id: "pipeline-capped",
+        num_clusters: 3,
+      },
+    });
+
+    const { runControlledPipeline } = await import("@/lib/pipeline/controlled-runner");
+    await runControlledPipeline(buildConfig({
+      mode: "draft_only",
+      briefingDateOverride: "2026-04-28",
+      testRunId: "phase-b-cap-test",
+      draftTierAllowlist: ["core_signal_eligible", "context_signal_eligible"],
+      draftMaxRows: 2,
+    }));
+
+    expect(persistSignalPostsForBriefing).toHaveBeenCalledWith({
+      briefingDate: "2026-04-28",
+      items: [
+        expect.objectContaining({ id: "item-1" }),
+        expect.objectContaining({ id: "item-2" }),
+      ],
+      mode: "draft_only",
+    });
+    expect(getPersistedItemIds()).toEqual([
+      "item-1",
+      "item-2",
+    ]);
   });
 
   it("refuses normal mode from the controlled test runner", async () => {

--- a/src/lib/pipeline/controlled-runner.ts
+++ b/src/lib/pipeline/controlled-runner.ts
@@ -9,6 +9,31 @@ import {
 import { isCoreSignalEligible } from "@/lib/signal-selection-eligibility";
 import { persistSignalPostsForBriefing } from "@/lib/signals-editorial";
 import { getPublicSourcePlanForSurface, getRequiredSourcesForPublicSurface } from "@/lib/source-manifest";
+import type { BriefingItem } from "@/lib/types";
+
+function selectDraftOnlyItems(input: {
+  briefingItems: BriefingItem[];
+  publicRankedItems: BriefingItem[];
+  config: ControlledPipelineConfig;
+}) {
+  const { briefingItems, config, publicRankedItems } = input;
+
+  if (!config.draftTierAllowlist && config.draftMaxRows === null) {
+    return briefingItems.filter(isCoreSignalEligible);
+  }
+
+  const allowedTiers = new Set(config.draftTierAllowlist ?? ["core_signal_eligible"]);
+  const candidates = publicRankedItems.length > 0 ? publicRankedItems : briefingItems;
+  const selected = candidates.filter((item) => {
+    const tier = item.selectionEligibility?.tier;
+
+    return tier === "core_signal_eligible" || tier === "context_signal_eligible"
+      ? allowedTiers.has(tier)
+      : false;
+  });
+
+  return config.draftMaxRows === null ? selected : selected.slice(0, config.draftMaxRows);
+}
 
 export async function runControlledPipeline(
   config: ControlledPipelineConfig,
@@ -32,7 +57,11 @@ export async function runControlledPipeline(
     },
   );
   const briefingDate = config.briefingDateOverride ?? briefing.briefingDate.slice(0, 10);
-  const structurallyEligibleItems = briefing.items.filter(isCoreSignalEligible);
+  const structurallyEligibleItems = selectDraftOnlyItems({
+    briefingItems: briefing.items,
+    publicRankedItems,
+    config,
+  });
   const persistence = config.mode === "draft_only"
     ? await persistSignalPostsForBriefing({
         briefingDate,


### PR DESCRIPTION
## Summary

- Adds explicit controlled-pipeline draft selector env controls for the limited Phase B Core+Context shape.
- Preserves default draft_only behavior as Core-only unless the selector envs are explicitly set.
- Fails closed for unsupported draft tiers and caps controlled selector rows at 3 so Depth/excluded rows are not inserted for Phase B.
- Documents this as remediation/alignment; no new canonical PRD is required because this aligns controlled pipeline behavior to the already-approved Phase B test shape.

## Safety Boundaries

- Does not run draft_only.
- Does not change cron settings or public publish behavior.
- Does not change source manifests, ranking calibration, WITM templates, homepage snapshot/schema, or Batch 2 sources.
- Production draft_only still requires PIPELINE_RUN_MODE=draft_only, ALLOW_PRODUCTION_PIPELINE_TEST=true, and PIPELINE_CRON_DISABLED_CONFIRMED=true.
## Validation

- npm install
- npm run lint
- npm run test
- npm run build
- npm run governance:coverage
- npm run governance:audit
- npm run governance:hotspots
- python3 scripts/validate-feature-system-csv.py
- python3 scripts/release-governance-gate.py
- Controlled dry_run only with PIPELINE_DRAFT_TIER_ALLOWLIST=core,context and PIPELINE_DRAFT_MAX_ROWS=3
