### PR TITLE
Remediate controlled Phase B artifact replay

### DIFF
--- a/docs/engineering/change-records/phase-b-artifact-replay-remediation.md
+++ b/docs/engineering/change-records/phase-b-artifact-replay-remediation.md
@@ -1,0 +1,35 @@
+# Phase B Artifact Replay Remediation
+
+## Change Type
+
+Remediation / controlled operations validation.
+
+## Source of Truth
+
+- Boot Up is a curated daily intelligence briefing, not a feed.
+- Limited Phase B may insert only Core and Context rows, max 3, as `needs_review`, `is_live=false`, `published_at=null`.
+- The Phase B regression diagnosis found live RSS/feed drift removed the previously approved Context rows from the current candidate set. This was not a selector regression.
+
+## PRD Status
+
+No new canonical PRD is required. This change aligns the already-approved controlled Phase B validation path with a stable replay input for operations safety.
+
+## Scope
+
+- Add `PIPELINE_REPLAY_ARTIFACT_PATH` for controlled-pipeline replay from a prior controlled `dry_run` artifact.
+- Add optional `PIPELINE_REPLAY_EXPECTED_RUN_ID` to bind replay to a specific source run.
+- Keep replay available only through the controlled pipeline script path.
+- Preserve existing `dry_run` and `draft_only` gates, including production `draft_only` requirements.
+- Reconstruct only Core and Context Signal candidates from `proposedTopFive` and `proposedContextRows`; Depth and Excluded rows remain out of the replay selection path.
+
+## Non-Goals
+
+- No production cron run or re-enable.
+- No public publish behavior changes.
+- No source manifest, ranking, calibration, or why-it-matters template changes.
+- No Batch 2 source implementation.
+- No card-level editorial authority or homepage snapshot schema work.
+
+## Safety Notes
+
+Replay artifacts must be controlled `dry_run` artifacts with `persistence=null`. Missing, malformed, mismatched-run, or disallowed-tier artifacts fail closed before ingestion or persistence. The path is explicitly configured and does not affect normal ingestion, public routes, cron execution, or live homepage reads.

--- a/src/lib/pipeline/controlled-execution.test.ts
+++ b/src/lib/pipeline/controlled-execution.test.ts
@@ -19,6 +19,8 @@ function buildConfig(overrides: Partial<ControlledPipelineConfig> = {}): Control
     draftTierAllowlist: null,
     draftMaxRows: null,
     artifactDir: ".pipeline-runs",
+    replayArtifactPath: null,
+    replayExpectedRunId: null,
     ...overrides,
   };
 }
@@ -104,6 +106,18 @@ describe("controlled pipeline execution config", () => {
 
     expect(config.draftTierAllowlist).toEqual(["core_signal_eligible", "context_signal_eligible"]);
     expect(config.draftMaxRows).toBe(3);
+    expect(() => assertControlledPipelineCanExecute(config)).not.toThrow();
+  });
+
+  it("resolves explicit replay artifact controls for controlled runs", () => {
+    const config = resolveControlledPipelineConfig({
+      PIPELINE_RUN_MODE: "dry_run",
+      PIPELINE_REPLAY_ARTIFACT_PATH: "/tmp/controlled-dry-run.json",
+      PIPELINE_REPLAY_EXPECTED_RUN_ID: "pipeline-123",
+    } as NodeJS.ProcessEnv);
+
+    expect(config.replayArtifactPath).toBe("/tmp/controlled-dry-run.json");
+    expect(config.replayExpectedRunId).toBe("pipeline-123");
     expect(() => assertControlledPipelineCanExecute(config)).not.toThrow();
   });
 
@@ -219,6 +233,23 @@ describe("controlled pipeline execution config", () => {
     });
 
     expect(() => assertControlledPipelineCanExecute(config)).toThrow(/PIPELINE_DRAFT_\*/);
+  });
+
+  it("does not allow normal mode to accept replay controls", () => {
+    const config = buildConfig({
+      mode: "normal",
+      replayArtifactPath: "/tmp/controlled-dry-run.json",
+    });
+
+    expect(() => assertControlledPipelineCanExecute(config)).toThrow(/PIPELINE_REPLAY_\*/);
+  });
+
+  it("requires a replay artifact path when an expected replay run id is set", () => {
+    const config = buildConfig({
+      replayExpectedRunId: "pipeline-123",
+    });
+
+    expect(() => assertControlledPipelineCanExecute(config)).toThrow(/PIPELINE_REPLAY_EXPECTED_RUN_ID/);
   });
 });
 

--- a/src/lib/pipeline/controlled-execution.ts
+++ b/src/lib/pipeline/controlled-execution.ts
@@ -20,6 +20,8 @@ export type ControlledPipelineConfig = {
   draftTierAllowlist: ControlledPipelineDraftTier[] | null;
   draftMaxRows: number | null;
   artifactDir: string;
+  replayArtifactPath: string | null;
+  replayExpectedRunId: string | null;
 };
 
 export type ControlledPipelineSignalReport = {
@@ -275,6 +277,8 @@ export function resolveControlledPipelineConfig(env: NodeJS.ProcessEnv = process
     draftTierAllowlist: parseDraftTierAllowlist(env.PIPELINE_DRAFT_TIER_ALLOWLIST),
     draftMaxRows: parseDraftMaxRows(env.PIPELINE_DRAFT_MAX_ROWS),
     artifactDir: normalizeEnv(env.PIPELINE_RUN_ARTIFACT_DIR) || ".pipeline-runs",
+    replayArtifactPath: normalizeEnv(env.PIPELINE_REPLAY_ARTIFACT_PATH) || null,
+    replayExpectedRunId: normalizeEnv(env.PIPELINE_REPLAY_EXPECTED_RUN_ID) || null,
   };
 }
 
@@ -289,6 +293,14 @@ export function assertControlledPipelineCanExecute(config: ControlledPipelineCon
 
   if (config.mode === "normal" && (config.draftTierAllowlist || config.draftMaxRows !== null)) {
     throw new Error("PIPELINE_DRAFT_* controls are allowed only for controlled dry_run or draft_only runs.");
+  }
+
+  if (config.mode === "normal" && (config.replayArtifactPath || config.replayExpectedRunId)) {
+    throw new Error("PIPELINE_REPLAY_* controls are allowed only for controlled dry_run or draft_only runs.");
+  }
+
+  if (config.replayExpectedRunId && !config.replayArtifactPath) {
+    throw new Error("PIPELINE_REPLAY_EXPECTED_RUN_ID requires PIPELINE_REPLAY_ARTIFACT_PATH.");
   }
 
   if (config.draftTierAllowlist && config.draftMaxRows === null) {

--- a/src/lib/pipeline/controlled-runner.test.ts
+++ b/src/lib/pipeline/controlled-runner.test.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ControlledPipelineConfig } from "@/lib/pipeline/controlled-execution";
@@ -26,6 +30,8 @@ function buildConfig(overrides: Partial<ControlledPipelineConfig> = {}): Control
     draftTierAllowlist: null,
     draftMaxRows: null,
     artifactDir: ".pipeline-runs",
+    replayArtifactPath: null,
+    replayExpectedRunId: null,
     ...overrides,
   };
 }
@@ -76,6 +82,140 @@ function getPersistedItemIds() {
   const input = persistSignalPostsForBriefing.mock.calls[0]?.[0] as { items: Array<{ id: string }> } | undefined;
 
   return input?.items.map((item) => item.id) ?? [];
+}
+
+function buildReplaySignal(index: number, tier: SignalSelectionEligibilityTier = "core_signal_eligible") {
+  const whyItMatters =
+    tier === "context_signal_eligible"
+      ? "TSA attrition is rising during the shutdown, which matters because it shows whether public institutions can maintain basic services under staffing or funding pressure."
+      : "Prediction-market violations are stacking up, which matters because it tests whether enforcement, settlements, or public oversight change accountability beyond the case itself.";
+
+  return {
+    id: `replay-${index}`,
+    rank: index,
+    title: `Replay signal ${index}`,
+    sourceName: tier === "context_signal_eligible" ? "Politico Congress" : "Politico Politics News",
+    sourceUrl: `https://example.com/replay-${index}`,
+    sourceCount: 1,
+    sourceTier: "tier2",
+    sourceRole: "secondary_authoritative",
+    contentAccessibility: "full_text_available",
+    accessibleTextLength: 1200 + index,
+    extractionMethod: "readability",
+    fetchStatus: "success",
+    parseStatus: "parsed",
+    articleId: `article-${index}`,
+    clusterId: `cluster-${index}`,
+    articleCount: 1,
+    sourceDiversity: 1,
+    recency: 80,
+    velocity: 70,
+    category: "Politics",
+    topic: "Politics",
+    eventType: tier === "context_signal_eligible" ? "government_capacity" : "public_interest_legal_accountability",
+    filterDecision: "pass",
+    filterSeverity: "pass",
+    filterReasons: ["passed_allowed_event_type"],
+    eligibilityTier: tier,
+    structuralImportanceScore: tier === "context_signal_eligible" ? 48 : 62,
+    sourceQualityScore: 76,
+    groupedScoreComponents: {
+      trust_timeliness: 75,
+      event_importance: 70,
+      support_and_novelty: 65,
+      importance_adjustment: 0,
+    },
+    legacyScoreComponents: {
+      credibility: 75,
+      novelty: 70,
+      urgency: 65,
+      reinforcement: 60,
+    },
+    finalScore: 80 - index,
+    rankingProvider: "fns",
+    diversityProvider: "fns",
+    whyItMatters,
+    validationStatus: "passed",
+    validationFailures: [],
+    validationDetails: [],
+    selectionQualityWarnings: [],
+    selectionEligibilityReasons: tier === "context_signal_eligible" ? ["structural_importance_below_core_threshold"] : [],
+    calibratedReasonLabels: [],
+    exclusionCause: null,
+    sourceAccessibilityWarnings: [],
+    coreBlockingReasons: [],
+  };
+}
+
+function buildReplayArtifact(overrides: Record<string, unknown> = {}) {
+  return {
+    mode: "dry_run",
+    testRunId: "source-dry-run",
+    runId: "pipeline-replay-source",
+    generatedBriefingDate: "2026-04-28",
+    candidateCount: 3,
+    clusterCount: 3,
+    signalCount: 3,
+    sourcePlan: {
+      plan: "fallback",
+      surface: null,
+      suppliedByManifest: false,
+      sourceCount: 0,
+      sourceIds: [],
+      sources: [],
+      warnings: [],
+    },
+    activeSourceCount: 0,
+    activeSources: [],
+    sourceDistribution: {},
+    categoryDistribution: {},
+    articleCandidates: [],
+    selectionSummary: {
+      activeSourceCount: 0,
+      activeSourceList: [],
+      sourceDistributionOfIngestedCandidates: {},
+      sourceDistributionOfProposedTopFive: {},
+      categoryDistributionOfCandidates: {},
+      sourcePlanWarnings: [],
+      manifestCoverageWarnings: [],
+      categoriesRepresented: [],
+      eligibleCoreCount: 1,
+      contextEligibleCount: 2,
+      depthOnlyCount: 1,
+      excludedWeakCandidateCount: 1,
+      candidate_pool_insufficient: true,
+      candidate_pool_insufficient_reason: "selection_quality",
+      sourceScarcityLikely: true,
+      sourceAccessibilityLikely: false,
+      functionalSourceCoverageByCategory: {},
+      sourceAccessibilityWarnings: [],
+      selectionQualityWarnings: [],
+    },
+    candidate_pool_insufficient: true,
+    candidate_pool_insufficient_reason: "selection_quality",
+    proposedTopFive: [buildReplaySignal(1)],
+    proposedContextRows: [
+      buildReplaySignal(2, "context_signal_eligible"),
+      buildReplaySignal(3, "context_signal_eligible"),
+    ],
+    proposedDepthRows: [buildReplaySignal(4, "depth_only")],
+    excludedCandidates: [buildReplaySignal(5, "exclude_from_public_candidates")],
+    persistence: null,
+    ...overrides,
+  };
+}
+
+async function writeReplayArtifact(artifact: unknown) {
+  const dir = await mkdtemp(path.join(tmpdir(), "phase-b-replay-test-"));
+  const artifactPath = path.join(dir, "artifact.json");
+  await writeFile(artifactPath, `${JSON.stringify(artifact)}\n`, "utf8");
+
+  return {
+    artifactPath,
+    async cleanup() {
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
 }
 
 describe("runControlledPipeline", () => {
@@ -267,6 +407,143 @@ describe("runControlledPipeline", () => {
       "item-1",
       "item-2",
     ]);
+  });
+
+  it("replays dry_run from a valid controlled artifact without live ingestion or writes", async () => {
+    const { artifactPath, cleanup } = await writeReplayArtifact(buildReplayArtifact());
+
+    try {
+      const { runControlledPipeline } = await import("@/lib/pipeline/controlled-runner");
+      const report = await runControlledPipeline(buildConfig({
+        mode: "dry_run",
+        briefingDateOverride: "2026-04-28",
+        testRunId: "replay-dry-run",
+        draftTierAllowlist: ["core_signal_eligible", "context_signal_eligible"],
+        draftMaxRows: 3,
+        replayArtifactPath: artifactPath,
+        replayExpectedRunId: "pipeline-replay-source",
+      }));
+
+      expect(generateDailyBriefing).not.toHaveBeenCalled();
+      expect(persistSignalPostsForBriefing).not.toHaveBeenCalled();
+      expect(report.runId).toBe("pipeline-replay-source");
+      expect(report.persistence).toBeNull();
+      expect(report.proposedTopFive).toHaveLength(1);
+      expect(report.proposedContextRows).toHaveLength(2);
+      expect(report.proposedDepthRows).toHaveLength(0);
+      expect(report.excludedCandidates).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("replay draft_only selection respects Core and Context allowlist without Depth or Excluded rows", async () => {
+    const { artifactPath, cleanup } = await writeReplayArtifact(buildReplayArtifact());
+
+    try {
+      const { runControlledPipeline } = await import("@/lib/pipeline/controlled-runner");
+      await runControlledPipeline(buildConfig({
+        mode: "draft_only",
+        briefingDateOverride: "2026-04-28",
+        testRunId: "replay-draft-only",
+        draftTierAllowlist: ["core_signal_eligible", "context_signal_eligible"],
+        draftMaxRows: 3,
+        replayArtifactPath: artifactPath,
+      }));
+
+      expect(generateDailyBriefing).not.toHaveBeenCalled();
+      expect(persistSignalPostsForBriefing).toHaveBeenCalledWith({
+        briefingDate: "2026-04-28",
+        items: [
+          expect.objectContaining({ id: "replay-replay-1" }),
+          expect.objectContaining({ id: "replay-replay-2" }),
+          expect.objectContaining({ id: "replay-replay-3" }),
+        ],
+        mode: "draft_only",
+      });
+      expect(getPersistedItemIds()).toEqual([
+        "replay-replay-1",
+        "replay-replay-2",
+        "replay-replay-3",
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("replay max rows cap limits selected Core and Context rows", async () => {
+    const { artifactPath, cleanup } = await writeReplayArtifact(buildReplayArtifact());
+
+    try {
+      const { runControlledPipeline } = await import("@/lib/pipeline/controlled-runner");
+      await runControlledPipeline(buildConfig({
+        mode: "draft_only",
+        briefingDateOverride: "2026-04-28",
+        testRunId: "replay-draft-only-capped",
+        draftTierAllowlist: ["core_signal_eligible", "context_signal_eligible"],
+        draftMaxRows: 2,
+        replayArtifactPath: artifactPath,
+      }));
+
+      expect(getPersistedItemIds()).toEqual([
+        "replay-replay-1",
+        "replay-replay-2",
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("replay fails closed for missing artifacts", async () => {
+    const { runControlledPipeline } = await import("@/lib/pipeline/controlled-runner");
+
+    await expect(runControlledPipeline(buildConfig({
+      mode: "dry_run",
+      replayArtifactPath: "/tmp/missing-phase-b-replay-artifact.json",
+    }))).rejects.toThrow(/could not be read/);
+  });
+
+  it("replay fails closed for malformed artifacts", async () => {
+    const { artifactPath, cleanup } = await writeReplayArtifact({
+      mode: "dry_run",
+      runId: "pipeline-bad",
+      persistence: null,
+    });
+
+    try {
+      const { runControlledPipeline } = await import("@/lib/pipeline/controlled-runner");
+
+      await expect(runControlledPipeline(buildConfig({
+        mode: "dry_run",
+        replayArtifactPath: artifactPath,
+      }))).rejects.toThrow(/proposedTopFive/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("replay fails closed when selected artifact tiers are outside the allowlist", async () => {
+    const { artifactPath, cleanup } = await writeReplayArtifact(buildReplayArtifact());
+
+    try {
+      const { runControlledPipeline } = await import("@/lib/pipeline/controlled-runner");
+
+      await expect(runControlledPipeline(buildConfig({
+        mode: "dry_run",
+        draftTierAllowlist: ["core_signal_eligible"],
+        draftMaxRows: 3,
+        replayArtifactPath: artifactPath,
+      }))).rejects.toThrow(/outside PIPELINE_DRAFT_TIER_ALLOWLIST/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("keeps replay unavailable unless the explicit replay artifact config is set", async () => {
+    const { runControlledPipeline } = await import("@/lib/pipeline/controlled-runner");
+    await runControlledPipeline(buildConfig({ mode: "dry_run" }));
+
+    expect(generateDailyBriefing).toHaveBeenCalledTimes(1);
   });
 
   it("refuses normal mode from the controlled test runner", async () => {

--- a/src/lib/pipeline/controlled-runner.ts
+++ b/src/lib/pipeline/controlled-runner.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+
 import { generateDailyBriefing } from "@/lib/data";
 import { demoTopics } from "@/lib/demo-data";
 import {
@@ -5,11 +7,15 @@ import {
   buildControlledPipelineReport,
   type ControlledPipelineConfig,
   type ControlledPipelineReport,
+  type ControlledPipelineDraftTier,
+  type ControlledPipelineSignalReport,
 } from "@/lib/pipeline/controlled-execution";
 import { isCoreSignalEligible } from "@/lib/signal-selection-eligibility";
 import { persistSignalPostsForBriefing } from "@/lib/signals-editorial";
 import { getPublicSourcePlanForSurface, getRequiredSourcesForPublicSurface } from "@/lib/source-manifest";
-import type { BriefingItem } from "@/lib/types";
+import type { BriefingItem, SignalSelectionEligibilityTier } from "@/lib/types";
+
+type ReplayArtifact = ControlledPipelineReport;
 
 function selectDraftOnlyItems(input: {
   briefingItems: BriefingItem[];
@@ -35,6 +41,218 @@ function selectDraftOnlyItems(input: {
   return config.draftMaxRows === null ? selected : selected.slice(0, config.draftMaxRows);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateReplaySignalRows(rows: unknown, label: string, expectedTier: SignalSelectionEligibilityTier) {
+  if (!Array.isArray(rows)) {
+    throw new Error(`PIPELINE_REPLAY_ARTIFACT_PATH is malformed: ${label} must be an array.`);
+  }
+
+  return rows.map((row, index) => {
+    if (!isRecord(row)) {
+      throw new Error(`PIPELINE_REPLAY_ARTIFACT_PATH is malformed: ${label}[${index}] must be an object.`);
+    }
+
+    if (row.eligibilityTier !== expectedTier) {
+      throw new Error(
+        `PIPELINE_REPLAY_ARTIFACT_PATH is malformed: ${label}[${index}] must use ${expectedTier}.`,
+      );
+    }
+
+    if (typeof row.title !== "string" || row.title.trim().length === 0) {
+      throw new Error(`PIPELINE_REPLAY_ARTIFACT_PATH is malformed: ${label}[${index}] must include a title.`);
+    }
+
+    if (typeof row.whyItMatters !== "string" || row.whyItMatters.trim().length === 0) {
+      throw new Error(`PIPELINE_REPLAY_ARTIFACT_PATH is malformed: ${label}[${index}] must include whyItMatters.`);
+    }
+
+    return row as unknown as ControlledPipelineSignalReport;
+  });
+}
+
+async function loadReplayArtifact(config: ControlledPipelineConfig): Promise<ReplayArtifact> {
+  if (!config.replayArtifactPath) {
+    throw new Error("PIPELINE_REPLAY_ARTIFACT_PATH is required for replay mode.");
+  }
+
+  let raw: string;
+
+  try {
+    raw = await readFile(config.replayArtifactPath, "utf8");
+  } catch {
+    throw new Error("PIPELINE_REPLAY_ARTIFACT_PATH could not be read.");
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("PIPELINE_REPLAY_ARTIFACT_PATH is malformed JSON.");
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error("PIPELINE_REPLAY_ARTIFACT_PATH is malformed: expected an object.");
+  }
+
+  if (parsed.mode !== "dry_run") {
+    throw new Error("PIPELINE_REPLAY_ARTIFACT_PATH must point to a controlled dry_run artifact.");
+  }
+
+  if (typeof parsed.runId !== "string" || parsed.runId.trim().length === 0) {
+    throw new Error("PIPELINE_REPLAY_ARTIFACT_PATH is malformed: missing runId.");
+  }
+
+  if (config.replayExpectedRunId && parsed.runId !== config.replayExpectedRunId) {
+    throw new Error("PIPELINE_REPLAY_EXPECTED_RUN_ID does not match the replay artifact runId.");
+  }
+
+  if (parsed.persistence !== null) {
+    throw new Error("PIPELINE_REPLAY_ARTIFACT_PATH must have persistence=null.");
+  }
+
+  validateReplaySignalRows(parsed.proposedTopFive, "proposedTopFive", "core_signal_eligible");
+  validateReplaySignalRows(parsed.proposedContextRows, "proposedContextRows", "context_signal_eligible");
+
+  return parsed as unknown as ReplayArtifact;
+}
+
+function selectReplaySignalRows(input: {
+  artifact: ReplayArtifact;
+  config: ControlledPipelineConfig;
+}) {
+  const { artifact, config } = input;
+  const allowedTiers = new Set<ControlledPipelineDraftTier>(config.draftTierAllowlist ?? ["core_signal_eligible"]);
+  const replayRows = [
+    ...artifact.proposedTopFive,
+    ...artifact.proposedContextRows,
+  ];
+  const disallowedRow = replayRows.find((row) => !allowedTiers.has(row.eligibilityTier as ControlledPipelineDraftTier));
+
+  if (disallowedRow) {
+    throw new Error(
+      `PIPELINE_REPLAY_ARTIFACT_PATH contains ${disallowedRow.eligibilityTier}, which is outside PIPELINE_DRAFT_TIER_ALLOWLIST.`,
+    );
+  }
+
+  const selected = config.draftMaxRows === null
+    ? replayRows
+    : replayRows.slice(0, config.draftMaxRows);
+
+  if (selected.length === 0) {
+    throw new Error("PIPELINE_REPLAY_ARTIFACT_PATH did not contain selectable Core or Context rows.");
+  }
+
+  return selected;
+}
+
+function normalizeReplayNumber(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function replaySignalToBriefingItem(row: ControlledPipelineSignalReport, index: number): BriefingItem {
+  const sourceTitle = row.sourceName ?? "Replay source";
+  const sourceUrl = row.sourceUrl ?? "";
+
+  return {
+    id: `replay-${row.id || index + 1}`,
+    topicId: "phase-b-replay",
+    topicName: row.topic ?? row.category ?? "Phase B Replay",
+    title: row.title,
+    whatHappened: row.title,
+    keyPoints: [
+      sourceTitle,
+      row.eventType ?? "event type unavailable",
+      row.contentAccessibility ?? "accessibility unavailable",
+    ],
+    whyItMatters: row.whyItMatters,
+    aiWhyItMatters: row.whyItMatters,
+    sources: [{ title: sourceTitle, url: sourceUrl }],
+    sourceCount: row.sourceCount ?? 1,
+    estimatedMinutes: 4,
+    read: false,
+    priority: row.eligibilityTier === "core_signal_eligible" ? "top" : "normal",
+    importanceScore: normalizeReplayNumber(row.finalScore),
+    rankingSignals: row.selectionEligibilityReasons.length > 0 ? row.selectionEligibilityReasons : undefined,
+    selectionEligibility: {
+      tier: row.eligibilityTier,
+      reasons: row.selectionEligibilityReasons,
+      warnings: row.selectionQualityWarnings,
+      filterDecision: row.filterDecision === "pass" || row.filterDecision === "suppress" || row.filterDecision === "reject"
+        ? row.filterDecision
+        : undefined,
+      filterSeverity: row.filterSeverity === "pass" || row.filterSeverity === "suppress" || row.filterSeverity === "reject"
+        ? row.filterSeverity
+        : undefined,
+      filterReasons: row.filterReasons,
+      sourceTier: row.sourceTier ?? undefined,
+      sourceRole: row.sourceRole ?? undefined,
+      contentAccessibility: row.contentAccessibility ?? undefined,
+      accessibleTextLength: row.accessibleTextLength ?? undefined,
+      sourceAccessibilityWarnings: row.sourceAccessibilityWarnings,
+      coreBlockingReasons: row.coreBlockingReasons,
+      calibratedReasonLabels: row.calibratedReasonLabels,
+      exclusionCause: row.exclusionCause,
+      eventType: row.eventType ?? undefined,
+      structuralImportanceScore: row.structuralImportanceScore ?? undefined,
+      sourceQualityScore: row.sourceQualityScore ?? undefined,
+      finalScore: row.finalScore ?? undefined,
+      scoreComponents: {
+        credibility: row.legacyScoreComponents?.credibility,
+        novelty: row.legacyScoreComponents?.novelty,
+        urgency: row.legacyScoreComponents?.urgency,
+        reinforcement: row.legacyScoreComponents?.reinforcement,
+        trust_timeliness: row.groupedScoreComponents?.trust_timeliness,
+        event_importance: row.groupedScoreComponents?.event_importance,
+        support_and_novelty: row.groupedScoreComponents?.support_and_novelty,
+        importance_adjustment: row.groupedScoreComponents?.importance_adjustment,
+      },
+      rankingProvider: row.rankingProvider,
+      diversityProvider: row.diversityProvider,
+    },
+  };
+}
+
+async function runControlledPipelineReplay(config: ControlledPipelineConfig): Promise<ControlledPipelineReport> {
+  const artifact = await loadReplayArtifact(config);
+  const replayRows = selectReplaySignalRows({ artifact, config });
+  const replayItems = replayRows.map(replaySignalToBriefingItem);
+  const briefingDate = config.briefingDateOverride ?? artifact.generatedBriefingDate;
+  const persistence = config.mode === "draft_only"
+    ? await persistSignalPostsForBriefing({
+        briefingDate,
+        items: replayItems,
+        mode: "draft_only",
+      })
+    : null;
+
+  return buildControlledPipelineReport({
+    mode: config.mode,
+    testRunId: config.testRunId,
+    briefing: {
+      id: `replay-${artifact.runId}`,
+      briefingDate: `${briefingDate}T12:00:00.000Z`,
+      title: "Controlled Replay Briefing",
+      intro: "Controlled replay from a prior dry-run artifact.",
+      readingWindow: "Controlled replay",
+      items: replayItems,
+    },
+    publicRankedItems: replayItems,
+    pipelineRun: {
+      run_id: artifact.runId,
+      num_clusters: replayItems.length,
+      active_sources: artifact.activeSources,
+      source_contributions: [],
+      article_filter_evaluations: [],
+    } as never,
+    sourcePlan: artifact.sourcePlan as never,
+    persistence,
+  });
+}
+
 export async function runControlledPipeline(
   config: ControlledPipelineConfig,
 ): Promise<ControlledPipelineReport> {
@@ -44,6 +262,10 @@ export async function runControlledPipeline(
     throw new Error(
       "Controlled pipeline execution is limited to dry_run and draft_only. Normal scheduled execution remains owned by /api/cron/fetch-news after re-enable approval.",
     );
+  }
+
+  if (config.replayArtifactPath) {
+    return runControlledPipelineReplay(config);
   }
 
   const sourcePlan = getPublicSourcePlanForSurface("public.home");


### PR DESCRIPTION
## Change type

Remediation / controlled operations validation.

## Source of truth

- Product Position: Boot Up is a curated daily intelligence briefing, not a feed; Top 5 Core Signals + Next 2 Context Signals; explicit structural why-it-matters; no false freshness.
- Reprioritized remaining task list: limited Phase B may insert only Core/Context rows, max 3, as needs_review, is_live=false, published_at=null, with cron disabled and no public publish.
- Latest Phase B replay stabilization report: live RSS/feed drift removed the previously approved Context rows, and the controlled runner did not previously have an artifact replay path.

## Summary

- Adds explicit controlled-pipeline artifact replay controls:
  - `PIPELINE_REPLAY_ARTIFACT_PATH`
  - `PIPELINE_REPLAY_EXPECTED_RUN_ID`
- Keeps replay limited to the controlled pipeline runner path.
- Replays only selected Core and Context rows from prior controlled dry_run artifacts.
- Fails closed for missing, malformed, mismatched, persisted, or disallowed-tier replay artifacts.
- Preserves existing production draft_only gates and Core/Context max-row selector behavior.

## Governance

No new canonical PRD is required. This aligns a controlled operations validation path to the already-approved Phase B test shape and is documented in `docs/engineering/change-records/phase-b-artifact-replay-remediation.md`.

## Out of scope

- No production cron run or re-enable.
- No public publish behavior changes.
- No source manifest/default changes.
- No ranking/calibration changes.
- No WITM template changes.
- No Batch 2 source implementation.
- No card-level editorial authority.
- No homepage snapshot/schema work.

## Validation already run

- `npm install`
- `npm run lint`
- `npm run test`
- `npm run build`
- `npm run governance:coverage`
- `npm run governance:audit`
- `npm run governance:hotspots`
- `python3 scripts/validate-feature-system-csv.py`
- `python3 scripts/release-governance-gate.py`

Replay dry_run artifact:
`/Users/bm/dev/worktrees/daily-intelligence-aggregator-phase-b-artifact-replay/.pipeline-runs/controlled-pipeline-dry_run-phase-b-artifact-replay-dryrun-20260428T235255Z-2026-04-28T23-52-57-140Z.json`

Replay dry_run confirmed 1 Core + 2 Context rows, no Depth rows, no Excluded rows, WITM passed for all selected rows, `persistence=null`, and `insertedCount=0`.
