### PR TITLE
Remediate Phase C admin workflow safety

### DIFF
--- a/docs/engineering/testing/2026-04-29-phase-c-track-a-admin-workflow-safety.md
+++ b/docs/engineering/testing/2026-04-29-phase-c-track-a-admin-workflow-safety.md
@@ -1,0 +1,49 @@
+# Phase C Track A Admin Workflow Safety Validation
+
+## Change Type
+
+remediation / controlled operations validation
+
+## Canonical PRD
+
+No new canonical PRD is required. This remediation validates and tightens the existing PRD-53 signals admin editorial workflow. It does not add Batch 2 sources, source ingestion, new public surfaces, card-level editorial authority, historical snapshot schema, or publishing capability.
+
+## Scope
+
+- Tighten public `signal_posts` reads to require `is_live = true`, `editorial_status = 'published'`, and non-null `published_at`.
+- Align homepage editorial override reads with the same public eligibility predicate.
+- Block the row-level publish bypass and remove the per-card Publish control from the admin editor.
+- Keep save and approve actions from setting `is_live` or `published_at`.
+- Surface WITM validation status and failure reasons in the admin review UI when the data exists.
+- Add regression coverage for draft isolation, publish gating, save/approve safety, row-level publish blocking, and WITM rewrite-required display through a local fixture.
+
+## P1 Compatibility Check
+
+Before deploy, the production read-only `published_at` compatibility check cleared:
+
+- `published_or_live_total = 30`
+- `published_or_live_missing_published_at = 0`
+- `published_status_missing_published_at = 0`
+- `live_rows_excluded_by_new_predicate = 0`
+
+No backfill was needed. No production SQL writes were performed.
+
+## Local Validation
+
+- `git diff --check` passed.
+- `npm run lint` passed.
+- `npm run test -- src/lib/signals-editorial.test.ts src/app/dashboard/signals/editorial-review/page.test.tsx` passed: 2 files, 49 tests.
+- `npm run test -- src/app/dashboard/signals/editorial-review/StructuredEditorialFields.test.tsx src/app/dashboard/signals/editorial-review/ApproveAllButton.test.tsx src/app/signals/page.test.tsx src/lib/homepage-editorial-overrides.test.ts src/lib/data.test.ts` passed: 5 files, 15 tests.
+- `npm run build` passed.
+- `npm run test` passed: 72 files, 492 tests.
+- `PLAYWRIGHT_MANAGED_WEBSERVER=1 npx playwright test --project=chromium` passed: 33 tests.
+- `PLAYWRIGHT_MANAGED_WEBSERVER=1 npx playwright test --project=webkit` passed: 33 tests.
+
+## Non-Validated Items
+
+- Manual Track A production admin write-side actions remain unvalidated: rewrite/save, approve, and reject/dismiss if non-destructive and implemented.
+- Manual publish remains unvalidated and out of scope.
+- WITM failure UI is validated only by local fixture, not by a real failed production row.
+- Representative editorial quality, daily slate quality, and candidate-pool sufficiency remain unvalidated.
+- Batch 2/source expansion remains future work.
+- A full controlled publish requires a representative five-row slate and separate explicit approval.

--- a/src/app/dashboard/signals/editorial-review/StructuredEditorialFields.tsx
+++ b/src/app/dashboard/signals/editorial-review/StructuredEditorialFields.tsx
@@ -10,12 +10,10 @@ import {
   ExternalLink,
   RotateCcw,
   Save,
-  Send,
 } from "lucide-react";
 
 import {
   approveSignalPostAction,
-  publishSignalPostAction,
   resetSignalPostToAiDraftAction,
   saveSignalDraftAction,
 } from "@/app/dashboard/signals/editorial-review/actions";
@@ -58,7 +56,6 @@ export function SignalPostEditor({ post, storageReady }: SignalPostEditorProps) 
     ["draft", "needs_review"].includes(post.editorialStatus) &&
     post.whyItMattersValidationStatus !== "requires_human_rewrite";
   const requiresHumanRewrite = post.whyItMattersValidationStatus === "requires_human_rewrite";
-  const canPublishPost = post.editorialStatus === "approved" && !requiresHumanRewrite;
   const toggleLabel = isExpanded ? "Collapse" : "Expand";
   const panelId = `editorial-panel-${post.id}`;
 
@@ -75,7 +72,7 @@ export function SignalPostEditor({ post, storageReady }: SignalPostEditorProps) 
                 </span>
                 {post.briefingDate ? <Badge>{post.briefingDate}</Badge> : null}
                 <Badge>{formatStatus(post.editorialStatus)}</Badge>
-                {requiresHumanRewrite ? <Badge>Requires rewrite</Badge> : null}
+                <Badge>{requiresHumanRewrite ? "WITM rewrite required" : "WITM passed"}</Badge>
                 {post.isLive ? <Badge>Live homepage set</Badge> : null}
                 {post.signalScore !== null ? <Badge>Score {Math.round(post.signalScore)}</Badge> : null}
                 {post.tags.map((tag) => (
@@ -168,17 +165,6 @@ export function SignalPostEditor({ post, storageReady }: SignalPostEditorProps) 
               <CheckCircle2 className="h-4 w-4" />
               Approve
             </Button>
-            {canPublishPost ? (
-              <Button
-                type="submit"
-                formAction={publishSignalPostAction}
-                disabled={controlsDisabled}
-                className="gap-2"
-              >
-                <Send className="h-4 w-4" />
-                Publish
-              </Button>
-            ) : null}
             <Button
               type="submit"
               formAction={resetSignalPostToAiDraftAction}
@@ -425,7 +411,7 @@ function getPostStateHint(post: EditorialSignalPost) {
   }
 
   if (post.editorialStatus === "approved") {
-    return "Approved and waiting to publish. Publish this card or use Publish Top 5 Signals when the full Top 5 is ready.";
+    return "Approved and waiting for the full Top 5 publish gate.";
   }
 
   if (post.editorialStatus === "published") {

--- a/src/app/dashboard/signals/editorial-review/page.test.tsx
+++ b/src/app/dashboard/signals/editorial-review/page.test.tsx
@@ -316,7 +316,7 @@ describe("signals editorial review page", () => {
     expect(screen.getByRole("button", { name: "Publish Top 5 Signals" })).toBeEnabled();
   });
 
-  it("shows a per-card Publish action for approved posts waiting to go live", async () => {
+  it("keeps approved rows waiting for the full Top 5 publish gate", async () => {
     getEditorialReviewState.mockResolvedValue({
       ...createAuthorizedState([approvedPost]),
     });
@@ -325,8 +325,8 @@ describe("signals editorial review page", () => {
     render(await Page({ searchParams: Promise.resolve({}) }));
 
     fireEvent.click(screen.getByRole("button", { name: "Expand" }));
-    expect(screen.getByRole("button", { name: "Publish" })).toBeEnabled();
-    expect(screen.getByText(/Approved and waiting to publish/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Publish" })).not.toBeInTheDocument();
+    expect(screen.getByText(/Approved and waiting for the full Top 5 publish gate/i)).toBeInTheDocument();
   });
 
   it("explains that draft rows still block publishing even when other rows are already published", async () => {
@@ -347,6 +347,74 @@ describe("signals editorial review page", () => {
 
     expect(screen.getByRole("button", { name: "Publish Top 5 Signals" })).toBeDisabled();
     expect(screen.getByText(/Already published posts remain publish-ready/i)).toBeInTheDocument();
+  });
+
+  it("blocks publishing with an exactly-five message for a three-row current set", async () => {
+    getEditorialReviewState.mockResolvedValue({
+      ...createAuthorizedState([
+        reviewPost,
+        {
+          ...reviewPost,
+          id: "signal-2",
+          rank: 2,
+          title: "Signal 2",
+        },
+        {
+          ...reviewPost,
+          id: "signal-3",
+          rank: 3,
+          title: "Signal 3",
+        },
+      ]),
+      latestBriefingDate: "2026-04-28",
+    });
+
+    const Page = (await import("@/app/dashboard/signals/editorial-review/page")).default;
+    render(await Page({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByText("Current set 2026-04-28")).toBeInTheDocument();
+    expect(screen.getByText("3 current cards")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Publish Top 5 Signals" })).toBeDisabled();
+    expect(
+      screen.getByText("Publishing requires exactly five ranked signal posts. Current count: 3."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows WITM rewrite-required status and failure reasons from a local fixture", async () => {
+    const rewritePost = {
+      ...reviewPost,
+      whyItMattersValidationStatus: "requires_human_rewrite" as const,
+      whyItMattersValidationFailures: ["minimum_specificity"],
+      whyItMattersValidationDetails: ["missing specific noun: no named entity, number, country, organization, or person found"],
+    };
+    getEditorialReviewState.mockResolvedValue({
+      ...createAuthorizedState([
+        rewritePost,
+        ...Array.from({ length: 4 }, (_, index) => ({
+          ...approvedPost,
+          id: `approved-${index + 2}`,
+          rank: index + 2,
+          title: `Approved ${index + 2}`,
+        })),
+      ]),
+    });
+
+    const Page = (await import("@/app/dashboard/signals/editorial-review/page")).default;
+    render(await Page({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByText("WITM rewrite required")).toBeInTheDocument();
+    expect(screen.getByText("Quality gate reasons")).toBeInTheDocument();
+    expect(
+      screen.getByText("missing specific noun: no named entity, number, country, organization, or person found"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Approve All" })).toBeDisabled();
+    expect(
+      screen.getByText("1 signal posts require a human rewrite before bulk approval."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Publish Top 5 Signals" })).toBeDisabled();
+    expect(
+      screen.getByText("1 signal posts require a human rewrite before publishing."),
+    ).toBeInTheDocument();
   });
 
   it("shows a clear historical review empty state when older dates have nothing waiting for review", async () => {

--- a/src/lib/homepage-editorial-overrides.ts
+++ b/src/lib/homepage-editorial-overrides.ts
@@ -11,6 +11,7 @@ type PublishedSignalPostRow = {
   published_why_it_matters: string | null;
   published_why_it_matters_payload: unknown | null;
   editorial_status: string | null;
+  published_at: string | null;
 };
 
 export type PublishedHomepageEditorialOverride = {
@@ -109,9 +110,10 @@ export async function getPublishedHomepageEditorialOverrides(): Promise<
 
   const result = await client
     .from("signal_posts")
-    .select("title, source_url, published_why_it_matters, published_why_it_matters_payload, editorial_status")
+    .select("title, source_url, published_why_it_matters, published_why_it_matters_payload, editorial_status, published_at")
     .eq("is_live", true)
     .eq("editorial_status", "published")
+    .not("published_at", "is", null)
     .order("rank", { ascending: true })
     .limit(5);
 

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -133,6 +133,7 @@ function createSupabaseMock(
       const filters: Array<{ column: keyof SignalPostRow; value: unknown }> = [];
       const inclusionFilters: Array<{ column: keyof SignalPostRow; values: unknown[] }> = [];
       const lessThanFilters: Array<{ column: keyof SignalPostRow; value: unknown }> = [];
+      const notNullFilters: Array<{ column: keyof SignalPostRow }> = [];
       let orSearch = "";
       const orderRules: Array<{ column: keyof SignalPostRow; ascending: boolean }> = [];
       let rangeStart: number | null = null;
@@ -143,6 +144,7 @@ function createSupabaseMock(
           filters.every((filter) => row[filter.column] === filter.value) &&
           inclusionFilters.every((filter) => filter.values.includes(row[filter.column])) &&
           lessThanFilters.every((filter) => String(row[filter.column]) < String(filter.value)) &&
+          notNullFilters.every((filter) => row[filter.column] !== null) &&
           (orSearch
             ? row.title.toLowerCase().includes(orSearch) || row.source_name.toLowerCase().includes(orSearch)
             : true),
@@ -273,6 +275,13 @@ function createSupabaseMock(
         },
         lt(column: keyof SignalPostRow, value: unknown) {
           lessThanFilters.push({ column, value });
+          return builder;
+        },
+        not(column: keyof SignalPostRow, operator: string, value: unknown) {
+          if (operator === "is" && value === null) {
+            notNullFilters.push({ column });
+          }
+
           return builder;
         },
         or(value: string) {
@@ -459,6 +468,8 @@ describe("signals editorial workflow", () => {
     expect(rows[0].edited_why_it_matters).toBe(createValidWhyItMatters());
     expect(rows[0].editorial_status).toBe("draft");
     expect(rows[0].edited_by).toBe("admin@example.com");
+    expect(rows[0].is_live).toBe(false);
+    expect(rows[0].published_at).toBeNull();
   });
 
   it("stores structured editorial draft content while preserving legacy text output", async () => {
@@ -552,6 +563,8 @@ describe("signals editorial workflow", () => {
     expect(rows[0].edited_why_it_matters).toBe(createValidWhyItMatters());
     expect(rows[0].editorial_status).toBe("approved");
     expect(rows[0].approved_by).toBe("admin@example.com");
+    expect(rows[0].is_live).toBe(false);
+    expect(rows[0].published_at).toBeNull();
   });
 
   it("blocks approval when the human rewrite still fails validation", async () => {
@@ -715,6 +728,38 @@ describe("signals editorial workflow", () => {
     expect(result.ok).toBe(false);
     expect(result.code).toBe("publish_blocked");
     expect(rows.some((row) => row.editorial_status === "published")).toBe(false);
+  });
+
+  it("blocks Top 5 publishing when the current set has fewer than exactly five approved rows", async () => {
+    const rows = Array.from({ length: 3 }, (_, index) =>
+      createRow({
+        id: `phase-b-${index + 1}`,
+        briefing_date: "2026-04-28",
+        rank: index + 1,
+        edited_why_it_matters: createValidWhyItMatters(`Phase B ${index + 1}`),
+        editorial_status: "approved",
+        is_live: false,
+        published_at: null,
+      }),
+    );
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { publishApprovedSignals } = await loadEditorialModule();
+    const result = await publishApprovedSignals();
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "publish_blocked",
+      message: "Publishing requires exactly five ranked signal posts. Current count: 3.",
+    });
+    expect(rows.every((row) => row.editorial_status === "approved")).toBe(true);
+    expect(rows.every((row) => row.is_live === false)).toBe(true);
+    expect(rows.every((row) => row.published_at === null)).toBe(true);
   });
 
   it("blocks publishing when approved why-it-matters copy fails the pre-publish gate", async () => {
@@ -979,7 +1024,7 @@ describe("signals editorial workflow", () => {
     expect(rows.every((row) => row.is_live === true)).toBe(true);
   });
 
-  it("publishes an individual approved signal post for homepage visibility", async () => {
+  it("blocks individual row publishing so the Top 5 gate cannot be bypassed", async () => {
     const rows = [
       createRow({
         id: "signal-1",
@@ -999,143 +1044,14 @@ describe("signals editorial workflow", () => {
     const { publishSignalPost } = await loadEditorialModule();
     const result = await publishSignalPost({ postId: "signal-1" });
 
-    expect(result.ok).toBe(true);
-    expect(result.message).toBe("Signal post published.");
-    expect(rows[0].editorial_status).toBe("published");
-    expect(rows[0].published_why_it_matters).toBe(createValidWhyItMatters("Google"));
-  });
-
-  it("captures individual publish storage failures as RSS publish failures", async () => {
-    const row = createRow({
-      id: "signal-1",
-      rank: 1,
-      briefing_date: "2026-04-20",
-      edited_why_it_matters: createValidWhyItMatters("Google"),
-      editorial_status: "approved",
-    });
-    createSupabaseServiceRoleClient.mockReturnValue({
-      from() {
-        let operation: "select" | "update" | null = null;
-        const builder = {
-          select() {
-            operation = "select";
-            return builder;
-          },
-          update() {
-            operation = "update";
-            return builder;
-          },
-          eq() {
-            if (operation === "update") {
-              return Promise.resolve({ error: { message: "write failed" } });
-            }
-
-            return builder;
-          },
-          maybeSingle() {
-            return Promise.resolve({ data: row, error: null });
-          },
-        };
-
-        return builder;
-      },
-    });
-    safeGetUser.mockResolvedValue({
-      user: { id: "admin-1", email: "admin@example.com" },
-      supabase: {},
-      sessionCookiePresent: true,
-    });
-
-    const { publishSignalPost } = await loadEditorialModule();
-    const result = await publishSignalPost({ postId: "signal-1" });
-
-    expect(result.ok).toBe(false);
-    expect(result.code).toBe("storage_error");
-    expect(captureRssFailure).toHaveBeenCalledWith(
-      expect.any(Error),
-      expect.objectContaining({
-        failureType: "rss_cache_write_failed",
-        phase: "publish",
-        extra: expect.objectContaining({
-          operation: "publish_signal_post",
-          postId: "signal-1",
-        }),
-      }),
-    );
-  });
-
-  it("publishes structured approved signal post payloads for homepage rendering", async () => {
-    const structured = {
-      preview: "Structured teaser.",
-      thesis: "Google's cloud strategy is now structurally tied to Amazon and Anthropic's infrastructure choices.",
-      sections: [{ title: "Why now", body: "That makes the dependency visible to customers deciding where durable AI workloads should run." }],
-    };
-    const rows = [
-      createRow({
-        id: "signal-1",
-        rank: 1,
-        briefing_date: "2026-04-20",
-        edited_why_it_matters:
-          "Google's cloud strategy is now structurally tied to Amazon and Anthropic's infrastructure choices.\n\nWhy now: That makes the dependency visible to customers deciding where durable AI workloads should run.",
-        edited_why_it_matters_payload: structured,
-        editorial_status: "approved",
-      }),
-    ];
-    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
-    safeGetUser.mockResolvedValue({
-      user: { id: "admin-1", email: "admin@example.com" },
-      supabase: {},
-      sessionCookiePresent: true,
-    });
-
-    const { publishSignalPost } = await loadEditorialModule();
-    const result = await publishSignalPost({ postId: "signal-1" });
-
-    expect(result.ok).toBe(true);
-    expect(rows[0].published_why_it_matters_payload).toEqual(structured);
-  });
-
-  it("blocks individual publishing until the signal post is approved", async () => {
-    const rows = [createRow({ id: "signal-1", editorial_status: "draft" })];
-    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
-    safeGetUser.mockResolvedValue({
-      user: { id: "admin-1", email: "admin@example.com" },
-      supabase: {},
-      sessionCookiePresent: true,
-    });
-
-    const { publishSignalPost } = await loadEditorialModule();
-    const result = await publishSignalPost({ postId: "signal-1" });
-
-    expect(result.ok).toBe(false);
-    expect(result.message).toBe("Approve this signal post before publishing it.");
-    expect(rows[0].editorial_status).toBe("draft");
-    expect(rows[0].published_why_it_matters).toBeNull();
-  });
-
-  it("blocks individual publishing when approved copy fails validation", async () => {
-    const rows = [
-      createRow({
-        id: "signal-1",
-        editorial_status: "approved",
-        edited_why_it_matters:
-          "This changes assumptions about defense posture, state capacity, or international alignment.",
-      }),
-    ];
-    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
-    safeGetUser.mockResolvedValue({
-      user: { id: "admin-1", email: "admin@example.com" },
-      supabase: {},
-      sessionCookiePresent: true,
-    });
-
-    const { publishSignalPost } = await loadEditorialModule();
-    const result = await publishSignalPost({ postId: "signal-1" });
-
     expect(result.ok).toBe(false);
     expect(result.code).toBe("publish_blocked");
-    expect(rows[0].editorial_status).toBe("needs_review");
-    expect(rows[0].why_it_matters_validation_status).toBe("requires_human_rewrite");
+    expect(result.message).toBe(
+      "Individual signal publishing is disabled. Use Publish Top 5 Signals after exactly five ranked posts are approved.",
+    );
+    expect(rows[0].editorial_status).toBe("approved");
+    expect(rows[0].is_live).toBe(false);
+    expect(rows[0].published_at).toBeNull();
     expect(rows[0].published_why_it_matters).toBeNull();
   });
 
@@ -1152,6 +1068,7 @@ describe("signals editorial workflow", () => {
           why_it_matters_validation_failures: index === 2 ? ["template_placeholder_language"] : [],
           why_it_matters_validation_details: index === 2 ? ["placeholder copy"] : [],
           is_live: true,
+          published_at: `2026-04-24T08:0${index}:00.000Z`,
         }),
       ),
       createRow({
@@ -1161,6 +1078,7 @@ describe("signals editorial workflow", () => {
         editorial_status: "published",
         published_why_it_matters: "Archived published 1",
         is_live: false,
+        published_at: "2026-04-23T08:00:00.000Z",
       }),
     ];
     createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
@@ -1172,6 +1090,35 @@ describe("signals editorial workflow", () => {
     expect(posts.map((post) => post.id)).toEqual(["live-1", "live-2", "live-4", "live-5"]);
   });
 
+  it("keeps approved but unpublished rows out of public signal and homepage reads", async () => {
+    const rows = Array.from({ length: 3 }, (_, index) =>
+      createRow({
+        id: `approved-unpublished-${index + 1}`,
+        briefing_date: "2026-04-28",
+        rank: index + 1,
+        edited_why_it_matters: createValidWhyItMatters(`Phase B ${index + 1}`),
+        editorial_status: "approved",
+        is_live: false,
+        published_at: null,
+      }),
+    );
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+
+    const { getPublishedSignalPosts, getHomepageSignalSnapshot } = await loadEditorialModule();
+    const publicSignals = await getPublishedSignalPosts();
+    const homepageSnapshot = await getHomepageSignalSnapshot({
+      today: new Date("2026-04-28T12:00:00.000Z"),
+    });
+
+    expect(publicSignals).toEqual([]);
+    expect(homepageSnapshot).toEqual({
+      source: "none",
+      posts: [],
+      depthPosts: [],
+      briefingDate: null,
+    });
+  });
+
   it("uses today's published rows as the homepage Tier 1 signal set", async () => {
     const rows = Array.from({ length: 7 }, (_, index) =>
         createRow({
@@ -1181,6 +1128,7 @@ describe("signals editorial workflow", () => {
           editorial_status: "published",
           published_why_it_matters: createValidWhyItMatters(`Google ${index + 1}`),
           is_live: true,
+          published_at: `2026-04-26T08:0${index}:00.000Z`,
         }),
     );
     createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
@@ -1221,7 +1169,8 @@ describe("signals editorial workflow", () => {
         rank: 1,
         editorial_status: "published",
         published_why_it_matters: createValidWhyItMatters("Google"),
-        is_live: false,
+        is_live: true,
+        published_at: "2026-04-25T08:00:00.000Z",
       }),
       createRow({
         id: "recent-2",
@@ -1229,7 +1178,8 @@ describe("signals editorial workflow", () => {
         rank: 2,
         editorial_status: "published",
         published_why_it_matters: createValidWhyItMatters("Amazon"),
-        is_live: false,
+        is_live: true,
+        published_at: "2026-04-25T08:01:00.000Z",
       }),
       createRow({
         id: "recent-empty-copy",
@@ -1237,7 +1187,8 @@ describe("signals editorial workflow", () => {
         rank: 3,
         editorial_status: "published",
         published_why_it_matters: null,
-        is_live: false,
+        is_live: true,
+        published_at: "2026-04-25T08:02:00.000Z",
       }),
       createRow({
         id: "older-1",
@@ -1245,7 +1196,8 @@ describe("signals editorial workflow", () => {
         rank: 1,
         editorial_status: "published",
         published_why_it_matters: createValidWhyItMatters("Microsoft"),
-        is_live: false,
+        is_live: true,
+        published_at: "2026-04-24T08:00:00.000Z",
       }),
     ];
     createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -846,7 +846,9 @@ async function loadPublishedHomepageSnapshotForDate(
     .from("signal_posts")
     .select(SIGNAL_POST_SELECT)
     .eq("briefing_date", briefingDate)
+    .eq("is_live", true)
     .eq("editorial_status", "published")
+    .not("published_at", "is", null)
     .order("rank", { ascending: true })
     .limit(limit);
 
@@ -866,7 +868,9 @@ async function loadMostRecentPublishedHomepageSnapshot(
   const result = await client
     .from("signal_posts")
     .select(SIGNAL_POST_SELECT)
+    .eq("is_live", true)
     .eq("editorial_status", "published")
+    .not("published_at", "is", null)
     .order("briefing_date", { ascending: false })
     .order("rank", { ascending: true })
     .limit(100);
@@ -1714,122 +1718,10 @@ export async function publishSignalPost(input: {
     };
   }
 
-  const lookup = await context.client
-    .from("signal_posts")
-    .select(SIGNAL_POST_SELECT)
-    .eq("id", input.postId)
-    .maybeSingle();
-
-  if (lookup.error) {
-    captureRssEditorialStorageFailure({
-      failureType: "rss_cache_read_failed",
-      phase: "publish",
-      operation: "load_signal_post_for_publish",
-      route: input.route ?? SIGNALS_EDITORIAL_ROUTE,
-      postId: input.postId,
-      message: "RSS signal post could not be loaded for publishing.",
-    });
-
-    return {
-      ok: false,
-      code: "not_found",
-      message: "The signal post could not be found.",
-    };
-  }
-
-  if (!lookup.data) {
-    return {
-      ok: false,
-      code: "not_found",
-      message: "The signal post could not be found.",
-    };
-  }
-
-  const post = mapStoredSignalPost(lookup.data as unknown as StoredSignalPost);
-
-  if (post.editorialStatus !== "approved") {
-    return {
-      ok: false,
-      code: "publish_blocked",
-      message: "Approve this signal post before publishing it.",
-    };
-  }
-
-  const structuredContent = post.editedWhyItMattersStructured;
-  const editorialText = normalizeEditorialText(
-    buildEditorialWhyItMattersText(structuredContent, post.editedWhyItMatters || ""),
-  );
-
-  if (!editorialText) {
-    return {
-      ok: false,
-      code: "publish_blocked",
-      message: "Add editorial Why it matters text before publishing this signal post.",
-    };
-  }
-
-  const now = new Date().toISOString();
-  const validation = validateWhyItMatters(editorialText);
-
-  if (!validation.passed) {
-    const flagResult = await context.client
-      .from("signal_posts")
-      .update({
-        editorial_status: "needs_review",
-        ...buildWhyItMattersValidationFields(validation, now),
-        updated_at: now,
-      })
-      .eq("id", post.id);
-
-    if (flagResult.error) {
-      return {
-        ok: false,
-        code: "storage_error",
-        message: "The signal post could not be flagged for rewrite.",
-      };
-    }
-
-    return {
-      ok: false,
-      code: "publish_blocked",
-      message: getValidationFailureMessage(validation),
-    };
-  }
-
-  const updateResult = await context.client
-    .from("signal_posts")
-    .update({
-      published_why_it_matters: editorialText,
-      published_why_it_matters_payload: structuredContent,
-      editorial_status: "published",
-      ...buildWhyItMattersValidationFields(validation, now),
-      published_at: now,
-      updated_at: now,
-    })
-    .eq("id", post.id);
-
-  if (updateResult.error) {
-    captureRssEditorialStorageFailure({
-      failureType: "rss_cache_write_failed",
-      phase: "publish",
-      operation: "publish_signal_post",
-      route: input.route ?? SIGNALS_EDITORIAL_ROUTE,
-      briefingDate: post.briefingDate,
-      postId: post.id,
-      message: "RSS signal post could not be published.",
-    });
-
-    return {
-      ok: false,
-      code: "storage_error",
-      message: "The signal post could not be published.",
-    };
-  }
-
   return {
-    ok: true,
-    code: "published",
-    message: "Signal post published.",
+    ok: false,
+    code: "publish_blocked",
+    message: "Individual signal publishing is disabled. Use Publish Top 5 Signals after exactly five ranked posts are approved.",
   };
 }
 
@@ -1851,6 +1743,7 @@ async function loadPublishedSignalPosts(limit: number): Promise<EditorialSignalP
     .select(SIGNAL_POST_SELECT)
     .eq("is_live", true)
     .eq("editorial_status", "published")
+    .not("published_at", "is", null)
     .order("rank", { ascending: true })
     .limit(limit);
 


### PR DESCRIPTION
Change type: remediation / controlled operations validation

Scope:
- Tightens public signal reads to require live + published + non-null published_at.
- Aligns homepage override reads with the same public eligibility predicate.
- Blocks/removes unsafe row-level publish bypass.
- Keeps save/approve actions unpublished.
- Surfaces WITM status/failure information in admin where data exists.
- Adds regression tests for draft isolation, publish gate, row-level publish bypass, save/approve safety, and WITM failure UI fixture.

P1 compatibility:
- Production read-only check passed before deploy:
  - published_or_live_total = 30
  - published_or_live_missing_published_at = 0
  - published_status_missing_published_at = 0
  - live_rows_excluded_by_new_predicate = 0
- No backfill was needed.
- No production writes were performed.

Local validation:
- git diff --check
- npm run lint
- npm run test -- src/lib/signals-editorial.test.ts src/app/dashboard/signals/editorial-review/page.test.tsx
- npm run test -- src/app/dashboard/signals/editorial-review/StructuredEditorialFields.test.tsx src/app/dashboard/signals/editorial-review/ApproveAllButton.test.tsx src/app/signals/page.test.tsx src/lib/homepage-editorial-overrides.test.ts src/lib/data.test.ts
- npm run build
- npm run test
- PLAYWRIGHT_MANAGED_WEBSERVER=1 npx playwright test --project=chromium
- PLAYWRIGHT_MANAGED_WEBSERVER=1 npx playwright test --project=webkit

Explicit non-goals:
- No public publish.
- No cron re-enablement.
- No pipeline/draft_only/ingestion run.
- No Batch 2 sources.
- No representative editorial-quality judgment.
- No manual publish validation.
