### PR TITLE
chore(remediation): preserve WITM metadata in draft persistence

### DIFF
--- a/docs/engineering/testing/witm-metadata-draft-persistence-remediation.md
+++ b/docs/engineering/testing/witm-metadata-draft-persistence-remediation.md
@@ -1,0 +1,189 @@
+# WITM Metadata Draft Persistence Remediation
+
+## Executive Summary
+
+- Effective change type: remediation / alignment.
+- Canonical PRD required: no.
+- Source of truth: PR #142 limited Core/Context draft-only validation result, PR #141 controlled-runner cap remediation, and the post-PR139 controlled dry-run artifact.
+- Scope: preserve WITM validation metadata that already exists in controlled dry-run artifacts when those artifacts are replayed into `draft_only` persistence.
+- Result: code remediation and tests preserve pass/rewrite status, failure reasons, and validation details through replay, draft row construction, and `signal_posts` insert mapping.
+- No `draft_only` rerun occurred.
+- No production rows were inserted, updated, deleted, published, or made live by this remediation.
+
+## Source of Truth
+
+- PR #142 validation report: `docs/engineering/testing/limited-core-context-draft-only-validation-20260429.md`
+- PR #141 controlled-runner cap remediation: `efb1eea94d0452863b487c5e5b796635380597b8`
+- Post-PR139 dry-run artifact:
+  `/Users/bm/dev/worktrees/daily-intelligence-aggregator-post-pr139-context-witm-post-deploy-validation/.pipeline-runs/controlled-pipeline-dry_run-post-pr139-context-witm-remediation-dryrun-20260429T0546Z-2026-04-29T05-47-11-859Z.json`
+- Product standard: Boot Up is a curated 7-story briefing, Top 5 Core plus Next 2 Context, with explicit structural why-it-matters reasoning.
+
+## Why No Canonical PRD Is Required
+
+This is remediation / alignment under existing product and operations governance. The change does not add a new product capability, source, public surface, schema, ranking threshold, WITM threshold, source-accessibility gate, URL/domain setting, or admin workflow. It preserves metadata that the existing controlled pipeline already generated and that the existing admin review surface needs to make non-live draft rows reviewable.
+
+## Limited Draft-Only Result Summary
+
+The prior limited Core/Context `draft_only` validation inserted exactly seven non-live review rows into `signal_posts`:
+
+- 5 Core rows.
+- 2 Context rows.
+- All rows had `editorial_status=needs_review`.
+- All rows had `is_live=false`.
+- All rows had `published_at=null`.
+- No Depth rows were inserted.
+- No publish occurred.
+- No cron ran.
+- No public homepage or `/signals` content changed.
+- `pipeline_article_candidates` was not affected.
+
+The validation remained blocked because one Core row lost expected WITM failure metadata after persistence.
+
+## Metadata Loss Blocker
+
+Expected from the dry-run artifact:
+
+| Rank | Tier | Title | Source | Expected status | Expected failure |
+| --- | --- | --- | --- | --- | --- |
+| 2 | Core | Economic Letter Countdown: Most Read Topics from 2025 | SF Fed Research and Insights | `requires_human_rewrite` | `unsupported_structural_claim` |
+
+Observed in the persisted draft row:
+
+- `why_it_matters_validation_status=passed`
+- `why_it_matters_validation_failures=[]`
+- `why_it_matters_validation_details=[]`
+
+This made the row appear cleaner than the controlled source artifact allowed. The row was still non-live and unpublished, but it was not safe to promote into admin review until the metadata preservation bug was remediated.
+
+## Root Cause
+
+The metadata was not missing from the dry-run artifact and the database schema already had fields for it:
+
+- `why_it_matters_validation_status`
+- `why_it_matters_validation_failures`
+- `why_it_matters_validation_details`
+
+The loss occurred in the replay and draft persistence mapping:
+
+1. `src/lib/pipeline/controlled-runner.ts` converted `ControlledPipelineSignalReport` rows into `BriefingItem` values without carrying `validationStatus`, `validationFailures`, or `validationDetails`.
+2. `src/lib/signals-editorial.ts` then recomputed WITM validation from text while building draft candidates.
+3. `persistSignalPostCandidates()` recomputed validation again before insert, which converted the artifact's review-required row into a passing row because the text alone passed the deterministic validator.
+
+## Code Remediation
+
+The remediation preserves explicit artifact metadata rather than deriving it again later:
+
+- `BriefingItem` now supports optional `whyItMattersValidation`.
+- Controlled replay maps `validationStatus`, `validationFailures`, and `validationDetails` into `BriefingItem.whyItMattersValidation`.
+- Replay artifacts now fail closed if selected Core/Context rows omit validation metadata.
+- Controlled report generation uses supplied `whyItMattersValidation` when present.
+- Draft candidate construction uses supplied `whyItMattersValidation` when present and falls back to deterministic validation only when no supplied metadata exists.
+- `signal_posts` insert mapping writes the already-derived `EditorialSignalPost` WITM status, failures, and details instead of re-flagging from text.
+- Persistence still forces `editorial_status=needs_review`, `is_live=false`, and `published_at=null`.
+
+## Files Changed
+
+- `src/lib/types.ts`
+- `src/lib/signals-editorial.ts`
+- `src/lib/signals-editorial.test.ts`
+- `src/lib/pipeline/controlled-execution.ts`
+- `src/lib/pipeline/controlled-runner.ts`
+- `src/lib/pipeline/controlled-runner.test.ts`
+- `docs/engineering/testing/witm-metadata-draft-persistence-remediation.md`
+
+## Tests Added
+
+- Draft-only persistence preserves supplied passing WITM validation metadata.
+- Draft-only persistence preserves supplied `requires_human_rewrite` metadata.
+- `unsupported_structural_claim` survives draft row mapping into `signal_posts`.
+- Empty supplied failure arrays do not silently convert rewrite-required rows into passing rows.
+- Replay draft-only mode preserves WITM metadata from the source artifact.
+- Replay report output preserves the same WITM metadata.
+- Depth rows remain excluded from the limited Core/Context replay path.
+
+Existing PR #141 cap behavior remains covered by controlled-execution tests: `PIPELINE_DRAFT_MAX_ROWS=7` is valid only for exact `core,context` draft-only allowlist, while 4/5/6, greater than 7, depth-including allowlists, and publish/normal mode remain rejected.
+
+## Existing Seven-Row State
+
+Read-only database inspection confirmed the existing limited draft-only rows:
+
+| Row ID | Rank | Tier | Title | Persisted status | Expected status |
+| --- | --- | --- | --- | --- | --- |
+| `c402254d-d34b-45a2-a8d7-3ef56c4febd8` | 1 | Core | Scoop: White House workshops plan to bring back Anthropic | `passed` | `passed` |
+| `e52bdbe4-cbf9-42ce-bb0e-e57c5011ba39` | 2 | Core | Economic Letter Countdown: Most Read Topics from 2025 | `passed` | `requires_human_rewrite` |
+| `25f9fa0a-d2c0-445f-9f3f-4c47b2c452eb` | 3 | Core | Democrats Need a Critical Minerals Policy Beyond Anti-Trumpism | `passed` | `passed` |
+| `d54873ce-b024-4487-b12f-ab76c5dcc888` | 4 | Core | A Closer Look at Emerging Market Resilience During Recent Shocks | `passed` | `passed` |
+| `d3e7afa2-bfe4-4232-8669-ae75b7a6380b` | 5 | Core | The R*-Labor Share Nexus | `passed` | `passed` |
+| `ee0a7572-caa0-4256-aa32-3b16056b7263` | 6 | Context | Trumps Shady Wind Deals Arent Over Yet | `passed` | `passed` |
+| `ff606539-f435-424f-bdd6-cb6f3833467d` | 7 | Context | Monetary Policy in a Slow (to No) Growth Labor Market | `passed` | `passed` |
+
+All seven rows are Core/Context only, `needs_review`, non-live, and unpublished. No Depth row from the run was found.
+
+## Dry-Run-Only Metadata Repair Plan
+
+This remediation does not execute the repair. The next separately approved operation should be a metadata-only update plan for the existing non-live draft row.
+
+Proposed target row:
+
+- `id = e52bdbe4-cbf9-42ce-bb0e-e57c5011ba39`
+- `briefing_date = 2026-04-29`
+- `rank = 2`
+- `title = Economic Letter Countdown: Most Read Topics from 2025`
+- `editorial_status = needs_review`
+- `is_live = false`
+- `published_at IS NULL`
+
+Proposed metadata-only update:
+
+- Set `why_it_matters_validation_status` to `requires_human_rewrite`.
+- Set `why_it_matters_validation_failures` to `["unsupported_structural_claim"]`.
+- Set `why_it_matters_validation_details` to `["unsupported_structural_claim: Core WITM is attached to a retrospective or meta-story that needs selection review before publication."]`.
+
+No update is proposed for the other six rows because their persisted passing status matches the source artifact.
+
+Required repair safeguards:
+
+- Affect only the existing non-live `2026-04-29` Core/Context draft row listed above.
+- Do not create rows.
+- Do not delete rows.
+- Do not publish rows.
+- Do not change `is_live`.
+- Do not change `published_at`.
+- Do not change `editorial_status`.
+- Do not touch Depth rows.
+- Do not touch existing live rows.
+- Do not change public homepage or `/signals` content.
+
+## Validation
+
+Completed before PR:
+
+- `git diff --check` passed.
+- `npm run lint` passed.
+- `npm run test -- src/lib/signals-editorial.test.ts src/lib/pipeline/controlled-runner.test.ts src/lib/pipeline/controlled-execution.test.ts` passed: 3 files / 71 tests.
+- `npm run test` passed: 72 files / 529 tests.
+- `npm run build` passed. Existing workspace-root and module-type warnings remained out of scope.
+- `python3 scripts/validate-feature-system-csv.py` passed with existing PRD slug warnings.
+- `python3 scripts/release-governance-gate.py --branch-name codex/preserve-witm-metadata-draft-persistence --pr-title "chore(remediation): preserve WITM metadata in draft persistence"` passed. The gate classified the change as `material-feature-change` with documented coverage.
+
+## Explicit No-Write Confirmation
+
+- No `draft_only` rerun occurred.
+- No `signal_posts` inserts occurred during this remediation.
+- No `signal_posts` updates occurred during this remediation.
+- No `pipeline_article_candidates` inserts occurred.
+- No production rows were updated.
+- No rows were deleted or reinserted.
+- No rows were published.
+- No live rows were created.
+- No existing live rows were modified.
+- No cron ran.
+- No `/api/cron/fetch-news` call was made.
+- No source-governance or source-list files were changed.
+- No URL/domain/env migration work occurred.
+- No Vercel settings or environment variables were changed.
+- No secrets were printed or committed.
+
+## Recommended Next Gate
+
+After this remediation is reviewed, merged, and deployed, run a separately authorized metadata-only repair for the existing seven non-live draft rows, scoped to the single flagged Core row if the six passing rows still match the source artifact. Do not rerun `draft_only`.

--- a/src/lib/pipeline/controlled-execution.ts
+++ b/src/lib/pipeline/controlled-execution.ts
@@ -3,7 +3,7 @@ import type { PublicSourcePlan } from "@/lib/source-manifest";
 import type { CandidatePoolInsufficientReason, ContentAccessibility, SourceRole } from "@/lib/source-accessibility-types";
 import type { SignalSnapshotPersistenceResult } from "@/lib/signals-editorial";
 import type { BriefingItem, DailyBriefing, SignalSelectionEligibilityTier } from "@/lib/types";
-import { validateWhyItMatters } from "@/lib/why-it-matters-quality-gate";
+import { validateWhyItMatters, type WhyItMattersFailureMode } from "@/lib/why-it-matters-quality-gate";
 import { summarizeSourceDistribution } from "@/lib/signal-selection-eligibility";
 
 export type PipelineRunMode = "normal" | "dry_run" | "draft_only";
@@ -60,7 +60,7 @@ export type ControlledPipelineSignalReport = {
   diversityProvider: string | null;
   whyItMatters: string;
   validationStatus: "passed" | "requires_human_rewrite";
-  validationFailures: string[];
+  validationFailures: WhyItMattersFailureMode[];
   validationDetails: string[];
   selectionQualityWarnings: string[];
   selectionEligibilityReasons: string[];
@@ -387,7 +387,7 @@ function mapSignalReport(item: BriefingItem, rank: number): ControlledPipelineSi
     item.sourceCount ??
     item.eventIntelligence?.signals.sourceDiversity ??
     new Set(item.sources.map((entry) => entry.title)).size;
-  const validation = validateWhyItMatters(whyItMatters, {
+  const validation = item.whyItMattersValidation ?? validateWhyItMatters(whyItMatters, {
     title: item.title,
     eligibilityTier: eligibility?.tier ?? "core_signal_eligible",
     contentAccessibility: eligibility?.contentAccessibility ?? null,

--- a/src/lib/pipeline/controlled-runner.test.ts
+++ b/src/lib/pipeline/controlled-runner.test.ts
@@ -84,7 +84,11 @@ function getPersistedItemIds() {
   return input?.items.map((item) => item.id) ?? [];
 }
 
-function buildReplaySignal(index: number, tier: SignalSelectionEligibilityTier = "core_signal_eligible") {
+function buildReplaySignal(
+  index: number,
+  tier: SignalSelectionEligibilityTier = "core_signal_eligible",
+  overrides: Record<string, unknown> = {},
+) {
   const whyItMatters =
     tier === "context_signal_eligible"
       ? "TSA attrition is rising during the shutdown, which matters because it shows whether public institutions can maintain basic services under staffing or funding pressure."
@@ -144,6 +148,7 @@ function buildReplaySignal(index: number, tier: SignalSelectionEligibilityTier =
     exclusionCause: null,
     sourceAccessibilityWarnings: [],
     coreBlockingReasons: [],
+    ...overrides,
   };
 }
 
@@ -642,6 +647,72 @@ describe("runControlledPipeline", () => {
         "replay-replay-7",
       ]);
       expect(getPersistedItemIds()).not.toContain("replay-replay-8");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("replay draft_only preserves WITM validation metadata from the source artifact", async () => {
+    const { artifactPath, cleanup } = await writeReplayArtifact(buildReplayArtifact({
+      proposedTopFive: [
+        buildReplaySignal(1, "core_signal_eligible", {
+          title: "Economic Letter Countdown: Most Read Topics from 2025",
+          whyItMatters:
+            "Economic Letter Countdown: Most Read Topics from 2025, which matters because it shows which inflation, labor, and growth questions dominated institutional attention.",
+          validationStatus: "requires_human_rewrite",
+          validationFailures: ["unsupported_structural_claim"],
+          validationDetails: [
+            "unsupported_structural_claim: Core WITM is attached to a retrospective or meta-story that needs selection review before publication.",
+          ],
+        }),
+      ],
+      proposedContextRows: [buildReplaySignal(2, "context_signal_eligible")],
+      proposedDepthRows: [buildReplaySignal(3, "depth_only")],
+    }));
+
+    try {
+      const { runControlledPipeline } = await import("@/lib/pipeline/controlled-runner");
+      const report = await runControlledPipeline(buildConfig({
+        mode: "draft_only",
+        briefingDateOverride: "2026-04-29",
+        testRunId: "replay-metadata-draft-only",
+        draftTierAllowlist: ["core_signal_eligible", "context_signal_eligible"],
+        draftMaxRows: 2,
+        replayArtifactPath: artifactPath,
+      }));
+
+      expect(persistSignalPostsForBriefing).toHaveBeenCalledWith({
+        briefingDate: "2026-04-29",
+        items: [
+          expect.objectContaining({
+            id: "replay-replay-1",
+            whyItMattersValidation: {
+              passed: false,
+              failures: ["unsupported_structural_claim"],
+              failureDetails: [
+                "unsupported_structural_claim: Core WITM is attached to a retrospective or meta-story that needs selection review before publication.",
+              ],
+              recommendedAction: "requires_human_rewrite",
+            },
+          }),
+          expect.objectContaining({
+            id: "replay-replay-2",
+            whyItMattersValidation: {
+              passed: true,
+              failures: [],
+              failureDetails: [],
+              recommendedAction: "approve",
+            },
+          }),
+        ],
+        mode: "draft_only",
+      });
+      expect(report.proposedTopFive[0].validationStatus).toBe("requires_human_rewrite");
+      expect(report.proposedTopFive[0].validationFailures).toEqual(["unsupported_structural_claim"]);
+      expect(report.proposedTopFive[0].validationDetails).toEqual([
+        "unsupported_structural_claim: Core WITM is attached to a retrospective or meta-story that needs selection review before publication.",
+      ]);
+      expect(report.proposedDepthRows).toHaveLength(0);
     } finally {
       await cleanup();
     }

--- a/src/lib/pipeline/controlled-runner.ts
+++ b/src/lib/pipeline/controlled-runner.ts
@@ -69,6 +69,18 @@ function validateReplaySignalRows(rows: unknown, label: string, expectedTier: Si
       throw new Error(`PIPELINE_REPLAY_ARTIFACT_PATH is malformed: ${label}[${index}] must include whyItMatters.`);
     }
 
+    if (row.validationStatus !== "passed" && row.validationStatus !== "requires_human_rewrite") {
+      throw new Error(`PIPELINE_REPLAY_ARTIFACT_PATH is malformed: ${label}[${index}] must include validationStatus.`);
+    }
+
+    if (!Array.isArray(row.validationFailures)) {
+      throw new Error(`PIPELINE_REPLAY_ARTIFACT_PATH is malformed: ${label}[${index}] must include validationFailures.`);
+    }
+
+    if (!Array.isArray(row.validationDetails)) {
+      throw new Error(`PIPELINE_REPLAY_ARTIFACT_PATH is malformed: ${label}[${index}] must include validationDetails.`);
+    }
+
     return row as unknown as ControlledPipelineSignalReport;
   });
 }
@@ -170,6 +182,12 @@ function replaySignalToBriefingItem(row: ControlledPipelineSignalReport, index: 
     ],
     whyItMatters: row.whyItMatters,
     aiWhyItMatters: row.whyItMatters,
+    whyItMattersValidation: {
+      passed: row.validationStatus === "passed",
+      failures: row.validationFailures,
+      failureDetails: row.validationDetails,
+      recommendedAction: row.validationStatus === "passed" ? "approve" : "requires_human_rewrite",
+    },
     sources: [{ title: sourceTitle, url: sourceUrl }],
     sourceCount: row.sourceCount ?? 1,
     estimatedMinutes: 4,

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -965,6 +965,85 @@ describe("signals editorial workflow", () => {
     expect(rows[1].why_it_matters_validation_status).toBe("passed");
   });
 
+  it("draft_only mode preserves supplied WITM validation metadata instead of recomputing it", async () => {
+    const rows: SignalPostRow[] = [];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+
+    const { persistSignalPostsForBriefing } = await loadEditorialModule();
+    const result = await persistSignalPostsForBriefing({
+      briefingDate: "2026-04-29",
+      mode: "draft_only",
+      items: [
+        {
+          ...createBriefingItem(1),
+          title: "Economic Letter Countdown: Most Read Topics from 2025",
+          aiWhyItMatters:
+            "Economic Letter Countdown: Most Read Topics from 2025, which matters because it shows which inflation, labor, and growth questions dominated institutional attention.",
+          whyItMattersValidation: {
+            passed: false,
+            failures: ["unsupported_structural_claim"],
+            failureDetails: [
+              "unsupported_structural_claim: Core WITM is attached to a retrospective or meta-story that needs selection review before publication.",
+            ],
+            recommendedAction: "requires_human_rewrite",
+          },
+        },
+        {
+          ...createBriefingItem(2),
+          aiWhyItMatters: createValidWhyItMatters("Google"),
+          whyItMattersValidation: {
+            passed: true,
+            failures: [],
+            failureDetails: [],
+            recommendedAction: "approve",
+          },
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.insertedCount).toBe(2);
+    expect(rows.every((row) => row.editorial_status === "needs_review")).toBe(true);
+    expect(rows.every((row) => row.is_live === false)).toBe(true);
+    expect(rows.every((row) => row.published_at === null)).toBe(true);
+    expect(rows[0].why_it_matters_validation_status).toBe("requires_human_rewrite");
+    expect(rows[0].why_it_matters_validation_failures).toEqual(["unsupported_structural_claim"]);
+    expect(rows[0].why_it_matters_validation_details).toEqual([
+      "unsupported_structural_claim: Core WITM is attached to a retrospective or meta-story that needs selection review before publication.",
+    ]);
+    expect(rows[1].why_it_matters_validation_status).toBe("passed");
+    expect(rows[1].why_it_matters_validation_failures).toEqual([]);
+    expect(rows[1].why_it_matters_validation_details).toEqual([]);
+  });
+
+  it("draft_only mode preserves rewrite status even when a supplied failure array is empty", async () => {
+    const rows: SignalPostRow[] = [];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+
+    const { persistSignalPostsForBriefing } = await loadEditorialModule();
+    const result = await persistSignalPostsForBriefing({
+      briefingDate: "2026-04-29",
+      mode: "draft_only",
+      items: [
+        {
+          ...createBriefingItem(1),
+          aiWhyItMatters: createValidWhyItMatters("Google"),
+          whyItMattersValidation: {
+            passed: false,
+            failures: [],
+            failureDetails: [],
+            recommendedAction: "requires_human_rewrite",
+          },
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(rows[0].why_it_matters_validation_status).toBe("requires_human_rewrite");
+    expect(rows[0].why_it_matters_validation_failures).toEqual([]);
+    expect(rows[0].why_it_matters_validation_details).toEqual([]);
+  });
+
   it("flags malformed why-it-matters drafts without blocking signal snapshot persistence", async () => {
     const rows: SignalPostRow[] = [];
     createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -15,7 +15,6 @@ import {
 import { captureRssFailure, type RssFailureType, type RssPhase } from "@/lib/observability/rss";
 import type { BriefingItem, EditorialStatus } from "@/lib/types";
 import {
-  flagCardForRewrite,
   validateWhyItMatters,
   type WhyItMattersReviewStatus,
   type WhyItMattersValidationResult,
@@ -384,7 +383,7 @@ function mapBriefingItemToSignalPost(item: BriefingItem, index: number): Editori
     item.importanceLabel,
   ].filter((value): value is string => Boolean(value));
   const aiWhyItMatters = normalizeEditorialText(item.aiWhyItMatters ?? item.whyItMatters);
-  const validation = flagCardForRewrite({ aiWhyItMatters }).whyItMattersValidation;
+  const validation = item.whyItMattersValidation ?? validateWhyItMatters(aiWhyItMatters);
 
   return {
     id: `candidate-${index + 1}`,
@@ -659,9 +658,8 @@ async function persistSignalPostCandidates(
 
   const now = new Date().toISOString();
 
-  const flaggedCandidates = missingCandidates.map(flagCardForRewrite);
   const insertResult = await client.from("signal_posts").insert(
-    flaggedCandidates.map((post) => ({
+    missingCandidates.map((post) => ({
       briefing_date: briefingDate,
       rank: post.rank,
       title: post.title,
@@ -672,11 +670,9 @@ async function persistSignalPostCandidates(
       signal_score: post.signalScore,
       selection_reason: post.selectionReason,
       ai_why_it_matters: post.aiWhyItMatters,
-      why_it_matters_validation_status: post.reviewStatus === "requires_human_rewrite"
-        ? "requires_human_rewrite"
-        : "passed",
-      why_it_matters_validation_failures: post.whyItMattersValidation.failures,
-      why_it_matters_validation_details: post.whyItMattersValidation.failureDetails,
+      why_it_matters_validation_status: post.whyItMattersValidationStatus,
+      why_it_matters_validation_failures: post.whyItMattersValidationFailures,
+      why_it_matters_validation_details: post.whyItMattersValidationDetails,
       why_it_matters_validated_at: now,
       editorial_status: "needs_review",
       published_at: null,
@@ -692,7 +688,7 @@ async function persistSignalPostCandidates(
       phase: "store",
       operation: "insert_signal_snapshot",
       briefingDate,
-      postCount: flaggedCandidates.length,
+      postCount: missingCandidates.length,
       message: "Current RSS Top 5 snapshot could not be persisted for editing.",
     });
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,6 +5,7 @@ import type {
 import type { HomepageCategoryClassification } from "@/lib/homepage-taxonomy";
 import type { SignalRole } from "@/lib/output-sanity";
 import type { EditorialWhyItMattersContent } from "@/lib/editorial-content";
+import type { WhyItMattersValidationResult } from "@/lib/why-it-matters-quality-gate";
 import type {
   ContentAccessibility,
   SourceExtractionMethod,
@@ -158,6 +159,7 @@ export type BriefingItem = {
   keyPoints: [string, string, string];
   whyItMatters: string;
   aiWhyItMatters?: string;
+  whyItMattersValidation?: WhyItMattersValidationResult;
   editedWhyItMatters?: string | null;
   publishedWhyItMatters?: string | null;
   editedWhyItMattersStructured?: EditorialWhyItMattersContent | null;


### PR DESCRIPTION
## Effective change type

remediation / alignment

## Source of truth

- PR #142 limited Core/Context draft-only validation result
- PR #141 controlled-runner cap remediation
- Post-PR139 dry-run artifact for 2026-04-29

## Canonical PRD required

No. This preserves WITM validation metadata generated by the existing controlled pipeline and required by the existing admin review workflow. It does not add a feature, source, public behavior, schema change, ranking change, WITM threshold change, source-accessibility change, URL/domain/env migration, or admin capability.

## Remediation report

- `docs/engineering/testing/witm-metadata-draft-persistence-remediation.md`

## Existing limited draft_only run

The prior controlled validation inserted exactly seven non-live Core/Context draft review rows into `signal_posts`: 5 Core and 2 Context, all `needs_review`, all `is_live=false`, all `published_at=null`, with no Depth rows, no publish, no cron, and no public surface mutation.

## Metadata loss blocker

The Core row `Economic Letter Countdown: Most Read Topics from 2025` should have retained `requires_human_rewrite` and `unsupported_structural_claim` from the dry-run artifact. Persisted readback showed it as `passed` with empty failure arrays.

## Root cause

Replay converted controlled artifact rows into `BriefingItem` values without carrying WITM validation metadata, then draft persistence recomputed validation from text and inserted the recomputed passing result. The database schema already had fields for the metadata.

## Files changed

- `src/lib/types.ts`
- `src/lib/signals-editorial.ts`
- `src/lib/signals-editorial.test.ts`
- `src/lib/pipeline/controlled-execution.ts`
- `src/lib/pipeline/controlled-runner.ts`
- `src/lib/pipeline/controlled-runner.test.ts`
- `docs/engineering/testing/witm-metadata-draft-persistence-remediation.md`

## Tests added

- Draft-only persistence preserves supplied WITM pass metadata.
- Draft-only persistence preserves supplied `requires_human_rewrite` metadata.
- `unsupported_structural_claim` survives draft row mapping into `signal_posts`.
- Empty supplied failure arrays do not silently convert rewrite-required rows into passing rows.
- Replay draft-only mode preserves WITM metadata from the source artifact.
- Replay report output preserves the same WITM metadata.
- Depth rows remain excluded from the limited Core/Context replay path.

## Validation

- `git diff --check` passed.
- `npm run lint` passed.
- `npm run test -- src/lib/signals-editorial.test.ts src/lib/pipeline/controlled-runner.test.ts src/lib/pipeline/controlled-execution.test.ts` passed: 3 files / 71 tests.
- `npm run test` passed: 72 files / 529 tests.
- `npm run build` passed. Existing workspace-root and module-type warnings remain out of scope.
- `python3 scripts/validate-feature-system-csv.py` passed with existing slug warnings.
- `python3 scripts/release-governance-gate.py --branch-name codex/preserve-witm-metadata-draft-persistence --pr-title "chore(remediation): preserve WITM metadata in draft persistence"` passed.

## No-write confirmation

- No `draft_only` was rerun.
- No production rows were updated.
- No `signal_posts` inserts occurred during this remediation.
- No `signal_posts` updates occurred during this remediation.
- No `pipeline_article_candidates` inserts occurred.
- No publish occurred.
- No cron ran.
- No live rows were created.
- No existing live rows were modified.
- No source-governance or source-list files were changed.
- No URL/domain/env migration work occurred.
- No Vercel settings/env changes occurred.

## Dry-run-only metadata repair plan

After this remediation is reviewed, merged, and deployed, run a separately authorized metadata-only repair for the existing non-live draft row `e52bdbe4-cbf9-42ce-bb0e-e57c5011ba39`. The repair should set only WITM validation metadata for the `2026-04-29` row titled `Economic Letter Countdown: Most Read Topics from 2025`, preserving `needs_review`, `is_live=false`, and `published_at=null`, and must not create rows, publish rows, touch Depth rows, or change public content.

## Recommended next gate

Targeted metadata-only repair of the existing seven non-live draft rows after this remediation is merged and deployed. Do not rerun `draft_only`.
