### PR TITLE
fix(signals): render published Context rows on public signal surface

### DIFF
--- a/docs/engineering/bug-fixes/public-context-signals-visibility-remediation.md
+++ b/docs/engineering/bug-fixes/public-context-signals-visibility-remediation.md
@@ -1,0 +1,71 @@
+# Public Context Signals Visibility Remediation
+
+- Date: 2026-04-30
+- Effective change type: remediation / public surface alignment
+- Canonical PRD required: no
+- Branch: `codex/public-context-signals-visibility-remediation`
+- Object level: Surface Placement
+
+## Source Of Truth
+
+- April 29 controlled manual publish verification: `april_29_controlled_manual_publish_verified`
+- Product Position: Boot Up is a seven-story daily briefing with Top 5 Core Signals plus Next 2 Context Signals.
+- Existing production state after the controlled manual publish: seven `2026-04-29` `signal_posts` rows are `published`, `is_live=true`, and have `published_at` populated.
+
+## Root Cause
+
+The public `/signals` route was still wired to a Top-5-only public reader:
+
+- `getPublishedSignalPosts()` loaded only five live published rows.
+- The `/signals` route rendered only when exactly five posts were returned.
+- Rank 6 and rank 7 Context rows were already live and published, but they were not included in the public `/signals` Surface Placement.
+
+This was a public-surface alignment issue, not a publishing, source, schema, ranking, WITM-threshold, or pipeline issue.
+
+## Remediation
+
+- Expanded the public published Signal read size from Top 5 to Top 5 Core plus Next 2 Context.
+- Kept public reads gated by:
+  - `is_live=true`
+  - `editorial_status='published'`
+  - `published_at IS NOT NULL`
+  - rank below the public seven-Signal slate boundary
+- Updated `/signals` to render separate sections:
+  - Top 5 Core Signals
+  - Next 2 Context Signals
+- Preserved the homepage Top 5 Core placement while keeping the already-published Context rows available to public ranked data.
+
+## Guardrails
+
+- No database rows were inserted, updated, deleted, approved, rejected, or published by this PR.
+- No cron, `draft_only`, `dry_run`, or pipeline write-mode was run.
+- No source-governance/source-list files were changed.
+- No ranking thresholds or WITM thresholds were changed.
+- No schema changes were made.
+- No URL/domain/env/Vercel settings were changed.
+- No secrets were used or exposed.
+
+## Validation
+
+Passed in this branch:
+
+- `git diff --check`
+- `npm run lint`
+- `npm run test -- src/lib/signals-editorial.test.ts`
+  - 1 file / 35 tests
+- `npm run test -- src/app/signals/page.test.tsx src/lib/data.test.ts src/app/page.test.tsx`
+  - 3 files / 8 tests
+- `npm run test -- src/components/landing/homepage.test.tsx`
+  - 1 file / 23 tests
+- `npm run build`
+- `python3 scripts/release-governance-gate.py --branch-name codex/public-context-signals-visibility-remediation --pr-title "fix(signals): render published Context rows on public signal surface" --diff-mode local`
+
+The release-governance gate classified the change as `bug-fix` and accepted the matching documentation lane.
+
+## Readiness
+
+Expected readiness after local validation and PR creation:
+
+```text
+ready_for_context_visibility_pr_review
+```

--- a/src/app/signals/page.test.tsx
+++ b/src/app/signals/page.test.tsx
@@ -9,7 +9,29 @@ vi.mock("@/lib/signals-editorial", () => {
   };
 });
 
-function createPublishedPost(index: number) {
+type PublishedPostFixture = {
+  id: string;
+  rank: number;
+  title: string;
+  sourceName: string;
+  sourceUrl: string;
+  summary: string;
+  tags: string[];
+  signalScore: number;
+  selectionReason: string;
+  aiWhyItMatters: string;
+  editedWhyItMatters: string;
+  publishedWhyItMatters: string;
+  editorialStatus: string;
+  editedBy: string;
+  editedAt: string;
+  approvedBy: string;
+  approvedAt: string;
+  publishedAt: string;
+  persisted: boolean;
+};
+
+function createPublishedPost(index: number, overrides: Partial<PublishedPostFixture> = {}) {
   return {
     id: `signal-${index}`,
     rank: index,
@@ -30,6 +52,7 @@ function createPublishedPost(index: number) {
     approvedAt: "2026-04-23T00:00:00.000Z",
     publishedAt: "2026-04-23T00:00:00.000Z",
     persisted: true,
+    ...overrides,
   };
 }
 
@@ -48,5 +71,33 @@ describe("public signals page", () => {
 
     expect(screen.getByText("Human final version 1")).toBeInTheDocument();
     expect(screen.queryByText("Raw AI draft should not be public")).not.toBeInTheDocument();
+  }, 10000);
+
+  it("renders Core and Context sections for the published seven-signal slate", async () => {
+    getPublishedSignalPosts.mockResolvedValue([
+      ...Array.from({ length: 5 }, (_, index) => createPublishedPost(index + 1)),
+      createPublishedPost(6, {
+        id: "context-1",
+        rank: 6,
+        title: "Published context signal 1",
+        publishedWhyItMatters: "Human final context version 1",
+      }),
+      createPublishedPost(7, {
+        id: "context-2",
+        rank: 7,
+        title: "Published context signal 2",
+        publishedWhyItMatters: "Human final context version 2",
+      }),
+    ]);
+
+    const Page = (await import("@/app/signals/page")).default;
+    render(await Page());
+
+    expect(screen.getByRole("heading", { name: "Top 5 Core Signals" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Next 2 Context Signals" })).toBeInTheDocument();
+    expect(screen.getByText("Published context signal 1")).toBeInTheDocument();
+    expect(screen.getByText("Published context signal 2")).toBeInTheDocument();
+    expect(screen.getByText("Human final context version 1")).toBeInTheDocument();
+    expect(screen.getByText("Human final context version 2")).toBeInTheDocument();
   }, 10000);
 });

--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -5,17 +5,23 @@ import { ExternalLink } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Panel } from "@/components/ui/panel";
-import { getPublishedSignalPosts } from "@/lib/signals-editorial";
+import {
+  getPublishedSignalPosts,
+  type EditorialSignalPost,
+} from "@/lib/signals-editorial";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export const metadata: Metadata = {
-  title: "Top 5 Signals",
+  title: "Published Signals",
 };
 
 export default async function PublicSignalsPage() {
   const posts = await getPublishedSignalPosts();
+  const corePosts = posts.filter((post) => post.rank >= 1 && post.rank <= 5);
+  const contextPosts = posts.filter((post) => post.rank >= 6 && post.rank <= 7);
+  const hasPublishedPosts = posts.length > 0;
 
   return (
     <main className="mx-auto min-h-screen w-full max-w-6xl px-4 py-6 md:px-6">
@@ -28,10 +34,10 @@ export default async function PublicSignalsPage() {
           <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
             <div className="max-w-3xl space-y-3">
               <h1 className="text-2xl font-semibold tracking-normal text-[var(--text-primary)] md:text-3xl">
-                Top 5 Signals
+                Published Signals
               </h1>
               <p className="text-base leading-7 text-[var(--text-secondary)]">
-                The current published signal list with editor-approved Why it matters context.
+                The current published briefing: Top 5 Core Signals plus the next 2 Context Signals.
               </p>
             </div>
             <Button asChild variant="secondary">
@@ -40,65 +46,102 @@ export default async function PublicSignalsPage() {
           </div>
         </header>
 
-        {posts.length === 5 ? (
-          <ol className="space-y-4">
-            {posts.map((post) => (
-              <li key={post.id}>
-                <Panel className="p-5">
-                  <div className="grid gap-4 md:grid-cols-[3rem_1fr]">
-                    <span className="flex h-10 w-10 items-center justify-center rounded-card bg-[var(--sidebar)] text-sm font-semibold text-[var(--text-primary)]">
-                      {post.rank}
-                    </span>
-                    <div className="min-w-0 space-y-3">
-                      <div>
-                        <div className="flex flex-wrap gap-2">
-                          {post.tags.map((tag) => (
-                            <Badge key={tag}>{tag}</Badge>
-                          ))}
-                          {post.signalScore !== null ? <Badge>Score {Math.round(post.signalScore)}</Badge> : null}
-                        </div>
-                        <h2 className="mt-3 text-xl font-semibold leading-7 text-[var(--text-primary)]">
-                          {post.title}
-                        </h2>
-                        <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-[var(--text-secondary)]">
-                          <span>{post.sourceName || "Unknown source"}</span>
-                          {post.sourceUrl ? (
-                            <a
-                              href={post.sourceUrl}
-                              target="_blank"
-                              rel="noreferrer"
-                              className="inline-flex items-center gap-1 text-[var(--accent)] hover:underline"
-                            >
-                              Source
-                              <ExternalLink className="h-3.5 w-3.5" />
-                            </a>
-                          ) : null}
-                        </div>
-                      </div>
-                      <p className="text-sm leading-6 text-[var(--text-secondary)]">{post.summary}</p>
-                      <div className="rounded-card border border-[var(--border)] bg-[var(--bg)] p-4">
-                        <p className="section-label">Why it matters</p>
-                        <p className="mt-2 text-base leading-7 text-[var(--text-primary)]">
-                          {post.publishedWhyItMatters}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </Panel>
-              </li>
-            ))}
-          </ol>
+        {hasPublishedPosts ? (
+          <div className="space-y-7">
+            <SignalSection
+              title="Top 5 Core Signals"
+              description="The five highest-priority published Signals for the current briefing."
+              posts={corePosts}
+            />
+            {contextPosts.length > 0 ? (
+              <SignalSection
+                title="Next 2 Context Signals"
+                description="Published Context Signals that add useful adjacent explanation without displacing the Core slate."
+                posts={contextPosts}
+              />
+            ) : null}
+          </div>
         ) : (
           <Panel className="p-6">
             <p className="text-base font-semibold text-[var(--text-primary)]">
-              Published Top 5 Signals are not available yet
+              Published Signals are not available yet
             </p>
             <p className="mt-2 text-sm leading-6 text-[var(--text-secondary)]">
-              The public signal page will appear after an editor approves and publishes all five posts.
+              The public signal page will appear after an editor approves and publishes the current Signal slate.
             </p>
           </Panel>
         )}
       </div>
     </main>
+  );
+}
+
+function SignalSection({
+  title,
+  description,
+  posts,
+}: {
+  title: string;
+  description: string;
+  posts: EditorialSignalPost[];
+}) {
+  if (posts.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-3">
+      <div>
+        <h2 className="text-lg font-semibold tracking-normal text-[var(--text-primary)]">{title}</h2>
+        <p className="mt-1 text-sm leading-6 text-[var(--text-secondary)]">{description}</p>
+      </div>
+      <ol className="space-y-4">
+        {posts.map((post) => (
+          <li key={post.id}>
+            <Panel className="p-5">
+              <div className="grid gap-4 md:grid-cols-[3rem_1fr]">
+                <span className="flex h-10 w-10 items-center justify-center rounded-card bg-[var(--sidebar)] text-sm font-semibold text-[var(--text-primary)]">
+                  {post.rank}
+                </span>
+                <div className="min-w-0 space-y-3">
+                  <div>
+                    <div className="flex flex-wrap gap-2">
+                      {post.tags.map((tag) => (
+                        <Badge key={tag}>{tag}</Badge>
+                      ))}
+                      {post.signalScore !== null ? <Badge>Score {Math.round(post.signalScore)}</Badge> : null}
+                    </div>
+                    <h3 className="mt-3 text-xl font-semibold leading-7 text-[var(--text-primary)]">
+                      {post.title}
+                    </h3>
+                    <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-[var(--text-secondary)]">
+                      <span>{post.sourceName || "Unknown source"}</span>
+                      {post.sourceUrl ? (
+                        <a
+                          href={post.sourceUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="inline-flex items-center gap-1 text-[var(--accent)] hover:underline"
+                        >
+                          Source
+                          <ExternalLink className="h-3.5 w-3.5" />
+                        </a>
+                      ) : null}
+                    </div>
+                  </div>
+                  <p className="text-sm leading-6 text-[var(--text-secondary)]">{post.summary}</p>
+                  <div className="rounded-card border border-[var(--border)] bg-[var(--bg)] p-4">
+                    <p className="section-label">Why it matters</p>
+                    <p className="mt-2 text-base leading-7 text-[var(--text-primary)]">
+                      {post.publishedWhyItMatters}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </Panel>
+          </li>
+        ))}
+      </ol>
+    </section>
   );
 }

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -143,7 +143,12 @@ function createSupabaseMock(
         return rows.filter((row) =>
           filters.every((filter) => row[filter.column] === filter.value) &&
           inclusionFilters.every((filter) => filter.values.includes(row[filter.column])) &&
-          lessThanFilters.every((filter) => String(row[filter.column]) < String(filter.value)) &&
+          lessThanFilters.every((filter) => {
+            const rowValue = row[filter.column];
+            return typeof rowValue === "number" && typeof filter.value === "number"
+              ? rowValue < filter.value
+              : String(rowValue) < String(filter.value);
+          }) &&
           notNullFilters.every((filter) => row[filter.column] !== null) &&
           (orSearch
             ? row.title.toLowerCase().includes(orSearch) || row.source_name.toLowerCase().includes(orSearch)
@@ -1136,7 +1141,7 @@ describe("signals editorial workflow", () => {
     expect(rows[0].published_why_it_matters).toBeNull();
   });
 
-  it("loads only the live published Top 5 for the public signals surface", async () => {
+  it("loads published Core and Context rows while excluding parked and non-public rows", async () => {
     const rows = [
       ...Array.from({ length: 7 }, (_, index) =>
         createRow({
@@ -1145,13 +1150,49 @@ describe("signals editorial workflow", () => {
           briefing_date: "2026-04-24",
           editorial_status: "published",
           published_why_it_matters: createValidWhyItMatters(`Google ${index + 1}`),
-          why_it_matters_validation_status: index === 2 ? "requires_human_rewrite" : "passed",
-          why_it_matters_validation_failures: index === 2 ? ["template_placeholder_language"] : [],
-          why_it_matters_validation_details: index === 2 ? ["placeholder copy"] : [],
+          why_it_matters_validation_status: "passed",
+          why_it_matters_validation_failures: [],
+          why_it_matters_validation_details: [],
           is_live: true,
           published_at: `2026-04-24T08:0${index}:00.000Z`,
         }),
       ),
+      createRow({
+        id: "parked-rank-8",
+        rank: 8,
+        briefing_date: "2026-04-24",
+        editorial_status: "published",
+        published_why_it_matters: createValidWhyItMatters("Depth"),
+        is_live: true,
+        published_at: "2026-04-24T08:08:00.000Z",
+      }),
+      createRow({
+        id: "depth-rank-10",
+        rank: 10,
+        briefing_date: "2026-04-24",
+        editorial_status: "published",
+        published_why_it_matters: createValidWhyItMatters("Depth 10"),
+        is_live: true,
+        published_at: "2026-04-24T08:10:00.000Z",
+      }),
+      createRow({
+        id: "unpublished-context",
+        rank: 6,
+        briefing_date: "2026-04-24",
+        editorial_status: "published",
+        published_why_it_matters: createValidWhyItMatters("Unpublished context"),
+        is_live: true,
+        published_at: null,
+      }),
+      createRow({
+        id: "non-live-context",
+        rank: 7,
+        briefing_date: "2026-04-24",
+        editorial_status: "published",
+        published_why_it_matters: createValidWhyItMatters("Non-live context"),
+        is_live: false,
+        published_at: "2026-04-24T08:07:00.000Z",
+      }),
       createRow({
         id: "archived-1",
         rank: 1,
@@ -1167,8 +1208,17 @@ describe("signals editorial workflow", () => {
     const { getPublishedSignalPosts } = await loadEditorialModule();
     const posts = await getPublishedSignalPosts();
 
-    expect(posts).toHaveLength(4);
-    expect(posts.map((post) => post.id)).toEqual(["live-1", "live-2", "live-4", "live-5"]);
+    expect(posts).toHaveLength(7);
+    expect(posts.map((post) => post.id)).toEqual([
+      "live-1",
+      "live-2",
+      "live-3",
+      "live-4",
+      "live-5",
+      "live-6",
+      "live-7",
+    ]);
+    expect(posts.map((post) => post.rank)).toEqual([1, 2, 3, 4, 5, 6, 7]);
   });
 
   it("keeps approved but unpublished rows out of public signal and homepage reads", async () => {
@@ -1201,7 +1251,8 @@ describe("signals editorial workflow", () => {
   });
 
   it("uses today's published rows as the homepage Tier 1 signal set", async () => {
-    const rows = Array.from({ length: 7 }, (_, index) =>
+    const rows = [
+      ...Array.from({ length: 7 }, (_, index) =>
         createRow({
           id: `live-${index + 1}`,
           rank: index + 1,
@@ -1211,7 +1262,17 @@ describe("signals editorial workflow", () => {
           is_live: true,
           published_at: `2026-04-26T08:0${index}:00.000Z`,
         }),
-    );
+      ),
+      createRow({
+        id: "parked-rank-8",
+        rank: 8,
+        briefing_date: "2026-04-26",
+        editorial_status: "published",
+        published_why_it_matters: createValidWhyItMatters("Parked"),
+        is_live: true,
+        published_at: "2026-04-26T08:08:00.000Z",
+      }),
+    ];
     createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
 
     const { getHomepageSignalSnapshot } = await loadEditorialModule();

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -57,8 +57,10 @@ const SIGNAL_POST_REQUIRED_COLUMNS = [
 const SIGNAL_POST_SELECT = SIGNAL_POST_REQUIRED_COLUMNS.join(", ");
 
 const EDITORIAL_PAGE_SIZE = 20;
-const PUBLIC_SIGNAL_DEPTH_LIMIT = 20;
+const SIGNAL_POST_CANDIDATE_DEPTH_LIMIT = 20;
 const TOP_SIGNAL_SET_SIZE = 5;
+const CONTEXT_SIGNAL_SET_SIZE = 2;
+const PUBLIC_SIGNAL_SET_SIZE = TOP_SIGNAL_SET_SIZE + CONTEXT_SIGNAL_SET_SIZE;
 
 type EditorialClient = NonNullable<ReturnType<typeof createSupabaseServiceRoleClient>>;
 
@@ -439,7 +441,7 @@ function getValidationFailureMessage(validation: WhyItMattersValidationResult) {
 }
 
 function buildSignalPostCandidates(items: BriefingItem[]) {
-  return items.slice(0, PUBLIC_SIGNAL_DEPTH_LIMIT).map(mapBriefingItemToSignalPost);
+  return items.slice(0, SIGNAL_POST_CANDIDATE_DEPTH_LIMIT).map(mapBriefingItemToSignalPost);
 }
 
 function parseEditorialSortTime(value: string | null | undefined) {
@@ -800,7 +802,7 @@ async function loadCurrentSignalDepth(client: EditorialClient, briefingDate: str
     .select(SIGNAL_POST_SELECT)
     .eq("briefing_date", briefingDate)
     .order("rank", { ascending: true })
-    .limit(PUBLIC_SIGNAL_DEPTH_LIMIT);
+    .limit(SIGNAL_POST_CANDIDATE_DEPTH_LIMIT);
 
   if (result.error) {
     return [];
@@ -845,6 +847,7 @@ async function loadPublishedHomepageSnapshotForDate(
     .eq("is_live", true)
     .eq("editorial_status", "published")
     .not("published_at", "is", null)
+    .lt("rank", PUBLIC_SIGNAL_SET_SIZE + 1)
     .order("rank", { ascending: true })
     .limit(limit);
 
@@ -867,6 +870,7 @@ async function loadMostRecentPublishedHomepageSnapshot(
     .eq("is_live", true)
     .eq("editorial_status", "published")
     .not("published_at", "is", null)
+    .lt("rank", PUBLIC_SIGNAL_SET_SIZE + 1)
     .order("briefing_date", { ascending: false })
     .order("rank", { ascending: true })
     .limit(100);
@@ -1740,6 +1744,7 @@ async function loadPublishedSignalPosts(limit: number): Promise<EditorialSignalP
     .eq("is_live", true)
     .eq("editorial_status", "published")
     .not("published_at", "is", null)
+    .lt("rank", PUBLIC_SIGNAL_SET_SIZE + 1)
     .order("rank", { ascending: true })
     .limit(limit);
 
@@ -1757,7 +1762,7 @@ async function loadPublishedSignalPosts(limit: number): Promise<EditorialSignalP
 }
 
 export async function getPublishedSignalPosts(): Promise<EditorialSignalPost[]> {
-  return (await loadPublishedSignalPosts(5)).slice(0, 5);
+  return (await loadPublishedSignalPosts(PUBLIC_SIGNAL_SET_SIZE)).slice(0, PUBLIC_SIGNAL_SET_SIZE);
 }
 
 export async function getHomepageSignalSnapshot(input: { today?: Date } = {}): Promise<HomepageSignalSnapshot> {
@@ -1788,9 +1793,9 @@ export async function getHomepageSignalSnapshot(input: { today?: Date } = {}): P
   const todayDepthPosts = await loadPublishedHomepageSnapshotForDate(
     supabase,
     todayKey,
-    PUBLIC_SIGNAL_DEPTH_LIMIT,
+    PUBLIC_SIGNAL_SET_SIZE,
   );
-  const todayPosts = todayDepthPosts.slice(0, 5);
+  const todayPosts = todayDepthPosts.slice(0, TOP_SIGNAL_SET_SIZE);
 
   if (todayPosts.length > 0) {
     return {
@@ -1803,9 +1808,9 @@ export async function getHomepageSignalSnapshot(input: { today?: Date } = {}): P
 
   const recentSnapshot = await loadMostRecentPublishedHomepageSnapshot(
     supabase,
-    PUBLIC_SIGNAL_DEPTH_LIMIT,
+    PUBLIC_SIGNAL_SET_SIZE,
   );
-  const recentPosts = recentSnapshot.posts.slice(0, 5);
+  const recentPosts = recentSnapshot.posts.slice(0, TOP_SIGNAL_SET_SIZE);
 
   if (recentPosts.length === 0) {
     return {


### PR DESCRIPTION
Effective change type: remediation / public surface alignment

Canonical PRD required: no. This aligns the public Surface Placement with the already-approved Product Position and already-published April 29 data.

Source of truth:
- April 29 controlled manual publish verification: april_29_controlled_manual_publish_verified
- Product Position: Top 5 Core Signals + Next 2 Context Signals
- Existing April 29 published signal_posts rows: 5 Core + 2 Context live/published

Root cause:
- The public /signals reader and renderer were still Top-5-oriented.
- Published rank 6-7 Context rows existed but were not loaded or rendered publicly.

Remediation:
- Load the public seven-signal boundary while preserving the live/published predicate.
- Keep homepage primary placement as Top 5 Core while retaining seven ranked rows in the public snapshot.
- Render /signals as Top 5 Core Signals plus Next 2 Context Signals.
- Exclude rank 8, Depth, non-live, unpublished, and missing-published_at rows.

Files changed:
- src/lib/signals-editorial.ts
- src/lib/signals-editorial.test.ts
- src/app/signals/page.tsx
- src/app/signals/page.test.tsx
- docs/engineering/bug-fixes/public-context-signals-visibility-remediation.md

Validation:
- git diff --check: passed
- npm run lint: passed
- npm run test -- src/lib/signals-editorial.test.ts: passed, 35 tests
- npm run test -- src/app/signals/page.test.tsx src/lib/data.test.ts src/app/page.test.tsx: passed, 8 tests
- npm run test -- src/components/landing/homepage.test.tsx: passed, 23 tests
- npm run build: passed
- release-governance gate: passed

Explicit non-goals confirmed:
- No database writes
- No publish
- No draft_only
- No dry_run
- No cron
- No pipeline write-mode
- No source-governance/source-list changes
- No ranking or WITM threshold changes
- No schema changes
- No URL/domain/env/Vercel setting changes
- No secrets exposed

Readiness label: ready_for_context_visibility_pr_review