### PR TITLE
PRD-53 editorial card controls

### DIFF
--- a/docs/engineering/change-records/prd-53-editorial-card-controls.md
+++ b/docs/engineering/change-records/prd-53-editorial-card-controls.md
@@ -1,0 +1,61 @@
+# PRD-53 Editorial Card Controls
+
+Date: 2026-04-30
+
+## Change Type
+
+Feature implementation under the approved PRD-53 amendment.
+
+## Source of Truth
+
+- `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+- `docs/operations/tracker-sync/2026-04-30-prd-53-card-level-editorial-authority.md`
+- `docs/engineering/change-records/prd-53-minimal-final-slate-composer.md`
+
+## Scope
+
+This change extends the PRD-53 final-slate composer with explicit card-level editorial controls:
+
+- approve and save draft edit through the existing editorial workflow
+- request rewrite
+- reject
+- hold as editorial evidence
+- replace a selected row with an existing candidate
+- promote or move a candidate into Core or Context slots
+- demote or remove a row from the draft slate
+- block rejected, held, rewrite-requested, removed, live, and already-published rows from draft slate assignment
+- keep public reads from showing rows with blocking editorial decisions
+
+## Persistence
+
+The migration adds nullable decision fields to `signal_posts`:
+
+- `editorial_decision`
+- `decision_note`
+- `rejected_reason`
+- `held_reason`
+- `replacement_of_row_id`
+- `reviewed_by`
+- `reviewed_at`
+
+The fields are additive and nullable by default. No production data backfill is included.
+
+## Public Visibility
+
+Public visibility remains gated by the existing public read contract:
+
+- `is_live = true`
+- `editorial_status = 'published'`
+- `published_at IS NOT NULL`
+
+Rows with `editorial_decision` values of `rejected`, `held`, `rewrite_requested`, or `removed_from_slate` are also filtered out as a safety measure.
+
+## Deferred
+
+- final 7-row publish workflow
+- publish batches
+- rollback execution
+- source concentration controls
+- full audit/history event tables
+- historical snapshot/schema layer
+- cron re-enable consideration

--- a/docs/operations/tracker-sync/2026-04-30-prd-53-editorial-card-controls.md
+++ b/docs/operations/tracker-sync/2026-04-30-prd-53-editorial-card-controls.md
@@ -1,0 +1,41 @@
+# Tracker Sync Fallback: PRD-53 Editorial Card Controls
+
+Date: 2026-04-30
+
+## Intended Tracker Update
+
+- PRD ID: PRD-53
+- PRD File: `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+- Status: In Review
+- Decision: keep
+- Change type: feature implementation
+- Branch: `codex/prd-53-editorial-card-controls`
+- Readiness label: `ready_for_prd_53_editorial_card_controls_review`
+
+## Summary
+
+Implemented the next scoped PRD-53 implementation step after the merged minimal final-slate composer:
+
+- admin card-level request rewrite, reject, and hold controls
+- replacement with existing candidate rows
+- promote, demote, reorder, and remove controls through draft final-slate placement
+- additive nullable `signal_posts` editorial decision fields
+- final-slate readiness updates for editorial decisions
+- public-read safety filtering for rejected, held, rewrite-requested, and removed rows
+- focused validator, server-action, public-read, and admin page tests
+
+## Explicit Non-Actions
+
+- No new PRD created.
+- No duplicate PRD-53 amendment file created.
+- `docs/product/feature-system.csv` intentionally left unchanged.
+- No cron run.
+- No `dry_run`.
+- No `draft_only`.
+- No pipeline write-mode run.
+- No production database row mutation.
+- No final publish workflow implementation.
+- No publish batches or rollback execution.
+- No source, ranking, or WITM threshold changes.
+- No public URL/domain/env/Vercel changes.
+- No historical snapshot/schema implementation.

--- a/docs/product/prd/prd-53-signals-admin-editorial-layer.md
+++ b/docs/product/prd/prd-53-signals-admin-editorial-layer.md
@@ -7,6 +7,8 @@
 - 2026-04-29 readiness label: `ready_for_card_level_editorial_authority_prd_review`
 - 2026-04-30 implementation checkpoint: minimal final-slate composer in review
 - 2026-04-30 readiness label: `ready_for_prd_53_minimal_final_slate_composer_review`
+- 2026-04-30 implementation checkpoint: editorial card controls in review
+- 2026-04-30 readiness label: `ready_for_prd_53_editorial_card_controls_review`
 
 ## Objective
 
@@ -710,12 +712,20 @@ Phase 2 - Admin final-slate composer:
 - Validate readiness for exactly 5 Core rows and 2 Context rows before any future publish workflow.
 - Keep final slate publish execution disabled in this phase.
 - Keep public reads gated by `is_live = true`, `editorial_status = 'published'`, and `published_at IS NOT NULL`; `final_slate_rank` alone is not public visibility.
-- Defer reject, hold, replace, promote, demote, publish batches, rollback execution, historical snapshots, and cron re-enable to later phases.
+- Defer reject, hold, replace, promote, demote, publish batches, rollback execution, historical snapshots, and cron re-enable to later phases from the composer-only checkpoint.
 
 Phase 3 - Replacement / hold / reject / promote / demote actions:
 
 - Approve row, request rewrite, save draft edit, reject row, hold row, replace with existing candidate, promote to Core, demote to Context/Depth, store decision audit trail, and show source concentration warning.
 - Publish can remain disabled or controlled until validation matures.
+
+2026-04-30 implementation checkpoint:
+
+- Add explicit admin controls for approve, save draft edit, request rewrite, reject, hold, replace with existing candidate, promote, demote, reorder, and remove from the draft slate.
+- Persist card-level decision state through nullable `signal_posts.editorial_decision`, decision notes/reasons, replacement linkage, and reviewer metadata.
+- Keep `editorial_status` as the existing draft/review/approved/published lifecycle and use `editorial_decision` for PRD-53 card-level authority so public visibility still requires `is_live = true`, `editorial_status = 'published'`, and `published_at IS NOT NULL`.
+- Block rejected, held, rewrite-requested, removed, live, and already-published rows from draft slate assignment.
+- Keep final public publish execution, publish batches, rollback execution, source concentration controls, historical snapshots, and cron re-enable out of this phase.
 
 Phase 4 - Controlled publish workflow hardening:
 

--- a/src/app/dashboard/signals/editorial-review/StructuredEditorialFields.tsx
+++ b/src/app/dashboard/signals/editorial-review/StructuredEditorialFields.tsx
@@ -14,6 +14,9 @@ import {
 
 import {
   approveSignalPostAction,
+  holdSignalPostAction,
+  rejectSignalPostAction,
+  requestRewriteAction,
   resetSignalPostToAiDraftAction,
   saveSignalDraftAction,
 } from "@/app/dashboard/signals/editorial-review/actions";
@@ -51,10 +54,13 @@ export function SignalPostEditor({ post, storageReady }: SignalPostEditorProps) 
   const structuredContent =
     post.editedWhyItMattersStructured ?? post.publishedWhyItMattersStructured;
   const controlsDisabled = !storageReady || !post.persisted;
+  const decisionControlsDisabled =
+    controlsDisabled || post.isLive || post.editorialStatus === "published" || Boolean(post.publishedAt);
   const eligibleForApproveAll =
     post.persisted &&
     ["draft", "needs_review"].includes(post.editorialStatus) &&
-    post.whyItMattersValidationStatus !== "requires_human_rewrite";
+    post.whyItMattersValidationStatus !== "requires_human_rewrite" &&
+    !isBlockingDecision(post.editorialDecision);
   const requiresHumanRewrite = post.whyItMattersValidationStatus === "requires_human_rewrite";
   const toggleLabel = isExpanded ? "Collapse" : "Expand";
   const panelId = `editorial-panel-${post.id}`;
@@ -72,8 +78,13 @@ export function SignalPostEditor({ post, storageReady }: SignalPostEditorProps) 
                 </span>
                 {post.briefingDate ? <Badge>{post.briefingDate}</Badge> : null}
                 <Badge>{formatStatus(post.editorialStatus)}</Badge>
+                <Badge>{formatDecision(post.editorialDecision)}</Badge>
                 <Badge>{requiresHumanRewrite ? "WITM rewrite required" : "WITM passed"}</Badge>
+                {post.finalSlateRank ? <Badge>Selected for final slate</Badge> : null}
+                {post.finalSlateTier ? <Badge>{formatStatus(post.finalSlateTier)}</Badge> : null}
+                {post.replacementOfRowId ? <Badge>Replacement</Badge> : null}
                 {post.isLive ? <Badge>Live homepage set</Badge> : null}
+                {post.publishedAt ? <Badge>Published warning</Badge> : null}
                 {post.signalScore !== null ? <Badge>Score {Math.round(post.signalScore)}</Badge> : null}
                 {post.tags.map((tag) => (
                   <Badge key={tag}>{tag}</Badge>
@@ -175,6 +186,45 @@ export function SignalPostEditor({ post, storageReady }: SignalPostEditorProps) 
               <RotateCcw className="h-4 w-4" />
               Reset to AI Draft
             </Button>
+          </div>
+          <div className="space-y-3 rounded-card border border-[var(--border)] bg-[var(--bg)] p-3">
+            <label htmlFor={`decisionNote-${post.id}`} className="text-sm font-semibold text-[var(--text-primary)]">
+              Editorial decision note
+              <textarea
+                id={`decisionNote-${post.id}`}
+                name="decisionNote"
+                defaultValue={post.decisionNote ?? post.rejectedReason ?? post.heldReason ?? ""}
+                rows={3}
+                placeholder="Required for reject, hold, and replacement decisions."
+                className="mt-2 w-full resize-y rounded-card border border-[var(--border)] bg-[var(--card)] px-3 py-3 text-sm leading-6 text-[var(--text-primary)] outline-none transition focus:border-[var(--accent)]"
+              />
+            </label>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="submit"
+                formAction={requestRewriteAction}
+                variant="secondary"
+                disabled={decisionControlsDisabled}
+              >
+                Request Rewrite
+              </Button>
+              <Button
+                type="submit"
+                formAction={rejectSignalPostAction}
+                variant="secondary"
+                disabled={decisionControlsDisabled}
+              >
+                Reject
+              </Button>
+              <Button
+                type="submit"
+                formAction={holdSignalPostAction}
+                variant="secondary"
+                disabled={decisionControlsDisabled}
+              >
+                Hold
+              </Button>
+            </div>
           </div>
           <p className="text-sm leading-6 text-[var(--text-secondary)]">
             {getPostStateHint(post)}
@@ -406,6 +456,18 @@ function FieldBlock({
 }
 
 function getPostStateHint(post: EditorialSignalPost) {
+  if (post.editorialDecision === "rejected") {
+    return "Rejected rows stay available in admin history and cannot be selected for the final slate.";
+  }
+
+  if (post.editorialDecision === "held") {
+    return "Held rows are retained as editorial evidence and cannot be selected for the final slate.";
+  }
+
+  if (post.editorialDecision === "rewrite_requested") {
+    return "Rewrite-requested rows stay in admin review and cannot pass final-slate readiness.";
+  }
+
   if (post.whyItMattersValidationStatus === "requires_human_rewrite") {
     return "Rewrite the Why it matters copy and approve again before this card can publish.";
   }
@@ -426,4 +488,17 @@ function formatStatus(status: string) {
     .split("_")
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
+}
+
+function formatDecision(decision: string | null) {
+  return decision ? formatStatus(decision) : "Needs review";
+}
+
+function isBlockingDecision(decision: string | null) {
+  return (
+    decision === "rejected" ||
+    decision === "held" ||
+    decision === "rewrite_requested" ||
+    decision === "removed_from_slate"
+  );
 }

--- a/src/app/dashboard/signals/editorial-review/actions.ts
+++ b/src/app/dashboard/signals/editorial-review/actions.ts
@@ -13,9 +13,13 @@ import {
   approveSignalPost,
   approveSignalPosts,
   assignSignalPostToFinalSlateSlot,
+  holdSignalPost,
   publishApprovedSignals,
   publishSignalPost,
+  rejectSignalPost,
   removeSignalPostFromFinalSlate,
+  replaceSignalPostInFinalSlate,
+  requestSignalPostRewrite,
   resetSignalPostToAiDraft,
   saveSignalDraft,
   type EditorialMutationResult,
@@ -132,6 +136,45 @@ export async function resetSignalPostToAiDraftAction(formData: FormData) {
   redirectWithResult(result);
 }
 
+export async function requestRewriteAction(formData: FormData) {
+  const result = await requestSignalPostRewrite({
+    postId: String(formData.get("postId") ?? ""),
+    decisionNote: String(formData.get("decisionNote") ?? ""),
+  });
+
+  if (result.ok) {
+    revalidateEditorialReviewRoute();
+  }
+
+  redirectWithResult(result);
+}
+
+export async function rejectSignalPostAction(formData: FormData) {
+  const result = await rejectSignalPost({
+    postId: String(formData.get("postId") ?? ""),
+    decisionNote: String(formData.get("decisionNote") ?? ""),
+  });
+
+  if (result.ok) {
+    revalidateEditorialReviewRoute();
+  }
+
+  redirectWithResult(result);
+}
+
+export async function holdSignalPostAction(formData: FormData) {
+  const result = await holdSignalPost({
+    postId: String(formData.get("postId") ?? ""),
+    decisionNote: String(formData.get("decisionNote") ?? ""),
+  });
+
+  if (result.ok) {
+    revalidateEditorialReviewRoute();
+  }
+
+  redirectWithResult(result);
+}
+
 export async function publishTopSignalsAction() {
   const result = await publishApprovedSignals();
 
@@ -170,6 +213,20 @@ export async function assignFinalSlateSlotAction(formData: FormData) {
 export async function removeFromFinalSlateAction(formData: FormData) {
   const result = await removeSignalPostFromFinalSlate({
     postId: String(formData.get("postId") ?? ""),
+  });
+
+  if (result.ok) {
+    revalidateEditorialReviewRoute();
+  }
+
+  redirectWithResult(result);
+}
+
+export async function replaceFinalSlateSlotAction(formData: FormData) {
+  const result = await replaceSignalPostInFinalSlate({
+    originalPostId: String(formData.get("originalPostId") ?? ""),
+    replacementPostId: String(formData.get("replacementPostId") ?? ""),
+    decisionNote: String(formData.get("decisionNote") ?? ""),
   });
 
   if (result.ok) {

--- a/src/app/dashboard/signals/editorial-review/page.test.tsx
+++ b/src/app/dashboard/signals/editorial-review/page.test.tsx
@@ -21,6 +21,10 @@ vi.mock("@/app/dashboard/signals/editorial-review/actions", () => ({
   publishSignalPostAction: vi.fn(),
   assignFinalSlateSlotAction: vi.fn(),
   removeFromFinalSlateAction: vi.fn(),
+  requestRewriteAction: vi.fn(),
+  rejectSignalPostAction: vi.fn(),
+  holdSignalPostAction: vi.fn(),
+  replaceFinalSlateSlotAction: vi.fn(),
 }));
 
 const reviewPost = {
@@ -46,6 +50,13 @@ const reviewPost = {
   editorialStatus: "needs_review",
   finalSlateRank: null,
   finalSlateTier: null,
+  editorialDecision: null,
+  decisionNote: null,
+  rejectedReason: null,
+  heldReason: null,
+  replacementOfRowId: null,
+  reviewedBy: null,
+  reviewedAt: null,
   editedBy: null,
   editedAt: null,
   approvedBy: null,
@@ -140,6 +151,10 @@ describe("signals editorial review page", () => {
     expect(screen.getByRole("button", { name: "Approve All" })).toBeEnabled();
     fireEvent.click(screen.getByRole("button", { name: "Expand" }));
     expect(screen.getByLabelText("Thesis / opening statement")).toHaveValue("Raw AI draft");
+    expect(screen.getByRole("button", { name: "Request Rewrite" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Reject" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Hold" })).toBeEnabled();
+    expect(screen.getByLabelText("Editorial decision note")).toBeInTheDocument();
   });
 
   it("renders the final-slate composer slots and disabled readiness state", async () => {

--- a/src/app/dashboard/signals/editorial-review/page.tsx
+++ b/src/app/dashboard/signals/editorial-review/page.tsx
@@ -11,6 +11,7 @@ import {
   assignFinalSlateSlotAction,
   approveAllSignalPostsAction,
   removeFromFinalSlateAction,
+  replaceFinalSlateSlotAction,
 } from "@/app/dashboard/signals/editorial-review/actions";
 import { ApproveAllButton } from "@/app/dashboard/signals/editorial-review/ApproveAllButton";
 import { SignalPostEditor } from "@/app/dashboard/signals/editorial-review/StructuredEditorialFields";
@@ -357,6 +358,7 @@ function FinalSlateComposer({
                 post={candidates.find((candidate) => candidate.finalSlateRank === rank) ?? null}
                 rowFailures={readiness.rowFailures}
                 slotFailures={readiness.slotFailures[rank] ?? []}
+                candidates={candidates}
                 storageReady={storageReady}
               />
             ))}
@@ -428,16 +430,21 @@ function FinalSlateSlot({
   post,
   rowFailures,
   slotFailures,
+  candidates,
   storageReady,
 }: {
   rank: number;
   post: EditorialSignalPost | null;
   rowFailures: Record<string, string[]>;
   slotFailures: string[];
+  candidates: EditorialSignalPost[];
   storageReady: boolean;
 }) {
   const tier = getFinalSlateTierForRank(rank);
   const failures = post ? rowFailures[post.id] ?? [] : slotFailures;
+  const replacements = post ? getEligibleReplacementCandidates(candidates, post) : [];
+  const previousRank = rank > 1 ? rank - 1 : null;
+  const nextRank = rank < 7 ? rank + 1 : null;
 
   return (
     <div className="min-h-56 rounded-card border border-[var(--border)] bg-[var(--bg)] p-3">
@@ -454,6 +461,10 @@ function FinalSlateSlot({
           <div className="flex flex-wrap gap-2">
             <Badge>{post.whyItMattersValidationStatus === "passed" ? "WITM passed" : "WITM rewrite required"}</Badge>
             <Badge>{post.editorialStatus}</Badge>
+            <Badge>{formatDecision(post.editorialDecision)}</Badge>
+            {post.replacementOfRowId ? <Badge>Replacement</Badge> : null}
+            {post.isLive ? <Badge>Live warning</Badge> : null}
+            {post.publishedAt ? <Badge>Published warning</Badge> : null}
           </div>
           {failures.length > 0 ? (
             <ul className="space-y-1 text-xs leading-5 text-[var(--text-secondary)]">
@@ -465,9 +476,57 @@ function FinalSlateSlot({
           <form action={removeFromFinalSlateAction}>
             <input type="hidden" name="postId" value={post.id} />
             <Button type="submit" variant="secondary" disabled={!storageReady} className="w-full">
-              Remove
+              Demote / Remove
             </Button>
           </form>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {previousRank ? (
+              <form action={assignFinalSlateSlotAction}>
+                <input type="hidden" name="postId" value={post.id} />
+                <input type="hidden" name="finalSlateRank" value={previousRank} />
+                <Button type="submit" variant="secondary" disabled={!storageReady} className="w-full">
+                  Move Up
+                </Button>
+              </form>
+            ) : null}
+            {nextRank ? (
+              <form action={assignFinalSlateSlotAction}>
+                <input type="hidden" name="postId" value={post.id} />
+                <input type="hidden" name="finalSlateRank" value={nextRank} />
+                <Button type="submit" variant="secondary" disabled={!storageReady} className="w-full">
+                  Move Down
+                </Button>
+              </form>
+            ) : null}
+          </div>
+          {replacements.length > 0 ? (
+            <form action={replaceFinalSlateSlotAction} className="space-y-2 rounded-card border border-[var(--border)] bg-[var(--card)] p-3">
+              <input type="hidden" name="originalPostId" value={post.id} />
+              <label className="section-label" htmlFor={`replacementPostId-${post.id}`}>Replace with</label>
+              <select
+                id={`replacementPostId-${post.id}`}
+                name="replacementPostId"
+                className="w-full rounded-button border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-xs text-[var(--text-primary)]"
+                required
+              >
+                {replacements.map((candidate) => (
+                  <option key={candidate.id} value={candidate.id}>
+                    {candidate.title} - {candidate.sourceName || "Missing source"}
+                  </option>
+                ))}
+              </select>
+              <textarea
+                name="decisionNote"
+                rows={2}
+                placeholder="Replacement reason"
+                className="w-full resize-y rounded-button border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-xs text-[var(--text-primary)]"
+                required
+              />
+              <Button type="submit" variant="secondary" disabled={!storageReady} className="w-full">
+                Replace
+              </Button>
+            </form>
+          ) : null}
         </div>
       ) : (
         <div className="flex min-h-36 flex-col justify-between gap-3">
@@ -492,7 +551,13 @@ function FinalSlateCandidateRow({
   rowFailures: string[];
   storageReady: boolean;
 }) {
-  const canAssign = storageReady && post.persisted && !post.isLive && post.editorialStatus !== "published" && !post.publishedAt;
+  const canAssign =
+    storageReady &&
+    post.persisted &&
+    !post.isLive &&
+    post.editorialStatus !== "published" &&
+    !post.publishedAt &&
+    !isBlockingDecision(post.editorialDecision);
   const placement = post.finalSlateRank ? formatSlotLabel(post.finalSlateRank) : "Not selected";
 
   return (
@@ -501,7 +566,12 @@ function FinalSlateCandidateRow({
         <div className="flex flex-wrap items-center gap-2">
           <Badge>Pipeline rank {post.rank}</Badge>
           <Badge>{placement}</Badge>
+          {post.finalSlateRank ? <Badge>Selected for final slate</Badge> : null}
+          {post.finalSlateTier ? <Badge>{post.finalSlateTier === "core" ? "Core" : "Context"}</Badge> : null}
           <Badge>{post.editorialStatus}</Badge>
+          <Badge>{formatDecision(post.editorialDecision)}</Badge>
+          {post.replacementOfRowId ? <Badge>Replacement</Badge> : null}
+          <Badge>{post.whyItMattersValidationStatus === "passed" ? "WITM passed" : "WITM failed / requires rewrite"}</Badge>
           <Badge>{post.isLive ? "Live" : "Non-live"}</Badge>
           <Badge>{post.publishedAt ? "Published date set" : "Unpublished"}</Badge>
         </div>
@@ -531,9 +601,9 @@ function FinalSlateCandidateRow({
         ) : null}
       </div>
       <div className="space-y-2">
-        <p className="section-label">Assign to slot</p>
-        <div className="grid grid-cols-7 gap-2">
-          {FINAL_SLATE_RANKS.map((rank) => (
+        <p className="section-label">Promote / move to Core slot</p>
+        <div className="grid grid-cols-5 gap-2">
+          {FINAL_SLATE_RANKS.slice(0, 5).map((rank) => (
             <form key={rank} action={assignFinalSlateSlotAction}>
               <input type="hidden" name="postId" value={post.id} />
               <input type="hidden" name="finalSlateRank" value={rank} />
@@ -549,14 +619,99 @@ function FinalSlateCandidateRow({
             </form>
           ))}
         </div>
+        <p className="section-label">Move to Context slot</p>
+        <div className="grid grid-cols-2 gap-2">
+          {FINAL_SLATE_RANKS.slice(5).map((rank) => (
+            <form key={rank} action={assignFinalSlateSlotAction}>
+              <input type="hidden" name="postId" value={post.id} />
+              <input type="hidden" name="finalSlateRank" value={rank} />
+              <Button
+                type="submit"
+                variant={post.finalSlateRank === rank ? "primary" : "secondary"}
+                disabled={!canAssign}
+                className="h-10 w-full px-0"
+                aria-label={`Assign ${post.title} to ${formatSlotLabel(rank)}`}
+              >
+                {rank}
+              </Button>
+            </form>
+          ))}
+        </div>
+        {post.finalSlateRank ? (
+          <form action={removeFromFinalSlateAction}>
+            <input type="hidden" name="postId" value={post.id} />
+            <Button type="submit" variant="secondary" disabled={!storageReady} className="w-full">
+              Remove from slate
+            </Button>
+          </form>
+        ) : null}
         <p className="text-xs leading-5 text-[var(--text-secondary)]">
           {canAssign
             ? "Slot assignment updates draft placement only."
-            : "Only persisted, non-live, unpublished rows can be assigned."}
+            : getAssignmentBlockedReason(post, storageReady)}
         </p>
       </div>
     </div>
   );
+}
+
+function getEligibleReplacementCandidates(
+  candidates: EditorialSignalPost[],
+  original: EditorialSignalPost,
+) {
+  return candidates.filter(
+    (candidate) =>
+      candidate.id !== original.id &&
+      candidate.persisted &&
+      candidate.briefingDate === original.briefingDate &&
+      !candidate.finalSlateRank &&
+      !candidate.isLive &&
+      candidate.editorialStatus !== "published" &&
+      !candidate.publishedAt &&
+      !isBlockingDecision(candidate.editorialDecision),
+  );
+}
+
+function isBlockingDecision(decision: string | null) {
+  return (
+    decision === "rejected" ||
+    decision === "held" ||
+    decision === "rewrite_requested" ||
+    decision === "removed_from_slate"
+  );
+}
+
+function getAssignmentBlockedReason(post: EditorialSignalPost, storageReady: boolean) {
+  if (!storageReady) {
+    return "Editorial storage must be configured before placement can change.";
+  }
+
+  if (!post.persisted) {
+    return "Only persisted rows can be assigned.";
+  }
+
+  if (post.isLive) {
+    return "Live rows cannot be assigned to the draft final slate.";
+  }
+
+  if (post.editorialStatus === "published" || post.publishedAt) {
+    return "Already published rows cannot be assigned.";
+  }
+
+  if (isBlockingDecision(post.editorialDecision)) {
+    return "Rejected, held, rewrite-requested, or removed rows cannot be assigned.";
+  }
+
+  return "Only persisted, non-live, unpublished rows can be assigned.";
+}
+
+function formatDecision(decision: string | null) {
+  return decision
+    ? decision
+      .split("_")
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ")
+    : "Needs review";
 }
 
 function normalizeStatusFilter(value: string | undefined): EditorialPostStatusFilter {
@@ -629,7 +784,8 @@ function isBulkApprovablePost(post: EditorialSignalPost) {
   return (
     post.persisted &&
     ["draft", "needs_review"].includes(post.editorialStatus) &&
-    post.whyItMattersValidationStatus !== "requires_human_rewrite"
+    post.whyItMattersValidationStatus !== "requires_human_rewrite" &&
+    !isBlockingDecision(post.editorialDecision)
   );
 }
 
@@ -782,6 +938,17 @@ function getApproveAllBlockedReason(
 
   if (rewriteRequiredCount > 0) {
     return `${rewriteRequiredCount} signal posts require a human rewrite before bulk approval.`;
+  }
+
+  const blockedDecisionCount = posts.filter(
+    (post) =>
+      post.persisted &&
+      ["draft", "needs_review"].includes(post.editorialStatus) &&
+      isBlockingDecision(post.editorialDecision),
+  ).length;
+
+  if (blockedDecisionCount > 0) {
+    return `${blockedDecisionCount} signal posts have rejected, held, or rewrite-requested editorial decisions.`;
   }
 
   if (eligibleCount === 0) {

--- a/src/lib/final-slate-readiness.test.ts
+++ b/src/lib/final-slate-readiness.test.ts
@@ -19,6 +19,7 @@ function makeRow(
     sourceName: overrides.sourceName ?? "Source",
     sourceUrl: overrides.sourceUrl ?? `https://example.com/source-${slot}`,
     editorialStatus: overrides.editorialStatus ?? "approved",
+    editorialDecision: overrides.editorialDecision ?? null,
     isLive: overrides.isLive ?? false,
     publishedAt: overrides.publishedAt ?? null,
     whyItMattersValidationStatus: overrides.whyItMattersValidationStatus ?? "passed",
@@ -122,10 +123,32 @@ describe("final slate readiness", () => {
     expect(result.rowFailures["signal-2"]).toContain("Selected row is marked held.");
   });
 
+  it("fails when a selected row has a held editorial decision", () => {
+    const result = validateFinalSlateReadiness(
+      validSlate({
+        2: { editorialDecision: "held" },
+      }),
+    );
+
+    expect(result.ready).toBe(false);
+    expect(result.rowFailures["signal-2"]).toContain("Selected row is marked held.");
+  });
+
   it("fails when a selected row is rejected", () => {
     const result = validateFinalSlateReadiness(
       validSlate({
         2: { editorialStatus: "rejected" },
+      }),
+    );
+
+    expect(result.ready).toBe(false);
+    expect(result.rowFailures["signal-2"]).toContain("Selected row is marked rejected.");
+  });
+
+  it("fails when a selected row has a rejected editorial decision", () => {
+    const result = validateFinalSlateReadiness(
+      validSlate({
+        2: { editorialDecision: "rejected" },
       }),
     );
 
@@ -142,6 +165,30 @@ describe("final slate readiness", () => {
 
     expect(result.ready).toBe(false);
     expect(result.rowFailures["signal-2"]).toContain("Selected row has rewrite_requested editorial status.");
+  });
+
+  it("fails when a selected row has a rewrite-requested editorial decision", () => {
+    const result = validateFinalSlateReadiness(
+      validSlate({
+        2: { editorialDecision: "rewrite_requested" },
+      }),
+    );
+
+    expect(result.ready).toBe(false);
+    expect(result.rowFailures["signal-2"]).toContain("Selected row has rewrite_requested editorial status.");
+  });
+
+  it("fails when an approved selected row still has a draft-edited decision", () => {
+    const result = validateFinalSlateReadiness(
+      validSlate({
+        2: { editorialDecision: "draft_edited" },
+      }),
+    );
+
+    expect(result.ready).toBe(false);
+    expect(result.rowFailures["signal-2"]).toContain(
+      "Selected row must have an approved editorial decision before readiness.",
+    );
   });
 
   it("fails when a selected row is already live before publish", () => {

--- a/src/lib/final-slate-readiness.ts
+++ b/src/lib/final-slate-readiness.ts
@@ -16,6 +16,7 @@ export type FinalSlateValidationRow = {
   sourceName?: string | null;
   sourceUrl?: string | null;
   editorialStatus?: string | null;
+  editorialDecision?: string | null;
   isLive?: boolean | null;
   publishedAt?: string | null;
   whyItMattersValidationStatus?: string | null;
@@ -23,6 +24,7 @@ export type FinalSlateValidationRow = {
   whyItMattersValidationDetails?: string[] | null;
   finalSlateRank?: number | null;
   finalSlateTier?: string | null;
+  replacementOfRowId?: string | null;
 };
 
 export type FinalSlateValidationFailure = {
@@ -193,19 +195,21 @@ function addRowContentFailures(
 ) {
   const rank = row.finalSlateRank ?? undefined;
   const editorialStatus = row.editorialStatus ?? "";
+  const editorialDecision = row.editorialDecision ?? "";
   const validationStatus = row.whyItMattersValidationStatus ?? "";
   const validationFailures = row.whyItMattersValidationFailures ?? [];
   const validationDetails = row.whyItMattersValidationDetails ?? [];
 
-  // Current signal_posts status values are draft/needs_review/approved/published.
-  // PRD-53 follow-up controls may add held/rejected/rewrite_requested, so the
-  // readiness gate treats those future decision states as hard blockers too.
-  if (editorialStatus === "rejected") {
+  if (editorialDecision === "rejected" || editorialStatus === "rejected") {
     addRowFailure(row, "Selected row is marked rejected.", "rejected_row", rank);
-  } else if (editorialStatus === "held") {
+  } else if (editorialDecision === "held" || editorialStatus === "held") {
     addRowFailure(row, "Selected row is marked held.", "held_row", rank);
-  } else if (editorialStatus === "rewrite_requested") {
+  } else if (editorialDecision === "rewrite_requested" || editorialStatus === "rewrite_requested") {
     addRowFailure(row, "Selected row has rewrite_requested editorial status.", "rewrite_requested_row", rank);
+  } else if (editorialDecision === "removed_from_slate") {
+    addRowFailure(row, "Selected row was removed from the final slate.", "removed_from_slate", rank);
+  } else if (editorialDecision && editorialDecision !== "approved") {
+    addRowFailure(row, "Selected row must have an approved editorial decision before readiness.", "decision_not_approved", rank);
   } else if (editorialStatus === "published") {
     addRowFailure(row, "Selected row is already published.", "already_published", rank);
   } else if (editorialStatus !== "approved") {

--- a/src/lib/homepage-editorial-overrides.ts
+++ b/src/lib/homepage-editorial-overrides.ts
@@ -11,6 +11,7 @@ type PublishedSignalPostRow = {
   published_why_it_matters: string | null;
   published_why_it_matters_payload: unknown | null;
   editorial_status: string | null;
+  editorial_decision: string | null;
   published_at: string | null;
 };
 
@@ -27,6 +28,10 @@ function normalizeMatchValue(value: string | null | undefined) {
 
 function normalizeEditorialText(value: string | null | undefined) {
   return value?.trim() ?? "";
+}
+
+function isPubliclyAllowedEditorialDecision(value: string | null | undefined) {
+  return value === null || value === undefined || value === "approved" || value === "draft_edited";
 }
 
 function getItemSourceUrl(item: BriefingItem) {
@@ -110,7 +115,7 @@ export async function getPublishedHomepageEditorialOverrides(): Promise<
 
   const result = await client
     .from("signal_posts")
-    .select("title, source_url, published_why_it_matters, published_why_it_matters_payload, editorial_status, published_at")
+    .select("title, source_url, published_why_it_matters, published_why_it_matters_payload, editorial_status, editorial_decision, published_at")
     .eq("is_live", true)
     .eq("editorial_status", "published")
     .not("published_at", "is", null)
@@ -122,6 +127,7 @@ export async function getPublishedHomepageEditorialOverrides(): Promise<
   }
 
   return ((result.data ?? []) as PublishedSignalPostRow[])
+    .filter((row) => isPubliclyAllowedEditorialDecision(row.editorial_decision))
     .map((row) => ({
       title: normalizeEditorialText(row.title),
       sourceUrl: normalizeEditorialText(row.source_url),

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -23,6 +23,13 @@ type SignalPostRow = {
   editorial_status: "draft" | "needs_review" | "approved" | "published";
   final_slate_rank: number | null;
   final_slate_tier: "core" | "context" | null;
+  editorial_decision: "pending_review" | "draft_edited" | "approved" | "rewrite_requested" | "rejected" | "held" | "removed_from_slate" | null;
+  decision_note: string | null;
+  rejected_reason: string | null;
+  held_reason: string | null;
+  replacement_of_row_id: string | null;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
   edited_by: string | null;
   edited_at: string | null;
   approved_by: string | null;
@@ -81,6 +88,13 @@ function createRow(overrides: Partial<SignalPostRow> = {}): SignalPostRow {
     editorial_status: overrides.editorial_status ?? "needs_review",
     final_slate_rank: overrides.final_slate_rank ?? null,
     final_slate_tier: overrides.final_slate_tier ?? null,
+    editorial_decision: overrides.editorial_decision ?? null,
+    decision_note: overrides.decision_note ?? null,
+    rejected_reason: overrides.rejected_reason ?? null,
+    held_reason: overrides.held_reason ?? null,
+    replacement_of_row_id: overrides.replacement_of_row_id ?? null,
+    reviewed_by: overrides.reviewed_by ?? null,
+    reviewed_at: overrides.reviewed_at ?? null,
     edited_by: overrides.edited_by ?? null,
     edited_at: overrides.edited_at ?? null,
     approved_by: overrides.approved_by ?? null,
@@ -268,14 +282,6 @@ function createSupabaseMock(
         eq(column: keyof SignalPostRow, value: unknown) {
           filters.push({ column, value });
 
-          if (operation === "update") {
-            applyFilters().forEach((row) => {
-              Object.assign(row, updateValues);
-            });
-
-            return Promise.resolve({ error: null });
-          }
-
           return builder;
         },
         in(column: keyof SignalPostRow, values: unknown[]) {
@@ -312,6 +318,14 @@ function createSupabaseMock(
               error: null,
               count: insertedRows.length,
             }).then(onfulfilled, onrejected);
+          }
+
+          if (operation === "update") {
+            applyFilters().forEach((row) => {
+              Object.assign(row, updateValues);
+            });
+
+            return Promise.resolve({ data: [], error: null, count: 0 }).then(onfulfilled, onrejected);
           }
 
           return Promise.resolve({ data: [], error: null, count: 0 }).then(onfulfilled, onrejected);
@@ -710,7 +724,9 @@ describe("signals editorial workflow", () => {
     });
 
     expect(result.ok).toBe(false);
-    expect(result.message).toBe("There are no Draft or Needs Review signal posts to approve.");
+    expect(result.message).toBe(
+      "There are no Draft or Needs Review signal posts without blocking editorial decisions to approve.",
+    );
     expect(rows[0].editorial_status).toBe("approved");
     expect(rows[1].editorial_status).toBe("published");
   });
@@ -1145,6 +1161,283 @@ describe("signals editorial workflow", () => {
     expect(rows[0].published_why_it_matters).toBeNull();
   });
 
+  it("reject action clears final-slate placement and records the rejection reason", async () => {
+    const rows = [
+      createRow({
+        id: "signal-1",
+        editorial_status: "approved",
+        editorial_decision: "approved",
+        final_slate_rank: 1,
+        final_slate_tier: "core",
+      }),
+    ];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { rejectSignalPost } = await loadEditorialModule();
+    const result = await rejectSignalPost({
+      postId: "signal-1",
+      decisionNote: "Duplicate of a stronger candidate.",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(rows[0].editorial_decision).toBe("rejected");
+    expect(rows[0].rejected_reason).toBe("Duplicate of a stronger candidate.");
+    expect(rows[0].final_slate_rank).toBeNull();
+    expect(rows[0].final_slate_tier).toBeNull();
+    expect(rows[0].reviewed_by).toBe("admin@example.com");
+  });
+
+  it("hold action clears final-slate placement and stores training evidence reason", async () => {
+    const rows = [
+      createRow({
+        id: "signal-1",
+        editorial_status: "needs_review",
+        final_slate_rank: 2,
+        final_slate_tier: "core",
+      }),
+    ];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { holdSignalPost } = await loadEditorialModule();
+    const result = await holdSignalPost({
+      postId: "signal-1",
+      decisionNote: "Useful calibration case, but unsupported structural claim.",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(rows[0].editorial_decision).toBe("held");
+    expect(rows[0].held_reason).toBe("Useful calibration case, but unsupported structural claim.");
+    expect(rows[0].final_slate_rank).toBeNull();
+    expect(rows[0].final_slate_tier).toBeNull();
+  });
+
+  it("request rewrite excludes the row from readiness without publishing it", async () => {
+    const rows = [
+      createRow({
+        id: "signal-1",
+        editorial_status: "approved",
+        editorial_decision: "approved",
+        final_slate_rank: 3,
+        final_slate_tier: "core",
+      }),
+    ];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { requestSignalPostRewrite } = await loadEditorialModule();
+    const result = await requestSignalPostRewrite({
+      postId: "signal-1",
+      decisionNote: "Needs a stronger structural link.",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(rows[0].editorial_status).toBe("needs_review");
+    expect(rows[0].editorial_decision).toBe("rewrite_requested");
+    expect(rows[0].final_slate_rank).toBeNull();
+    expect(rows[0].is_live).toBe(false);
+    expect(rows[0].published_at).toBeNull();
+  });
+
+  it("remove-from-slate clears placement without rejecting the row", async () => {
+    const rows = [
+      createRow({
+        id: "signal-1",
+        editorial_status: "approved",
+        editorial_decision: "approved",
+        final_slate_rank: 4,
+        final_slate_tier: "core",
+      }),
+    ];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { removeSignalPostFromFinalSlate } = await loadEditorialModule();
+    const result = await removeSignalPostFromFinalSlate({ postId: "signal-1" });
+
+    expect(result.ok).toBe(true);
+    expect(rows[0].editorial_decision).toBe("approved");
+    expect(rows[0].final_slate_rank).toBeNull();
+    expect(rows[0].final_slate_tier).toBeNull();
+  });
+
+  it("promote assigns final-slate tier and rank through the composer model", async () => {
+    const rows = [
+      createRow({
+        id: "signal-1",
+        editorial_status: "approved",
+        editorial_decision: "approved",
+      }),
+    ];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { assignSignalPostToFinalSlateSlot } = await loadEditorialModule();
+    const result = await assignSignalPostToFinalSlateSlot({
+      postId: "signal-1",
+      finalSlateRank: 1,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(rows[0].final_slate_rank).toBe(1);
+    expect(rows[0].final_slate_tier).toBe("core");
+    expect(rows[0].is_live).toBe(false);
+    expect(rows[0].published_at).toBeNull();
+  });
+
+  it("demote moves a Core row to Context placement without rejecting it", async () => {
+    const rows = [
+      createRow({
+        id: "signal-1",
+        editorial_status: "approved",
+        editorial_decision: "approved",
+        final_slate_rank: 2,
+        final_slate_tier: "core",
+      }),
+    ];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { assignSignalPostToFinalSlateSlot } = await loadEditorialModule();
+    const result = await assignSignalPostToFinalSlateSlot({
+      postId: "signal-1",
+      finalSlateRank: 6,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(rows[0].editorial_decision).toBe("approved");
+    expect(rows[0].final_slate_rank).toBe(6);
+    expect(rows[0].final_slate_tier).toBe("context");
+  });
+
+  it("blocks rejected rows from final-slate assignment", async () => {
+    const rows = [
+      createRow({
+        id: "signal-1",
+        editorial_status: "approved",
+        editorial_decision: "rejected",
+      }),
+    ];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { assignSignalPostToFinalSlateSlot } = await loadEditorialModule();
+    const result = await assignSignalPostToFinalSlateSlot({
+      postId: "signal-1",
+      finalSlateRank: 1,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(rows[0].final_slate_rank).toBeNull();
+    expect(rows[0].final_slate_tier).toBeNull();
+  });
+
+  it("replacement candidate occupies the original slot and stores replacement relationship when valid", async () => {
+    const rows = [
+      createRow({
+        id: "original",
+        rank: 1,
+        editorial_status: "approved",
+        editorial_decision: "approved",
+        final_slate_rank: 1,
+        final_slate_tier: "core",
+      }),
+      createRow({
+        id: "replacement",
+        rank: 8,
+        editorial_status: "approved",
+        editorial_decision: "approved",
+      }),
+    ];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { replaceSignalPostInFinalSlate } = await loadEditorialModule();
+    const result = await replaceSignalPostInFinalSlate({
+      originalPostId: "original",
+      replacementPostId: "replacement",
+      decisionNote: "Stronger source evidence.",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(rows[0].editorial_decision).toBe("held");
+    expect(rows[0].final_slate_rank).toBeNull();
+    expect(rows[1].replacement_of_row_id).toBe("original");
+    expect(rows[1].final_slate_rank).toBe(1);
+    expect(rows[1].final_slate_tier).toBe("core");
+    expect(rows[1].is_live).toBe(false);
+    expect(rows[1].published_at).toBeNull();
+  });
+
+  it("blocks invalid replacement candidates before moving the original slot", async () => {
+    const rows = [
+      createRow({
+        id: "original",
+        editorial_status: "approved",
+        editorial_decision: "approved",
+        final_slate_rank: 1,
+        final_slate_tier: "core",
+      }),
+      createRow({
+        id: "replacement",
+        rank: 8,
+        editorial_status: "approved",
+        editorial_decision: "held",
+      }),
+    ];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { replaceSignalPostInFinalSlate } = await loadEditorialModule();
+    const result = await replaceSignalPostInFinalSlate({
+      originalPostId: "original",
+      replacementPostId: "replacement",
+      decisionNote: "Try invalid replacement.",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(rows[0].editorial_decision).toBe("approved");
+    expect(rows[0].final_slate_rank).toBe(1);
+    expect(rows[1].replacement_of_row_id).toBeNull();
+  });
+
   it("loads published Core and Context rows while excluding parked and non-public rows", async () => {
     const rows = [
       ...Array.from({ length: 7 }, (_, index) =>
@@ -1252,6 +1545,62 @@ describe("signals editorial workflow", () => {
       depthPosts: [],
       briefingDate: null,
     });
+  });
+
+  it("keeps rejected, held, and rewrite-requested rows out of public signal reads", async () => {
+    const rows = [
+      createRow({
+        id: "live-approved",
+        briefing_date: "2026-04-28",
+        rank: 1,
+        editorial_status: "published",
+        editorial_decision: "approved",
+        published_why_it_matters: createValidWhyItMatters("Google"),
+        is_live: true,
+        published_at: "2026-04-28T08:00:00.000Z",
+      }),
+      createRow({
+        id: "live-rejected",
+        briefing_date: "2026-04-28",
+        rank: 2,
+        editorial_status: "published",
+        editorial_decision: "rejected",
+        published_why_it_matters: createValidWhyItMatters("Amazon"),
+        is_live: true,
+        published_at: "2026-04-28T08:01:00.000Z",
+      }),
+      createRow({
+        id: "live-held",
+        briefing_date: "2026-04-28",
+        rank: 3,
+        editorial_status: "published",
+        editorial_decision: "held",
+        published_why_it_matters: createValidWhyItMatters("Microsoft"),
+        is_live: true,
+        published_at: "2026-04-28T08:02:00.000Z",
+      }),
+      createRow({
+        id: "live-rewrite",
+        briefing_date: "2026-04-28",
+        rank: 4,
+        editorial_status: "published",
+        editorial_decision: "rewrite_requested",
+        published_why_it_matters: createValidWhyItMatters("OpenAI"),
+        is_live: true,
+        published_at: "2026-04-28T08:03:00.000Z",
+      }),
+    ];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+
+    const { getPublishedSignalPosts, getHomepageSignalSnapshot } = await loadEditorialModule();
+    const publicSignals = await getPublishedSignalPosts();
+    const homepageSnapshot = await getHomepageSignalSnapshot({
+      today: new Date("2026-04-28T12:00:00.000Z"),
+    });
+
+    expect(publicSignals.map((post) => post.id)).toEqual(["live-approved"]);
+    expect(homepageSnapshot.posts.map((post) => post.id)).toEqual(["live-approved"]);
+    expect(homepageSnapshot.depthPosts.map((post) => post.id)).toEqual(["live-approved"]);
   });
 
   it("uses today's published rows as the homepage Tier 1 signal set", async () => {

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -18,7 +18,7 @@ import {
   isFinalSlateRank,
   type FinalSlateTier,
 } from "@/lib/final-slate-readiness";
-import type { BriefingItem, EditorialStatus } from "@/lib/types";
+import type { BriefingItem, EditorialDecision, EditorialStatus } from "@/lib/types";
 import {
   validateWhyItMatters,
   type WhyItMattersReviewStatus,
@@ -51,6 +51,13 @@ const SIGNAL_POST_REQUIRED_COLUMNS = [
   "editorial_status",
   "final_slate_rank",
   "final_slate_tier",
+  "editorial_decision",
+  "decision_note",
+  "rejected_reason",
+  "held_reason",
+  "replacement_of_row_id",
+  "reviewed_by",
+  "reviewed_at",
   "edited_by",
   "edited_at",
   "approved_by",
@@ -97,6 +104,13 @@ type StoredSignalPost = {
   editorial_status: EditorialStatus;
   final_slate_rank: number | null;
   final_slate_tier: FinalSlateTier | null;
+  editorial_decision: EditorialDecision | null;
+  decision_note: string | null;
+  rejected_reason: string | null;
+  held_reason: string | null;
+  replacement_of_row_id: string | null;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
   edited_by: string | null;
   edited_at: string | null;
   approved_by: string | null;
@@ -130,6 +144,13 @@ export type EditorialSignalPost = {
   editorialStatus: EditorialStatus;
   finalSlateRank: number | null;
   finalSlateTier: FinalSlateTier | null;
+  editorialDecision: EditorialDecision | null;
+  decisionNote: string | null;
+  rejectedReason: string | null;
+  heldReason: string | null;
+  replacementOfRowId: string | null;
+  reviewedBy: string | null;
+  reviewedAt: string | null;
   editedBy: string | null;
   editedAt: string | null;
   approvedBy: string | null;
@@ -185,6 +206,7 @@ export type EditorialMutationResult = {
   code:
     | "approved"
     | "bulk_approved"
+    | "decision_updated"
     | "draft_saved"
     | "empty_editorial_text"
     | "not_admin"
@@ -193,6 +215,7 @@ export type EditorialMutationResult = {
     | "published"
     | "publish_blocked"
     | "reset"
+    | "replacement_updated"
     | "slate_updated"
     | "storage_unavailable"
     | "storage_error";
@@ -324,6 +347,23 @@ function normalizeSearchQuery(value: string | null | undefined) {
   return value?.trim() ?? "";
 }
 
+function normalizeDecisionNote(value: string | null | undefined) {
+  return value?.trim() ?? "";
+}
+
+function isBlockingEditorialDecision(value: EditorialDecision | string | null | undefined) {
+  return (
+    value === "rejected" ||
+    value === "held" ||
+    value === "rewrite_requested" ||
+    value === "removed_from_slate"
+  );
+}
+
+function isPubliclyAllowedEditorialDecision(value: EditorialDecision | string | null | undefined) {
+  return value === null || value === undefined || value === "approved" || value === "draft_edited";
+}
+
 function normalizePageNumber(page?: number) {
   return Number.isFinite(page) && page && page > 0 ? Math.floor(page) : 1;
 }
@@ -377,6 +417,13 @@ function mapStoredSignalPost(row: StoredSignalPost): EditorialSignalPost {
     editorialStatus: row.editorial_status,
     finalSlateRank: row.final_slate_rank,
     finalSlateTier: row.final_slate_tier,
+    editorialDecision: row.editorial_decision,
+    decisionNote: row.decision_note,
+    rejectedReason: row.rejected_reason,
+    heldReason: row.held_reason,
+    replacementOfRowId: row.replacement_of_row_id,
+    reviewedBy: row.reviewed_by,
+    reviewedAt: row.reviewed_at,
     editedBy: row.edited_by,
     editedAt: row.edited_at,
     approvedBy: row.approved_by,
@@ -425,6 +472,13 @@ function mapBriefingItemToSignalPost(item: BriefingItem, index: number): Editori
     editorialStatus: "needs_review",
     finalSlateRank: null,
     finalSlateTier: null,
+    editorialDecision: "pending_review",
+    decisionNote: null,
+    rejectedReason: null,
+    heldReason: null,
+    replacementOfRowId: null,
+    reviewedBy: null,
+    reviewedAt: null,
     editedBy: null,
     editedAt: null,
     approvedBy: null,
@@ -696,6 +750,13 @@ async function persistSignalPostCandidates(
       editorial_status: "needs_review",
       final_slate_rank: null,
       final_slate_tier: null,
+      editorial_decision: "pending_review",
+      decision_note: null,
+      rejected_reason: null,
+      held_reason: null,
+      replacement_of_row_id: null,
+      reviewed_by: null,
+      reviewed_at: null,
       published_at: null,
       is_live: false,
       created_at: now,
@@ -832,6 +893,10 @@ async function loadCurrentSignalDepth(client: EditorialClient, briefingDate: str
 
 function selectPublishedEditorialWhyItMatters(post: EditorialSignalPost) {
   if (post.editorialStatus !== "published") {
+    return "";
+  }
+
+  if (!isPubliclyAllowedEditorialDecision(post.editorialDecision)) {
     return "";
   }
 
@@ -1137,7 +1202,7 @@ export async function saveSignalDraft(input: {
   const now = new Date().toISOString();
   const lookup = await context.client
     .from("signal_posts")
-    .select("id, editorial_status")
+    .select("id, editorial_status, editorial_decision")
     .eq("id", input.postId)
     .maybeSingle();
 
@@ -1187,6 +1252,7 @@ export async function saveSignalDraft(input: {
           }
         : {}),
       editorial_status: nextEditorialStatus,
+      editorial_decision: validation.passed ? (nextEditorialStatus === "approved" ? "approved" : "draft_edited") : "rewrite_requested",
       ...buildWhyItMattersValidationFields(validation, now),
       edited_by: context.user.email ?? null,
       edited_at: now,
@@ -1245,6 +1311,7 @@ async function approveSignalPostWithContext(
         edited_why_it_matters: editorialText,
         edited_why_it_matters_payload: structuredContent,
         editorial_status: "needs_review",
+        editorial_decision: "rewrite_requested",
         ...buildWhyItMattersValidationFields(validation, now),
         edited_by: context.user.email ?? null,
         edited_at: now,
@@ -1273,7 +1340,13 @@ async function approveSignalPostWithContext(
       edited_why_it_matters: editorialText,
       edited_why_it_matters_payload: structuredContent,
       editorial_status: "approved",
+      editorial_decision: "approved",
+      decision_note: null,
+      rejected_reason: null,
+      held_reason: null,
       ...buildWhyItMattersValidationFields(validation, now),
+      reviewed_by: context.user.email ?? null,
+      reviewed_at: now,
       edited_by: context.user.email ?? null,
       edited_at: now,
       approved_by: context.user.email ?? null,
@@ -1357,7 +1430,7 @@ export async function approveSignalPosts(input: {
 
   const eligibilityLookup = await context.client
     .from("signal_posts")
-    .select("id, editorial_status")
+    .select("id, editorial_status, editorial_decision")
     .in("id", uniquePosts.map((post) => post.postId));
 
   if (eligibilityLookup.error) {
@@ -1369,8 +1442,12 @@ export async function approveSignalPosts(input: {
   }
 
   const eligibleIds = new Set(
-    (((eligibilityLookup.data ?? []) as Array<Pick<StoredSignalPost, "id" | "editorial_status">>))
-      .filter((post) => post.editorial_status === "draft" || post.editorial_status === "needs_review")
+    (((eligibilityLookup.data ?? []) as Array<Pick<StoredSignalPost, "id" | "editorial_status" | "editorial_decision">>))
+      .filter(
+        (post) =>
+          (post.editorial_status === "draft" || post.editorial_status === "needs_review") &&
+          !isBlockingEditorialDecision(post.editorial_decision),
+      )
       .map((post) => post.id),
   );
   const eligiblePosts = uniquePosts.filter((post) => eligibleIds.has(post.postId));
@@ -1379,7 +1456,7 @@ export async function approveSignalPosts(input: {
     return {
       ok: false,
       code: "publish_blocked",
-      message: "There are no Draft or Needs Review signal posts to approve.",
+      message: "There are no Draft or Needs Review signal posts without blocking editorial decisions to approve.",
     };
   }
 
@@ -1453,6 +1530,7 @@ export async function resetSignalPostToAiDraft(input: {
       edited_why_it_matters: aiDraft,
       edited_why_it_matters_payload: null,
       editorial_status: validation.passed ? "draft" : "needs_review",
+      editorial_decision: validation.passed ? "pending_review" : "rewrite_requested",
       ...buildWhyItMattersValidationFields(validation, now),
       edited_by: context.user.email ?? null,
       edited_at: now,
@@ -1472,6 +1550,248 @@ export async function resetSignalPostToAiDraft(input: {
     ok: true,
     code: "reset",
     message: "Editorial text reset to the AI draft.",
+  };
+}
+
+async function loadDecisionTarget(
+  context: {
+    client: EditorialClient;
+    user: User;
+  },
+  postId: string,
+) {
+  const lookup = await context.client
+    .from("signal_posts")
+    .select("id, briefing_date, editorial_status, editorial_decision, final_slate_rank, final_slate_tier, is_live, published_at")
+    .eq("id", postId)
+    .maybeSingle();
+
+  if (lookup.error || !lookup.data) {
+    return {
+      ok: false as const,
+      code: "not_found" as const,
+      message: "The signal post could not be found.",
+    };
+  }
+
+  const post = lookup.data as Pick<
+    StoredSignalPost,
+    | "id"
+    | "briefing_date"
+    | "editorial_status"
+    | "editorial_decision"
+    | "final_slate_rank"
+    | "final_slate_tier"
+    | "is_live"
+    | "published_at"
+  >;
+
+  return {
+    ok: true as const,
+    post,
+  };
+}
+
+function blockPublishedDecisionTarget(
+  post: Pick<StoredSignalPost, "editorial_status" | "is_live" | "published_at">,
+) {
+  return Boolean(post.is_live || post.editorial_status === "published" || post.published_at);
+}
+
+export async function requestSignalPostRewrite(input: {
+  postId: string;
+  decisionNote?: string | null;
+  route?: string;
+}): Promise<EditorialMutationResult> {
+  const context = await getAdminEditorialContext(input.route ?? SIGNALS_EDITORIAL_ROUTE);
+
+  if (!context.ok) {
+    return {
+      ok: false,
+      code: context.code,
+      message: context.message,
+    };
+  }
+
+  const target = await loadDecisionTarget(context, input.postId);
+
+  if (!target.ok) {
+    return target;
+  }
+
+  if (blockPublishedDecisionTarget(target.post)) {
+    return {
+      ok: false,
+      code: "publish_blocked",
+      message: "Live or already published rows cannot be marked for rewrite in this non-publish phase.",
+    };
+  }
+
+  const now = new Date().toISOString();
+  const updateResult = await context.client
+    .from("signal_posts")
+    .update({
+      editorial_status: "needs_review",
+      editorial_decision: "rewrite_requested",
+      decision_note: normalizeDecisionNote(input.decisionNote) || null,
+      final_slate_rank: null,
+      final_slate_tier: null,
+      reviewed_by: context.user.email ?? null,
+      reviewed_at: now,
+      updated_at: now,
+    })
+    .eq("id", input.postId);
+
+  if (updateResult.error) {
+    return {
+      ok: false,
+      code: "storage_error",
+      message: "The signal post could not be marked for rewrite.",
+    };
+  }
+
+  return {
+    ok: true,
+    code: "decision_updated",
+    message: "Requested rewrite and removed the row from the draft final slate.",
+  };
+}
+
+export async function rejectSignalPost(input: {
+  postId: string;
+  decisionNote?: string | null;
+  route?: string;
+}): Promise<EditorialMutationResult> {
+  const context = await getAdminEditorialContext(input.route ?? SIGNALS_EDITORIAL_ROUTE);
+
+  if (!context.ok) {
+    return {
+      ok: false,
+      code: context.code,
+      message: context.message,
+    };
+  }
+
+  const note = normalizeDecisionNote(input.decisionNote);
+
+  if (!note) {
+    return {
+      ok: false,
+      code: "publish_blocked",
+      message: "Add a rejection reason before rejecting this row.",
+    };
+  }
+
+  const target = await loadDecisionTarget(context, input.postId);
+
+  if (!target.ok) {
+    return target;
+  }
+
+  if (blockPublishedDecisionTarget(target.post)) {
+    return {
+      ok: false,
+      code: "publish_blocked",
+      message: "Live or already published rows cannot be rejected in this non-publish phase.",
+    };
+  }
+
+  const now = new Date().toISOString();
+  const updateResult = await context.client
+    .from("signal_posts")
+    .update({
+      editorial_decision: "rejected",
+      decision_note: note,
+      rejected_reason: note,
+      final_slate_rank: null,
+      final_slate_tier: null,
+      reviewed_by: context.user.email ?? null,
+      reviewed_at: now,
+      updated_at: now,
+    })
+    .eq("id", input.postId);
+
+  if (updateResult.error) {
+    return {
+      ok: false,
+      code: "storage_error",
+      message: "The signal post could not be rejected.",
+    };
+  }
+
+  return {
+    ok: true,
+    code: "decision_updated",
+    message: "Rejected row and removed it from the draft final slate.",
+  };
+}
+
+export async function holdSignalPost(input: {
+  postId: string;
+  decisionNote?: string | null;
+  route?: string;
+}): Promise<EditorialMutationResult> {
+  const context = await getAdminEditorialContext(input.route ?? SIGNALS_EDITORIAL_ROUTE);
+
+  if (!context.ok) {
+    return {
+      ok: false,
+      code: context.code,
+      message: context.message,
+    };
+  }
+
+  const note = normalizeDecisionNote(input.decisionNote);
+
+  if (!note) {
+    return {
+      ok: false,
+      code: "publish_blocked",
+      message: "Add a hold reason before holding this row.",
+    };
+  }
+
+  const target = await loadDecisionTarget(context, input.postId);
+
+  if (!target.ok) {
+    return target;
+  }
+
+  if (blockPublishedDecisionTarget(target.post)) {
+    return {
+      ok: false,
+      code: "publish_blocked",
+      message: "Live or already published rows cannot be held in this non-publish phase.",
+    };
+  }
+
+  const now = new Date().toISOString();
+  const updateResult = await context.client
+    .from("signal_posts")
+    .update({
+      editorial_decision: "held",
+      decision_note: note,
+      held_reason: note,
+      final_slate_rank: null,
+      final_slate_tier: null,
+      reviewed_by: context.user.email ?? null,
+      reviewed_at: now,
+      updated_at: now,
+    })
+    .eq("id", input.postId);
+
+  if (updateResult.error) {
+    return {
+      ok: false,
+      code: "storage_error",
+      message: "The signal post could not be held.",
+    };
+  }
+
+  return {
+    ok: true,
+    code: "decision_updated",
+    message: "Held row as editorial evidence and removed it from the draft final slate.",
   };
 }
 
@@ -1510,7 +1830,7 @@ export async function assignSignalPostToFinalSlateSlot(input: {
 
   const lookup = await context.client
     .from("signal_posts")
-    .select("id, briefing_date, editorial_status, is_live, published_at")
+    .select("id, briefing_date, editorial_status, editorial_decision, is_live, published_at")
     .eq("id", input.postId)
     .maybeSingle();
 
@@ -1524,7 +1844,7 @@ export async function assignSignalPostToFinalSlateSlot(input: {
 
   const post = lookup.data as Pick<
     StoredSignalPost,
-    "id" | "briefing_date" | "editorial_status" | "is_live" | "published_at"
+    "id" | "briefing_date" | "editorial_status" | "editorial_decision" | "is_live" | "published_at"
   >;
   const briefingDate = normalizeDateValue(post.briefing_date);
 
@@ -1541,6 +1861,14 @@ export async function assignSignalPostToFinalSlateSlot(input: {
       ok: false,
       code: "publish_blocked",
       message: "Live or already published rows cannot be assigned to the draft final slate.",
+    };
+  }
+
+  if (isBlockingEditorialDecision(post.editorial_decision)) {
+    return {
+      ok: false,
+      code: "publish_blocked",
+      message: "Rejected, held, rewrite-requested, or removed rows cannot be assigned to the final slate.",
     };
   }
 
@@ -1636,6 +1964,170 @@ export async function removeSignalPostFromFinalSlate(input: {
   };
 }
 
+export async function replaceSignalPostInFinalSlate(input: {
+  originalPostId: string;
+  replacementPostId: string;
+  decisionNote?: string | null;
+  route?: string;
+}): Promise<EditorialMutationResult> {
+  const context = await getAdminEditorialContext(input.route ?? SIGNALS_EDITORIAL_ROUTE);
+
+  if (!context.ok) {
+    return {
+      ok: false,
+      code: context.code,
+      message: context.message,
+    };
+  }
+
+  if (input.originalPostId === input.replacementPostId) {
+    return {
+      ok: false,
+      code: "publish_blocked",
+      message: "Choose a different row as the replacement.",
+    };
+  }
+
+  const note = normalizeDecisionNote(input.decisionNote);
+
+  if (!note) {
+    return {
+      ok: false,
+      code: "publish_blocked",
+      message: "Add a replacement reason before replacing this row.",
+    };
+  }
+
+  const schemaPreflight = await getSignalPostsSchemaPreflight(context.client);
+
+  if (!schemaPreflight.ok) {
+    return {
+      ok: false,
+      code: "storage_unavailable",
+      message: schemaPreflight.message,
+    };
+  }
+
+  const [originalTarget, replacementTarget] = await Promise.all([
+    loadDecisionTarget(context, input.originalPostId),
+    loadDecisionTarget(context, input.replacementPostId),
+  ]);
+
+  if (!originalTarget.ok) {
+    return originalTarget;
+  }
+
+  if (!replacementTarget.ok) {
+    return replacementTarget;
+  }
+
+  const original = originalTarget.post;
+  const replacement = replacementTarget.post;
+  const originalRank = original.final_slate_rank;
+
+  if (!isFinalSlateRank(originalRank)) {
+    return {
+      ok: false,
+      code: "publish_blocked",
+      message: "The original row must occupy a Core or Context slot before it can be replaced.",
+    };
+  }
+
+  const briefingDate = normalizeDateValue(original.briefing_date);
+
+  if (!briefingDate || normalizeDateValue(replacement.briefing_date) !== briefingDate) {
+    return {
+      ok: false,
+      code: "publish_blocked",
+      message: "Replacement candidates must belong to the same briefing date.",
+    };
+  }
+
+  if (blockPublishedDecisionTarget(original) || blockPublishedDecisionTarget(replacement)) {
+    return {
+      ok: false,
+      code: "publish_blocked",
+      message: "Live or already published rows cannot participate in replacement.",
+    };
+  }
+
+  if (isBlockingEditorialDecision(replacement.editorial_decision)) {
+    return {
+      ok: false,
+      code: "publish_blocked",
+      message: "Rejected, held, rewrite-requested, or removed rows cannot be used as replacements.",
+    };
+  }
+
+  const finalSlateTier = getFinalSlateTierForRank(originalRank);
+  const now = new Date().toISOString();
+  const holdOriginal = await context.client
+    .from("signal_posts")
+    .update({
+      editorial_decision: "held",
+      decision_note: note,
+      held_reason: note,
+      final_slate_rank: null,
+      final_slate_tier: null,
+      reviewed_by: context.user.email ?? null,
+      reviewed_at: now,
+      updated_at: now,
+    })
+    .eq("id", input.originalPostId);
+
+  if (holdOriginal.error) {
+    return {
+      ok: false,
+      code: "storage_error",
+      message: "The original row could not be held before replacement.",
+    };
+  }
+
+  const clearSlotResult = await context.client
+    .from("signal_posts")
+    .update({
+      final_slate_rank: null,
+      final_slate_tier: null,
+      updated_at: now,
+    })
+    .eq("briefing_date", briefingDate)
+    .eq("final_slate_rank", originalRank);
+
+  if (clearSlotResult.error) {
+    return {
+      ok: false,
+      code: "storage_error",
+      message: "The existing final-slate slot could not be cleared for replacement.",
+    };
+  }
+
+  const assignReplacement = await context.client
+    .from("signal_posts")
+    .update({
+      final_slate_rank: originalRank,
+      final_slate_tier: finalSlateTier,
+      replacement_of_row_id: input.originalPostId,
+      reviewed_by: context.user.email ?? null,
+      reviewed_at: now,
+      updated_at: now,
+    })
+    .eq("id", input.replacementPostId);
+
+  if (assignReplacement.error) {
+    return {
+      ok: false,
+      code: "storage_error",
+      message: "The replacement row could not be assigned to the final slate.",
+    };
+  }
+
+  return {
+    ok: true,
+    code: "replacement_updated",
+    message: `Held original row and assigned replacement to ${finalSlateTier === "core" ? "Core" : "Context"} slot ${originalRank}.`,
+  };
+}
+
 export async function publishApprovedSignals(input: {
   route?: string;
 } = {}): Promise<EditorialMutationResult> {
@@ -1680,14 +2172,16 @@ export async function publishApprovedSignals(input: {
   }
 
   const notReadyToPublish = topFivePosts.filter(
-    (post) => post.editorialStatus !== "approved" && post.editorialStatus !== "published",
+    (post) =>
+      (post.editorialStatus !== "approved" && post.editorialStatus !== "published") ||
+      isBlockingEditorialDecision(post.editorialDecision),
   );
 
   if (notReadyToPublish.length > 0) {
     return {
       ok: false,
       code: "publish_blocked",
-      message: "Approve all five signal posts before publishing. Already published posts remain publish-ready.",
+      message: "Approve all five signal posts and clear rejected, held, or rewrite-requested decisions before publishing.",
     };
   }
 
@@ -1788,6 +2282,7 @@ export async function publishApprovedSignals(input: {
           published_why_it_matters: text,
           published_why_it_matters_payload: structuredContent,
           editorial_status: "published",
+          editorial_decision: "approved",
           ...buildWhyItMattersValidationFields(validation, now),
           is_live: true,
           published_at: now,
@@ -1851,6 +2346,7 @@ export async function publishApprovedSignals(input: {
           published_why_it_matters: depthText,
           published_why_it_matters_payload: structuredContent,
           editorial_status: "published",
+          editorial_decision: "approved",
           ...buildWhyItMattersValidationFields(validation, now),
           is_live: true,
           published_at: now,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -102,6 +102,14 @@ export type EventIntelligence = {
 
 export type EventDisplayState = "new" | "changed" | "escalated" | "unchanged";
 export type EditorialStatus = "draft" | "needs_review" | "approved" | "published";
+export type EditorialDecision =
+  | "pending_review"
+  | "draft_edited"
+  | "approved"
+  | "rewrite_requested"
+  | "rejected"
+  | "held"
+  | "removed_from_slate";
 export type SignalSelectionEligibilityTier =
   | "core_signal_eligible"
   | "context_signal_eligible"

--- a/supabase/migrations/20260430110000_signal_posts_editorial_card_controls.sql
+++ b/supabase/migrations/20260430110000_signal_posts_editorial_card_controls.sql
@@ -1,0 +1,31 @@
+alter table public.signal_posts
+  add column if not exists editorial_decision text,
+  add column if not exists decision_note text,
+  add column if not exists rejected_reason text,
+  add column if not exists held_reason text,
+  add column if not exists replacement_of_row_id uuid,
+  add column if not exists reviewed_by text,
+  add column if not exists reviewed_at timestamptz;
+
+alter table public.signal_posts
+  drop constraint if exists signal_posts_editorial_decision_check,
+  drop constraint if exists signal_posts_replacement_of_row_id_fkey;
+
+alter table public.signal_posts
+  add constraint signal_posts_editorial_decision_check
+    check (
+      editorial_decision is null
+      or editorial_decision in (
+        'pending_review',
+        'draft_edited',
+        'approved',
+        'rewrite_requested',
+        'rejected',
+        'held',
+        'removed_from_slate'
+      )
+    ),
+  add constraint signal_posts_replacement_of_row_id_fkey
+    foreign key (replacement_of_row_id)
+    references public.signal_posts(id)
+    on delete set null;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -149,6 +149,25 @@ create table if not exists public.signal_posts (
     check (final_slate_rank is null or final_slate_rank between 1 and 7),
   final_slate_tier text
     check (final_slate_tier is null or final_slate_tier in ('core', 'context')),
+  editorial_decision text
+    check (
+      editorial_decision is null
+      or editorial_decision in (
+        'pending_review',
+        'draft_edited',
+        'approved',
+        'rewrite_requested',
+        'rejected',
+        'held',
+        'removed_from_slate'
+      )
+    ),
+  decision_note text,
+  rejected_reason text,
+  held_reason text,
+  replacement_of_row_id uuid references public.signal_posts(id) on delete set null,
+  reviewed_by text,
+  reviewed_at timestamptz,
   edited_by text,
   edited_at timestamptz,
   approved_by text,


### PR DESCRIPTION
## Summary

Implements the next scoped PRD-53 feature step after the merged minimal final-slate composer: card-level editorial controls for the Signals admin workflow.

## Effective change type

Feature implementation under the approved PRD-53 amendment.

## Source of truth

- `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
- Canonical PRD coverage was satisfied by merged PR #149.
- Minimal final-slate composer was implemented by merged PR #150.
- No duplicate PRD was created.

## What changed

- Added additive nullable `signal_posts` editorial decision fields for card-level authority:
  - `editorial_decision`
  - `decision_note`
  - `rejected_reason`
  - `held_reason`
  - `replacement_of_row_id`
  - `reviewed_by`
  - `reviewed_at`
- Added admin controls for request rewrite, reject, hold, replacement, promote/move to Core, move to Context, reorder, demote, and remove from slate.
- Extended replacement handling so an existing non-live candidate can occupy the original slot while the original is held.
- Updated final-slate readiness validation for rejected, held, rewrite-requested, removed, and non-approved decision states.
- Added admin badges and disabled-state reasons for editorial decisions, WITM state, placement, live, published, and replacement state.
- Added public-read safety filtering so rows with blocking editorial decisions do not appear publicly.
- Added focused tests for validator behavior, server actions, replacement, public visibility, and admin page controls.
- Added repo-safe PRD checkpoint, change record, and tracker-sync fallback.

## What did not change

- No final publish workflow.
- No cron run.
- No pipeline run.
- No `dry_run`.
- No `draft_only`.
- No production DB mutation.
- No source governance changes.
- No ranking threshold changes.
- No WITM threshold changes.
- No public URL/domain/env/Vercel changes.
- No historical snapshot/schema implementation.

## Validation

Passed:

- `npm install`
- `git diff --check`
- `npm run lint`
- `npm run test -- src/lib/final-slate-readiness.test.ts src/lib/signals-editorial.test.ts src/app/dashboard/signals/editorial-review/page.test.tsx`
- `npm run test` — 73 files, 558 tests passed
- `npm run build`
- `python3 scripts/validate-feature-system-csv.py` — passed with pre-existing slug warnings only
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-editorial-card-controls --pr-title "PRD-53 editorial card controls"`
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-editorial-card-controls --pr-title "PRD-53 editorial card controls"`
- `npm run test:e2e:chromium` — 33 passed
- `npm run test:e2e:webkit` — 33 passed

Notes:

- Local dev server used for Playwright: `http://localhost:3000`.
- Build emitted existing workspace-root / module-type warnings; build completed successfully.
- `npm install` reported 2 audit vulnerabilities. No audit fix was run because that is outside this PR scope.

## Risks / follow-up

- 7-row publish workflow hardening remains next.
- Minimal audit/history remains later.
- Second controlled cycle remains after publish workflow.
- Measurement instrumentation remains later.
- Cron remains last.

## Readiness label

`ready_for_prd_53_editorial_card_controls_review`