### PR TITLE
PRD-53 seven-row publish hardening

### DIFF
--- a/docs/engineering/SIGNAL_POSTS_OPERATIONAL_CONTRACT.md
+++ b/docs/engineering/SIGNAL_POSTS_OPERATIONAL_CONTRACT.md
@@ -41,7 +41,7 @@ The current table is not allowed to serve these purposes:
 
 - `src/lib/signals-editorial.ts`
   - `persistSignalPostsForBriefing()` writes daily placement/card candidates.
-  - `publishApprovedSignals()` publishes approved placement/card rows.
+  - `publishApprovedSignals()` publishes the validated `5 Core + 2 Context` final Surface Placement slate.
   - `getPublishedSignalPosts()` reads public `/signals` card rows.
   - `getHomepageSignalSnapshot()` reads homepage placement/card snapshots.
 - `src/lib/data.ts`

--- a/docs/engineering/change-records/prd-53-seven-row-publish-hardening.md
+++ b/docs/engineering/change-records/prd-53-seven-row-publish-hardening.md
@@ -1,0 +1,54 @@
+# PRD-53 Seven-Row Publish Hardening
+
+Date: 2026-04-30
+Branch: `codex/prd-53-seven-row-publish-hardening`
+Readiness label: `ready_for_prd_53_seven_row_publish_hardening_review`
+
+## Source of truth
+
+- `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+- `docs/engineering/change-records/prd-53-minimal-final-slate-composer.md`
+- `docs/engineering/change-records/prd-53-editorial-card-controls.md`
+
+## Summary
+
+This change hardens the PRD-53 admin publish workflow so the existing editorial review surface can publish exactly the validated `5 Core + 2 Context` final slate.
+
+The implementation updates the existing publish path instead of adding a parallel workflow:
+
+- runs the final-slate readiness validator immediately before writes
+- blocks invalid slates without modifying rows
+- archives the existing live rows by setting `is_live = false`
+- publishes exactly seven selected final-slate rows
+- sets selected rows to `is_live = true`, `editorial_status = 'published'`, and `published_at`
+- keeps rank-8, held, rejected, rewrite-requested, removed, Depth/unpromoted, candidate, and non-selected rows hidden
+- keeps public reads gated by `is_live = true`, `editorial_status = 'published'`, and `published_at IS NOT NULL`
+- uses `final_slate_rank` for public Core/Context ordering when present, with legacy `rank` as a fallback for older published rows
+
+## Atomicity note
+
+The current Supabase client path does not expose a repository transaction helper for this publish operation. The implementation validates all publishability conditions before writes, limits writes to previous live rows and selected final-slate rows, and performs best-effort restoration if selected-row publication fails after archiving.
+
+Full transaction-backed publish batches and durable rollback history remain out of scope for this PR and belong to the next audit/history phase.
+
+## Rollback preparation
+
+If post-publish verification fails:
+
+1. Identify the newly live seven final-slate rows.
+2. Set those rows `is_live = false`.
+3. Restore the archived previous live rows to `is_live = true`.
+4. Preserve row data for diagnosis.
+5. Verify `/` and `/signals` again.
+
+This PR does not implement a rollback execution system or publish batch history.
+
+## Non-actions
+
+- No production publish was performed.
+- No cron change was made.
+- No `dry_run`, `draft_only`, or pipeline write-mode run was performed.
+- No production database rows were mutated.
+- No source governance, source list, ranking threshold, or WITM threshold changed.
+- No full historical snapshot/schema layer was implemented.
+- No Phase 2 architecture or personalization work was started.

--- a/docs/operations/tracker-sync/2026-04-30-prd-53-seven-row-publish-hardening.md
+++ b/docs/operations/tracker-sync/2026-04-30-prd-53-seven-row-publish-hardening.md
@@ -1,0 +1,43 @@
+# Tracker Sync Fallback - PRD-53 Seven-Row Publish Hardening
+
+Date: 2026-04-30
+Branch: `codex/prd-53-seven-row-publish-hardening`
+PRD: `PRD-53`
+Canonical PRD file: `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+Readiness label: `ready_for_prd_53_seven_row_publish_hardening_review`
+
+## Manual tracker update payload
+
+Use this fallback if live Google Sheets tracker access is unavailable.
+
+| Field | Value |
+| --- | --- |
+| `prd_id` | `PRD-53` |
+| `PRD File` | `docs/product/prd/prd-53-signals-admin-editorial-layer.md` |
+| `Status` | `In Review` |
+| `Decision` | `build` |
+| `Owner` | `Codex` |
+| `Last Updated` | `2026-04-30` |
+| `Notes` | Supported seven-row admin publish workflow hardening implemented for the validated 5 Core + 2 Context final slate. No production publish, cron, pipeline run, or production database mutation performed. |
+
+## Scope completed
+
+- Supported admin publish action validates the current final slate immediately before writes.
+- Invalid slates fail closed with no row mutation.
+- Previous live rows are archived before successful final-slate publication.
+- Exactly seven selected final-slate rows become live published rows.
+- Public reads remain gated by `is_live = true`, `editorial_status = 'published'`, and `published_at IS NOT NULL`.
+- Public ordering uses `final_slate_rank` where available while keeping rank fallback for older published rows.
+- Admin composer publish button now enables only when readiness passes and displays verification/rollback preparation copy.
+
+## Explicit non-actions
+
+- No production publish.
+- No cron.
+- No `dry_run`.
+- No `draft_only`.
+- No pipeline write-mode.
+- No production database mutation.
+- No source governance, ranking threshold, or WITM threshold change.
+- No full historical snapshot/schema layer.
+- No automatic public publishing.

--- a/docs/product/prd/prd-53-signals-admin-editorial-layer.md
+++ b/docs/product/prd/prd-53-signals-admin-editorial-layer.md
@@ -9,6 +9,8 @@
 - 2026-04-30 readiness label: `ready_for_prd_53_minimal_final_slate_composer_review`
 - 2026-04-30 implementation checkpoint: editorial card controls in review
 - 2026-04-30 readiness label: `ready_for_prd_53_editorial_card_controls_review`
+- 2026-04-30 implementation checkpoint: seven-row publish workflow hardening in review
+- 2026-04-30 readiness label: `ready_for_prd_53_seven_row_publish_hardening_review`
 
 ## Objective
 

--- a/src/app/dashboard/signals/editorial-review/actions.ts
+++ b/src/app/dashboard/signals/editorial-review/actions.ts
@@ -175,7 +175,7 @@ export async function holdSignalPostAction(formData: FormData) {
   redirectWithResult(result);
 }
 
-export async function publishTopSignalsAction() {
+async function runPublishFinalSlateAction() {
   const result = await publishApprovedSignals();
 
   if (result.ok) {
@@ -183,6 +183,14 @@ export async function publishTopSignalsAction() {
   }
 
   redirectWithResult(result);
+}
+
+export async function publishFinalSlateAction() {
+  await runPublishFinalSlateAction();
+}
+
+export async function publishTopSignalsAction() {
+  await runPublishFinalSlateAction();
 }
 
 export async function publishSignalPostAction(formData: FormData) {

--- a/src/app/dashboard/signals/editorial-review/page.test.tsx
+++ b/src/app/dashboard/signals/editorial-review/page.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@/app/dashboard/signals/editorial-review/actions", () => ({
   saveSignalDraftAction: vi.fn(),
   approveSignalPostAction: vi.fn(),
   resetSignalPostToAiDraftAction: vi.fn(),
+  publishFinalSlateAction: vi.fn(),
   publishTopSignalsAction: vi.fn(),
   publishSignalPostAction: vi.fn(),
   assignFinalSlateSlotAction: vi.fn(),
@@ -173,6 +174,37 @@ describe("signals editorial review page", () => {
     expect(screen.getAllByRole("button", { name: "Publish Final Slate" })[0]).toBeDisabled();
     expect(screen.getByText("Slate not ready")).toBeInTheDocument();
     expect(screen.getAllByText(/Final slate requires exactly 7 selected rows/i)[0]).toBeInTheDocument();
+  });
+
+  it("enables final-slate publish only after the 5 Core + 2 Context slate is ready", async () => {
+    const readySlate = Array.from({ length: 7 }, (_, index) => {
+      const slot = index + 1;
+
+      return {
+        ...approvedPost,
+        id: `ready-${slot}`,
+        rank: slot === 5 ? 8 : slot,
+        title: `Ready Signal ${slot}`,
+        editorialDecision: "approved" as const,
+        finalSlateRank: slot,
+        finalSlateTier: slot <= 5 ? ("core" as const) : ("context" as const),
+        editedWhyItMatters:
+          "This structurally changes how markets price cloud capacity, AI infrastructure, and platform dependency over the next year.",
+      };
+    });
+    getEditorialReviewState.mockResolvedValue({
+      ...createAuthorizedState(readySlate),
+    });
+
+    const Page = (await import("@/app/dashboard/signals/editorial-review/page")).default;
+    render(await Page({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByText("Slate ready")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Publish Final Slate" }).every((button) => !button.hasAttribute("disabled")))
+      .toBe(true);
+    expect(screen.getAllByText("Ready to publish the validated 5 Core + 2 Context slate.")[0]).toBeInTheDocument();
+    expect(screen.getByText("Post-publish verification")).toBeInTheDocument();
+    expect(screen.getByText("Rollback preparation")).toBeInTheDocument();
   });
 
   it("collapses each editorial panel by default and expands only the selected card", async () => {

--- a/src/app/dashboard/signals/editorial-review/page.tsx
+++ b/src/app/dashboard/signals/editorial-review/page.tsx
@@ -10,6 +10,7 @@ import {
 import {
   assignFinalSlateSlotAction,
   approveAllSignalPostsAction,
+  publishFinalSlateAction,
   removeFromFinalSlateAction,
   replaceFinalSlateSlotAction,
 } from "@/app/dashboard/signals/editorial-review/actions";
@@ -158,16 +159,18 @@ export default async function SignalsEditorialReviewPage({ searchParams }: PageP
                 ) : null}
               </form>
               <div className="space-y-2">
-                <Button
-                  type="button"
-                  disabled
-                  className="w-full gap-2"
-                >
-                  <Send className="h-4 w-4" />
-                  Publish Final Slate
-                </Button>
+                <form action={publishFinalSlateAction}>
+                  <Button
+                    type="submit"
+                    disabled={Boolean(publishDisabledReason)}
+                    className="w-full gap-2"
+                  >
+                    <Send className="h-4 w-4" />
+                    Publish Final Slate
+                  </Button>
+                </form>
                 <p className="text-sm leading-6 text-[var(--text-secondary)]">
-                  {publishDisabledReason}
+                  {publishDisabledReason ?? getReadyToPublishMessage()}
                 </p>
               </div>
             </div>
@@ -374,12 +377,17 @@ function FinalSlateComposer({
                 Publish Readiness
               </h3>
             </div>
-            <Button type="button" disabled className="w-full gap-2">
-              <Send className="h-4 w-4" />
-              Publish Final Slate
-            </Button>
+            <form action={publishFinalSlateAction}>
+              <Button type="submit" disabled={Boolean(publishDisabledReason)} className="w-full gap-2">
+                <Send className="h-4 w-4" />
+                Publish Final Slate
+              </Button>
+            </form>
             <p className="text-sm leading-6 text-[var(--text-secondary)]">
-              {publishDisabledReason}
+              {publishDisabledReason ?? getReadyToPublishMessage()}
+            </p>
+            <p className="text-sm leading-6 text-[var(--text-secondary)]">
+              Publishing archives the previous live slate and makes only these seven selected rows public.
             </p>
             {readiness.failures.length > 0 ? (
               <ul className="space-y-1 text-sm leading-6 text-[var(--text-secondary)]">
@@ -390,6 +398,25 @@ function FinalSlateComposer({
                 ))}
               </ul>
             ) : null}
+            <div className="space-y-2 border-t border-[var(--border)] pt-3">
+              <h4 className="text-sm font-semibold text-[var(--text-primary)]">
+                Post-publish verification
+              </h4>
+              <ul className="space-y-1 text-xs leading-5 text-[var(--text-secondary)]">
+                <li>Homepage returns 200 and shows Core slots 1-5.</li>
+                <li>/signals returns 200 and shows Core slots 1-5 plus Context slots 6-7.</li>
+                <li>Held, rejected, rewrite-requested, Depth, rank-8, and unpublished rows stay hidden.</li>
+                <li>Cron remains disabled.</li>
+              </ul>
+            </div>
+            <div className="space-y-2 border-t border-[var(--border)] pt-3">
+              <h4 className="text-sm font-semibold text-[var(--text-primary)]">
+                Rollback preparation
+              </h4>
+              <p className="text-xs leading-5 text-[var(--text-secondary)]">
+                If verification fails, identify the newly live seven rows, turn them non-live, and restore the archived previous live rows.
+              </p>
+            </div>
           </div>
         </div>
       </Panel>
@@ -972,7 +999,7 @@ function getApproveAllBlockedReason(
 function getComposerPublishDisabledReason(
   readiness: FinalSlateReadinessResult,
   storageReady: boolean,
-) {
+): string | null {
   if (!storageReady) {
     return "Publishing is blocked until editorial storage is configured.";
   }
@@ -981,7 +1008,11 @@ function getComposerPublishDisabledReason(
     return `Publish is disabled: ${readiness.failures[0]?.message ?? "final slate validation has not passed."}`;
   }
 
-  return "Slate readiness passes, but publish execution stays disabled in this Phase 2 composer PR.";
+  return null;
+}
+
+function getReadyToPublishMessage() {
+  return "Ready to publish the validated 5 Core + 2 Context slate.";
 }
 
 function normalizeEditorialText(value: string | null | undefined) {

--- a/src/lib/homepage-editorial-overrides.ts
+++ b/src/lib/homepage-editorial-overrides.ts
@@ -6,6 +6,9 @@ import {
 import type { BriefingItem, DashboardData } from "@/lib/types";
 
 type PublishedSignalPostRow = {
+  rank: number | null;
+  final_slate_rank: number | null;
+  final_slate_tier: string | null;
   title: string | null;
   source_url: string | null;
   published_why_it_matters: string | null;
@@ -32,6 +35,18 @@ function normalizeEditorialText(value: string | null | undefined) {
 
 function isPubliclyAllowedEditorialDecision(value: string | null | undefined) {
   return value === null || value === undefined || value === "approved" || value === "draft_edited";
+}
+
+function getPublicSlateRank(row: PublishedSignalPostRow) {
+  if (typeof row.final_slate_rank === "number" && row.final_slate_rank >= 1 && row.final_slate_rank <= 7) {
+    return row.final_slate_rank;
+  }
+
+  if (typeof row.rank === "number" && row.rank >= 1 && row.rank <= 7) {
+    return row.rank;
+  }
+
+  return null;
 }
 
 function getItemSourceUrl(item: BriefingItem) {
@@ -115,12 +130,12 @@ export async function getPublishedHomepageEditorialOverrides(): Promise<
 
   const result = await client
     .from("signal_posts")
-    .select("title, source_url, published_why_it_matters, published_why_it_matters_payload, editorial_status, editorial_decision, published_at")
+    .select("rank, final_slate_rank, final_slate_tier, title, source_url, published_why_it_matters, published_why_it_matters_payload, editorial_status, editorial_decision, published_at")
     .eq("is_live", true)
     .eq("editorial_status", "published")
     .not("published_at", "is", null)
     .order("rank", { ascending: true })
-    .limit(5);
+    .limit(100);
 
   if (result.error) {
     return [];
@@ -128,6 +143,13 @@ export async function getPublishedHomepageEditorialOverrides(): Promise<
 
   return ((result.data ?? []) as PublishedSignalPostRow[])
     .filter((row) => isPubliclyAllowedEditorialDecision(row.editorial_decision))
+    .filter((row) => {
+      const publicRank = getPublicSlateRank(row);
+
+      return Boolean(publicRank && publicRank <= 5 && (!row.final_slate_tier || row.final_slate_tier === "core"));
+    })
+    .sort((left, right) => (getPublicSlateRank(left) ?? 99) - (getPublicSlateRank(right) ?? 99))
+    .slice(0, 5)
     .map((row) => ({
       title: normalizeEditorialText(row.title),
       sourceUrl: normalizeEditorialText(row.source_url),

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -106,6 +106,29 @@ function createRow(overrides: Partial<SignalPostRow> = {}): SignalPostRow {
   };
 }
 
+function createFinalSlateRow(slot: number, overrides: Partial<SignalPostRow> = {}) {
+  return createRow({
+    id: `slate-${slot}`,
+    briefing_date: "2026-04-30",
+    rank: slot,
+    edited_why_it_matters: createValidWhyItMatters(`Slate ${slot}`),
+    editorial_status: "approved",
+    editorial_decision: "approved",
+    final_slate_rank: slot,
+    final_slate_tier: slot <= 5 ? "core" : "context",
+    is_live: false,
+    published_at: null,
+    ...overrides,
+  });
+}
+
+function createValidFinalSlate(overrides: Record<number, Partial<SignalPostRow>> = {}) {
+  return Array.from({ length: 7 }, (_, index) => {
+    const slot = index + 1;
+    return createFinalSlateRow(slot, overrides[slot] ?? {});
+  });
+}
+
 function createBriefingItem(rank: number) {
   return {
     id: `generated-${rank}`,
@@ -731,15 +754,13 @@ describe("signals editorial workflow", () => {
     expect(rows[1].editorial_status).toBe("published");
   });
 
-  it("blocks publishing unless all five signal posts are approved", async () => {
-    const rows = Array.from({ length: 5 }, (_, index) =>
-      createRow({
-        id: `signal-${index + 1}`,
-        rank: index + 1,
-        edited_why_it_matters: createValidWhyItMatters(`Anthropic ${index + 1}`),
-        editorial_status: index === 4 ? "draft" : "approved",
-      }),
-    );
+  it("blocks publishing unless all seven final-slate rows are approved", async () => {
+    const rows = createValidFinalSlate({
+      7: {
+        editorial_status: "draft",
+        editorial_decision: "draft_edited",
+      },
+    });
     createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
     safeGetUser.mockResolvedValue({
       user: { id: "admin-1", email: "admin@example.com" },
@@ -755,18 +776,8 @@ describe("signals editorial workflow", () => {
     expect(rows.some((row) => row.editorial_status === "published")).toBe(false);
   });
 
-  it("blocks Top 5 publishing when the current set has fewer than exactly five approved rows", async () => {
-    const rows = Array.from({ length: 3 }, (_, index) =>
-      createRow({
-        id: `phase-b-${index + 1}`,
-        briefing_date: "2026-04-28",
-        rank: index + 1,
-        edited_why_it_matters: createValidWhyItMatters(`Phase B ${index + 1}`),
-        editorial_status: "approved",
-        is_live: false,
-        published_at: null,
-      }),
-    );
+  it("blocks final-slate publishing when fewer than seven rows are selected", async () => {
+    const rows = createValidFinalSlate().slice(0, 3);
     createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
     safeGetUser.mockResolvedValue({
       user: { id: "admin-1", email: "admin@example.com" },
@@ -780,25 +791,42 @@ describe("signals editorial workflow", () => {
     expect(result).toMatchObject({
       ok: false,
       code: "publish_blocked",
-      message: "Publishing requires exactly five ranked signal posts. Current count: 3.",
     });
+    expect(result.message).toContain("Final slate requires exactly 7 selected rows. Current count: 3.");
     expect(rows.every((row) => row.editorial_status === "approved")).toBe(true);
     expect(rows.every((row) => row.is_live === false)).toBe(true);
     expect(rows.every((row) => row.published_at === null)).toBe(true);
   });
 
-  it("blocks publishing when approved why-it-matters copy fails the pre-publish gate", async () => {
-    const rows = Array.from({ length: 5 }, (_, index) =>
-      createRow({
-        id: `signal-${index + 1}`,
-        rank: index + 1,
-        edited_why_it_matters:
-          index === 0
-            ? "This changes how investors price rates, demand, or risk in rates and equities over."
-            : createValidWhyItMatters(`Anthropic ${index + 1}`),
-        editorial_status: "approved",
-      }),
-    );
+  it.each([
+    {
+      label: "held",
+      overrides: { editorial_decision: "held" as const },
+      expectedMessage: "Selected row is marked held.",
+    },
+    {
+      label: "rejected",
+      overrides: { editorial_decision: "rejected" as const },
+      expectedMessage: "Selected row is marked rejected.",
+    },
+    {
+      label: "rewrite-requested",
+      overrides: { editorial_decision: "rewrite_requested" as const },
+      expectedMessage: "Selected row has rewrite_requested editorial status.",
+    },
+    {
+      label: "WITM-failed",
+      overrides: {
+        why_it_matters_validation_status: "requires_human_rewrite" as const,
+        why_it_matters_validation_failures: ["minimum_specificity"],
+        why_it_matters_validation_details: ["missing specificity"],
+      },
+      expectedMessage: "Row 3 has WITM status requires_human_rewrite.",
+    },
+  ])("blocks final-slate publish when a selected row is $label", async ({ overrides, expectedMessage }) => {
+    const rows = createValidFinalSlate({
+      3: overrides,
+    });
     createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
     safeGetUser.mockResolvedValue({
       user: { id: "admin-1", email: "admin@example.com" },
@@ -811,41 +839,98 @@ describe("signals editorial workflow", () => {
 
     expect(result.ok).toBe(false);
     expect(result.code).toBe("publish_blocked");
-    expect(rows[0].editorial_status).toBe("needs_review");
-    expect(rows[0].why_it_matters_validation_status).toBe("requires_human_rewrite");
+    expect(result.message).toContain(expectedMessage);
+    expect(rows.every((row) => row.editorial_status !== "published")).toBe(true);
+    expect(rows.every((row) => row.is_live === false)).toBe(true);
+    expect(rows.every((row) => row.published_at === null)).toBe(true);
+  });
+
+  it.each([
+    {
+      label: "duplicate rank",
+      overrides: { 5: { final_slate_rank: 4, final_slate_tier: "core" as const } },
+      expectedMessage: "Rank 4 is duplicated.",
+    },
+    {
+      label: "rank gap",
+      overrides: { 6: { final_slate_rank: null, final_slate_tier: null } },
+      expectedMessage: "Context slot 6 is empty.",
+    },
+    {
+      label: "6 Core + 1 Context",
+      overrides: { 6: { final_slate_tier: "core" as const } },
+      expectedMessage: "6 Core rows selected; 5 required.",
+    },
+  ])("blocks final-slate publish on $label without writes", async ({ overrides, expectedMessage }) => {
+    const rows = createValidFinalSlate(overrides);
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { publishApprovedSignals } = await loadEditorialModule();
+    const result = await publishApprovedSignals();
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("publish_blocked");
+    expect(result.message).toContain(expectedMessage);
+    expect(rows.every((row) => row.editorial_status !== "published")).toBe(true);
+    expect(rows.every((row) => row.is_live === false)).toBe(true);
+    expect(rows.every((row) => row.published_at === null)).toBe(true);
+  });
+
+  it("blocks publishing when approved why-it-matters copy fails the pre-publish gate without mutating rows", async () => {
+    const rows = createValidFinalSlate({
+      1: {
+        edited_why_it_matters: "This changes how investors price rates, demand, or risk in rates and equities over.",
+      },
+    });
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { publishApprovedSignals } = await loadEditorialModule();
+    const result = await publishApprovedSignals();
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("publish_blocked");
+    expect(rows[0].editorial_status).toBe("approved");
+    expect(rows[0].why_it_matters_validation_status).toBe("passed");
     expect(rows[0].published_why_it_matters).toBeNull();
-    expect(rows.slice(1).every((row) => row.editorial_status === "approved")).toBe(true);
+    expect(rows.every((row) => row.editorial_status === "approved")).toBe(true);
     expect(rows.every((row) => row.is_live === false)).toBe(true);
   });
 
-  it("publishes approved edits without promoting unapproved depth fallback text", async () => {
+  it("publishes exactly the selected 5 Core + 2 Context slate without promoting non-selected candidates", async () => {
     const rows = [
-      createRow({
-        id: "signal-1",
-        rank: 1,
-        edited_why_it_matters: createValidWhyItMatters("Google"),
-        editorial_status: "approved",
+      ...createValidFinalSlate({
+        5: {
+          id: "promoted-rank-8",
+          rank: 8,
+          final_slate_rank: 5,
+          final_slate_tier: "core",
+          edited_why_it_matters: createValidWhyItMatters("Promoted replacement"),
+        },
       }),
-      ...Array.from({ length: 4 }, (_, index) =>
-        createRow({
-          id: `signal-${index + 2}`,
-          rank: index + 2,
-          edited_why_it_matters: createValidWhyItMatters(`Amazon ${index + 2}`),
-          published_why_it_matters: createValidWhyItMatters(`Google ${index + 2}`),
-          editorial_status: "published",
-        }),
-      ),
       createRow({
-        id: "signal-6",
-        rank: 6,
+        id: "rank-8-not-selected",
+        briefing_date: "2026-04-30",
+        rank: 8,
         ai_why_it_matters: "Generated category-depth context.",
         editorial_status: "needs_review",
       }),
       createRow({
-        id: "signal-7",
-        rank: 7,
-        edited_why_it_matters: "Edited category-depth context.",
-        editorial_status: "draft",
+        id: "approved-not-selected",
+        briefing_date: "2026-04-30",
+        rank: 9,
+        edited_why_it_matters: createValidWhyItMatters("Non-selected"),
+        editorial_status: "approved",
+        editorial_decision: "approved",
       }),
     ];
     createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
@@ -859,19 +944,20 @@ describe("signals editorial workflow", () => {
     const result = await publishApprovedSignals();
 
     expect(result.ok).toBe(true);
-    expect(rows.slice(0, 5).every((row) => row.editorial_status === "published")).toBe(true);
-    expect(rows[0].published_why_it_matters).toBe(createValidWhyItMatters("Google"));
-    expect(rows[1].published_why_it_matters).toBe(createValidWhyItMatters("Amazon 2"));
-    expect(rows[5].editorial_status).toBe("needs_review");
-    expect(rows[5].published_why_it_matters).toBeNull();
-    expect(rows[5].is_live).toBe(false);
-    expect(rows[6].editorial_status).toBe("draft");
-    expect(rows[6].published_why_it_matters).toBeNull();
-    expect(rows[6].is_live).toBe(false);
+    expect(rows.filter((row) => row.is_live)).toHaveLength(7);
+    expect(rows.slice(0, 7).every((row) => row.editorial_status === "published")).toBe(true);
+    expect(rows[4].id).toBe("promoted-rank-8");
+    expect(rows[4].published_why_it_matters).toBe(createValidWhyItMatters("Promoted replacement"));
+    expect(rows[7].editorial_status).toBe("needs_review");
+    expect(rows[7].published_why_it_matters).toBeNull();
+    expect(rows[7].is_live).toBe(false);
+    expect(rows[8].editorial_status).toBe("approved");
+    expect(rows[8].published_why_it_matters).toBeNull();
+    expect(rows[8].is_live).toBe(false);
   });
 
   it("keeps live-set replacement inside the explicit publish workflow", async () => {
-    const oldLiveRows = Array.from({ length: 5 }, (_, index) =>
+    const oldLiveRows = Array.from({ length: 7 }, (_, index) =>
       createRow({
         id: `old-live-${index + 1}`,
         briefing_date: "2026-04-26",
@@ -882,15 +968,17 @@ describe("signals editorial workflow", () => {
         published_at: "2026-04-26T10:00:00.000Z",
       }),
     );
-    const approvedRows = Array.from({ length: 5 }, (_, index) =>
-      createRow({
-        id: `approved-${index + 1}`,
-        briefing_date: "2026-04-27",
-        rank: index + 1,
-        edited_why_it_matters: createValidWhyItMatters(`New Google ${index + 1}`),
-        editorial_status: "approved",
-        is_live: false,
-      }),
+    const approvedRows = createValidFinalSlate(
+      Object.fromEntries(
+        Array.from({ length: 7 }, (_, index) => [
+          index + 1,
+          {
+            id: `approved-${index + 1}`,
+            briefing_date: "2026-04-30",
+            edited_why_it_matters: createValidWhyItMatters(`New Google ${index + 1}`),
+          },
+        ]),
+      ),
     );
     const rows = [...oldLiveRows, ...approvedRows];
     createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
@@ -900,15 +988,17 @@ describe("signals editorial workflow", () => {
       sessionCookiePresent: true,
     });
 
-    const { publishApprovedSignals } = await loadEditorialModule();
+    const { publishApprovedSignals, getPublishedSignalPosts } = await loadEditorialModule();
     const result = await publishApprovedSignals();
 
     expect(result.ok).toBe(true);
+    expect(result.message).toBe("Published final slate: 5 Core + 2 Context rows are live. Archived 7 previous live rows.");
     expect(oldLiveRows.every((row) => row.is_live === false)).toBe(true);
     expect(approvedRows.every((row) => row.editorial_status === "published")).toBe(true);
     expect(approvedRows.every((row) => row.is_live === true)).toBe(true);
     expect(approvedRows.every((row) => row.published_at !== null)).toBe(true);
     expect(approvedRows[0].published_why_it_matters).toBe(createValidWhyItMatters("New Google 1"));
+    await expect(getPublishedSignalPosts()).resolves.toHaveLength(7);
   });
 
   it("persists generated signal posts for editorial review without changing the live public set", async () => {
@@ -1153,7 +1243,7 @@ describe("signals editorial workflow", () => {
     expect(result.ok).toBe(false);
     expect(result.code).toBe("publish_blocked");
     expect(result.message).toBe(
-      "Individual signal publishing is disabled. Use Publish Top 5 Signals after exactly five ranked posts are approved.",
+      "Individual signal publishing is disabled. Use Publish Final Slate after the 5 Core + 2 Context slate passes validation.",
     );
     expect(rows[0].editorial_status).toBe("approved");
     expect(rows[0].is_live).toBe(false);
@@ -1516,6 +1606,84 @@ describe("signals editorial workflow", () => {
       "live-7",
     ]);
     expect(posts.map((post) => post.rank)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it("uses final-slate placement for public order while keeping visibility gated by live published state", async () => {
+    const rows = [
+      createRow({
+        id: "slot-1-promoted-rank-8",
+        rank: 8,
+        briefing_date: "2026-04-30",
+        final_slate_rank: 1,
+        final_slate_tier: "core",
+        editorial_status: "published",
+        editorial_decision: "approved",
+        published_why_it_matters: createValidWhyItMatters("Promoted"),
+        is_live: true,
+        published_at: "2026-04-30T08:00:00.000Z",
+      }),
+      ...Array.from({ length: 6 }, (_, index) => {
+        const slot = index + 2;
+
+        return createRow({
+          id: `slot-${slot}`,
+          rank: slot,
+          briefing_date: "2026-04-30",
+          final_slate_rank: slot,
+          final_slate_tier: slot <= 5 ? "core" : "context",
+          editorial_status: "published",
+          editorial_decision: "approved",
+          published_why_it_matters: createValidWhyItMatters(`Slot ${slot}`),
+          is_live: true,
+          published_at: "2026-04-30T08:00:00.000Z",
+        });
+      }),
+      createRow({
+        id: "approved-selected-not-live",
+        rank: 1,
+        briefing_date: "2026-04-30",
+        final_slate_rank: 1,
+        final_slate_tier: "core",
+        editorial_status: "approved",
+        editorial_decision: "approved",
+        edited_why_it_matters: createValidWhyItMatters("Approved only"),
+        is_live: false,
+        published_at: null,
+      }),
+    ];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+
+    const { getPublishedSignalPosts, getHomepageSignalSnapshot } = await loadEditorialModule();
+    const publicSignals = await getPublishedSignalPosts();
+    const homepageSnapshot = await getHomepageSignalSnapshot({
+      today: new Date("2026-04-30T12:00:00.000Z"),
+    });
+
+    expect(publicSignals.map((post) => post.id)).toEqual([
+      "slot-1-promoted-rank-8",
+      "slot-2",
+      "slot-3",
+      "slot-4",
+      "slot-5",
+      "slot-6",
+      "slot-7",
+    ]);
+    expect(homepageSnapshot.posts.map((post) => post.id)).toEqual([
+      "slot-1-promoted-rank-8",
+      "slot-2",
+      "slot-3",
+      "slot-4",
+      "slot-5",
+    ]);
+    expect(homepageSnapshot.depthPosts.map((post) => post.id)).toEqual([
+      "slot-1-promoted-rank-8",
+      "slot-2",
+      "slot-3",
+      "slot-4",
+      "slot-5",
+      "slot-6",
+      "slot-7",
+    ]);
   });
 
   it("keeps approved but unpublished rows out of public signal and homepage reads", async () => {

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -16,7 +16,9 @@ import { captureRssFailure, type RssFailureType, type RssPhase } from "@/lib/obs
 import {
   getFinalSlateTierForRank,
   isFinalSlateRank,
+  validateFinalSlateReadiness,
   type FinalSlateTier,
+  type FinalSlateValidationFailure,
 } from "@/lib/final-slate-readiness";
 import type { BriefingItem, EditorialDecision, EditorialStatus } from "@/lib/types";
 import {
@@ -853,25 +855,6 @@ async function getLatestBriefingDate(client: EditorialClient) {
   };
 }
 
-async function loadCurrentTopFive(client: EditorialClient, briefingDate: string | null) {
-  if (!briefingDate) {
-    return [];
-  }
-
-  const result = await client
-    .from("signal_posts")
-    .select(SIGNAL_POST_SELECT)
-    .eq("briefing_date", briefingDate)
-    .order("rank", { ascending: true })
-    .limit(5);
-
-  if (result.error) {
-    return [];
-  }
-
-  return ((result.data ?? []) as unknown as StoredSignalPost[]).map(mapStoredSignalPost);
-}
-
 async function loadCurrentSignalDepth(client: EditorialClient, briefingDate: string | null) {
   if (!briefingDate) {
     return [];
@@ -907,12 +890,34 @@ function selectPublishedEditorialWhyItMatters(post: EditorialSignalPost) {
   return normalizeEditorialText(post.publishedWhyItMatters);
 }
 
-function selectApprovedEditorialWhyItMatters(post: EditorialSignalPost) {
-  if (post.editorialStatus !== "approved" && post.editorialStatus !== "published") {
-    return "";
+function getPublicSlateRank(post: EditorialSignalPost) {
+  if (isFinalSlateRank(post.finalSlateRank)) {
+    return post.finalSlateRank;
   }
 
-  return normalizeEditorialText(post.editedWhyItMatters || post.publishedWhyItMatters);
+  return isFinalSlateRank(post.rank) ? post.rank : null;
+}
+
+function isPublicSlatePost(post: EditorialSignalPost) {
+  return Boolean(selectPublishedEditorialWhyItMatters(post) && getPublicSlateRank(post));
+}
+
+function comparePublicSlatePosts(left: EditorialSignalPost, right: EditorialSignalPost) {
+  const leftRank = getPublicSlateRank(left) ?? Number.MAX_SAFE_INTEGER;
+  const rightRank = getPublicSlateRank(right) ?? Number.MAX_SAFE_INTEGER;
+
+  if (leftRank !== rightRank) {
+    return leftRank - rightRank;
+  }
+
+  return left.rank - right.rank;
+}
+
+function selectPublicSlatePosts(posts: EditorialSignalPost[], limit: number) {
+  return posts
+    .filter(isPublicSlatePost)
+    .sort(comparePublicSlatePosts)
+    .slice(0, limit);
 }
 
 async function loadPublishedHomepageSnapshotForDate(
@@ -931,17 +936,17 @@ async function loadPublishedHomepageSnapshotForDate(
     .eq("is_live", true)
     .eq("editorial_status", "published")
     .not("published_at", "is", null)
-    .lt("rank", PUBLIC_SIGNAL_SET_SIZE + 1)
     .order("rank", { ascending: true })
-    .limit(limit);
+    .limit(100);
 
   if (result.error) {
     return [];
   }
 
-  return ((result.data ?? []) as unknown as StoredSignalPost[])
-    .map(mapStoredSignalPost)
-    .filter((post) => selectPublishedEditorialWhyItMatters(post));
+  return selectPublicSlatePosts(
+    ((result.data ?? []) as unknown as StoredSignalPost[]).map(mapStoredSignalPost),
+    limit,
+  );
 }
 
 async function loadMostRecentPublishedHomepageSnapshot(
@@ -954,8 +959,8 @@ async function loadMostRecentPublishedHomepageSnapshot(
     .eq("is_live", true)
     .eq("editorial_status", "published")
     .not("published_at", "is", null)
-    .lt("rank", PUBLIC_SIGNAL_SET_SIZE + 1)
     .order("briefing_date", { ascending: false })
+    .order("published_at", { ascending: false })
     .order("rank", { ascending: true })
     .limit(100);
 
@@ -968,13 +973,16 @@ async function loadMostRecentPublishedHomepageSnapshot(
 
   const publishedPosts = ((result.data ?? []) as unknown as StoredSignalPost[])
     .map(mapStoredSignalPost)
-    .filter((post) => selectPublishedEditorialWhyItMatters(post));
+    .filter(isPublicSlatePost);
   const briefingDate = publishedPosts[0]?.briefingDate ?? null;
 
   return {
     briefingDate,
     posts: briefingDate
-      ? publishedPosts.filter((post) => post.briefingDate === briefingDate).slice(0, limit)
+      ? selectPublicSlatePosts(
+          publishedPosts.filter((post) => post.briefingDate === briefingDate),
+          limit,
+        )
       : [],
   };
 }
@@ -1173,11 +1181,11 @@ function getEditorialStorageWarning(postCount: number, scope: EditorialScopeFilt
   if (postCount < 5) {
     return scope === "historical"
       ? `Editorial archive currently has ${postCount} matching historical signal posts.`
-      : `Editorial storage currently has ${postCount} matching signal posts. Publishing requires exactly five ranked signal posts in the current set.`;
+      : `Editorial storage currently has ${postCount} matching signal posts. Publishing requires a validated 5 Core + 2 Context final slate.`;
   }
 
   if (postCount > 5 && scope === "all") {
-    return `Editorial storage has ${postCount} matching signal posts. This page is paginated; publishing still uses only the latest five ranked posts.`;
+    return `Editorial storage has ${postCount} matching signal posts. This page is paginated; publishing still uses only the latest validated final slate.`;
   }
 
   return null;
@@ -2141,64 +2149,63 @@ export async function publishApprovedSignals(input: {
     };
   }
 
+  const schemaPreflight = await getSignalPostsSchemaPreflight(context.client);
+
+  if (!schemaPreflight.ok) {
+    return {
+      ok: false,
+      code: "storage_unavailable",
+      message: schemaPreflight.message,
+    };
+  }
+
   const latest = await getLatestBriefingDate(context.client);
-  const topFivePosts = await loadCurrentTopFive(context.client, latest.latestBriefingDate);
-  const depthPosts = (await loadCurrentSignalDepth(context.client, latest.latestBriefingDate)).filter(
-    (post) => post.rank > TOP_SIGNAL_SET_SIZE,
-  );
 
   if (latest.errorMessage) {
     captureRssEditorialStorageFailure({
       failureType: "rss_cache_read_failed",
       phase: "publish",
-      operation: "load_latest_signal_snapshot_for_publish",
+      operation: "load_latest_final_slate_for_publish",
       route: input.route ?? SIGNALS_EDITORIAL_ROUTE,
-      message: "RSS signal set could not be loaded for publishing.",
+      message: "Final slate candidates could not be loaded for publishing.",
     });
 
     return {
       ok: false,
       code: "storage_error",
-      message: "The Top 5 list could not be loaded for publishing.",
+      message: "The final slate candidates could not be loaded for publishing.",
     };
   }
 
-  if (topFivePosts.length !== 5) {
+  const currentCandidates = await loadCurrentSignalDepth(context.client, latest.latestBriefingDate);
+  const readiness = validateFinalSlateReadiness(currentCandidates);
+
+  if (!readiness.ready) {
     return {
       ok: false,
       code: "publish_blocked",
-      message: `Publishing requires exactly five ranked signal posts. Current count: ${topFivePosts.length}.`,
+      message: buildFinalSlatePublishFailureMessage(readiness.failures),
     };
   }
 
-  const notReadyToPublish = topFivePosts.filter(
-    (post) =>
-      (post.editorialStatus !== "approved" && post.editorialStatus !== "published") ||
-      isBlockingEditorialDecision(post.editorialDecision),
+  const selectedIds = new Set(readiness.selectedRows.map((row) => row.id));
+  const selectedPosts = currentCandidates
+    .filter((post) => selectedIds.has(post.id))
+    .sort((left, right) => (left.finalSlateRank ?? 0) - (right.finalSlateRank ?? 0));
+  const missingSelectedPosts = readiness.selectedRows.filter(
+    (row) => !selectedPosts.some((post) => post.id === row.id),
   );
 
-  if (notReadyToPublish.length > 0) {
+  if (selectedPosts.length !== PUBLIC_SIGNAL_SET_SIZE || missingSelectedPosts.length > 0) {
     return {
       ok: false,
       code: "publish_blocked",
-      message: "Approve all five signal posts and clear rejected, held, or rewrite-requested decisions before publishing.",
-    };
-  }
-
-  const missingEditorialText = topFivePosts.filter(
-    (post) => !normalizeEditorialText(post.editedWhyItMatters || post.publishedWhyItMatters),
-  );
-
-  if (missingEditorialText.length > 0) {
-    return {
-      ok: false,
-      code: "publish_blocked",
-      message: "Every approved signal post needs editorial Why it matters text before publishing.",
+      message: "Final slate selection changed before publish. Reload the composer and validate the slate again.",
     };
   }
 
   const now = new Date().toISOString();
-  const topFivePublicationCandidates = topFivePosts.map((post) => {
+  const publicationCandidates = selectedPosts.map((post) => {
     const structuredContent =
       post.editedWhyItMattersStructured ?? post.publishedWhyItMattersStructured;
     const text = normalizeEditorialText(
@@ -2215,67 +2222,86 @@ export async function publishApprovedSignals(input: {
       validation: validateWhyItMatters(text),
     };
   });
-  const invalidTopFive = topFivePublicationCandidates.filter((entry) => !entry.validation.passed);
 
-  if (invalidTopFive.length > 0) {
-    const flagResults = await Promise.all(
-      invalidTopFive.map(({ post, validation }) =>
-        context.client
-          .from("signal_posts")
-          .update({
-            editorial_status: "needs_review",
-            ...buildWhyItMattersValidationFields(validation, now),
-            updated_at: now,
-          })
-          .eq("id", post.id),
-      ),
-    );
+  const missingEditorialText = publicationCandidates.filter((entry) => !entry.text);
 
-    if (flagResults.some((result) => result.error)) {
-      return {
-        ok: false,
-        code: "storage_error",
-        message: "The invalid signal posts could not be flagged for rewrite.",
-      };
-    }
+  if (missingEditorialText.length > 0) {
+    return {
+      ok: false,
+      code: "publish_blocked",
+      message: "Every selected final-slate row needs editorial Why it matters text before publishing. No rows were changed.",
+    };
+  }
 
+  const invalidPublicationCandidates = publicationCandidates.filter((entry) => !entry.validation.passed);
+
+  if (invalidPublicationCandidates.length > 0) {
     return {
       ok: false,
       code: "publish_blocked",
       message:
-        invalidTopFive.length === 1
-          ? getValidationFailureMessage(invalidTopFive[0].validation)
-          : `${invalidTopFive.length} signal posts require human rewrite before publishing.`,
+        invalidPublicationCandidates.length === 1
+          ? `${getValidationFailureMessage(invalidPublicationCandidates[0].validation)} No rows were changed.`
+          : `${invalidPublicationCandidates.length} final-slate rows require human rewrite before publishing. No rows were changed.`,
     };
   }
 
-  const deactivateOldLiveSet = await context.client
+  const previousLiveResult = await context.client
     .from("signal_posts")
-    .update({
-      is_live: false,
-      updated_at: now,
-    })
+    .select("id")
     .eq("is_live", true);
 
-  if (deactivateOldLiveSet.error) {
+  if (previousLiveResult.error) {
     captureRssEditorialStorageFailure({
-      failureType: "rss_cache_write_failed",
+      failureType: "rss_cache_read_failed",
       phase: "publish",
-      operation: "archive_previous_live_signal_set_for_publish",
+      operation: "load_previous_live_signal_set_for_publish",
       route: input.route ?? SIGNALS_EDITORIAL_ROUTE,
       briefingDate: latest.latestBriefingDate,
-      message: "Previous live RSS signal set could not be archived before publishing.",
+      message: "Previous live RSS signal set could not be loaded before publishing.",
     });
 
     return {
       ok: false,
       code: "storage_error",
-      message: "The previous live signal set could not be archived before publishing.",
+      message: "The previous live signal set could not be loaded before publishing.",
     };
   }
 
+  const previousLiveIds = ((previousLiveResult.data ?? []) as Array<Pick<StoredSignalPost, "id">>)
+    .map((row) => row.id)
+    .filter((id): id is string => Boolean(id));
+  const selectedPostIds = publicationCandidates.map((entry) => entry.post.id);
+
+  if (previousLiveIds.length > 0) {
+    const deactivateOldLiveSet = await context.client
+      .from("signal_posts")
+      .update({
+        is_live: false,
+        updated_at: now,
+      })
+      .in("id", previousLiveIds);
+
+    if (deactivateOldLiveSet.error) {
+      captureRssEditorialStorageFailure({
+        failureType: "rss_cache_write_failed",
+        phase: "publish",
+        operation: "archive_previous_live_signal_set_for_publish",
+        route: input.route ?? SIGNALS_EDITORIAL_ROUTE,
+        briefingDate: latest.latestBriefingDate,
+        message: "Previous live RSS signal set could not be archived before publishing.",
+      });
+
+      return {
+        ok: false,
+        code: "storage_error",
+        message: "The previous live signal set could not be archived before publishing.",
+      };
+    }
+  }
+
   const updateResults = await Promise.all(
-    topFivePublicationCandidates.map(({ post, structuredContent, text, validation }) =>
+    publicationCandidates.map(({ post, structuredContent, text, validation }) =>
       context.client
         .from("signal_posts")
         .update({
@@ -2292,97 +2318,82 @@ export async function publishApprovedSignals(input: {
     ),
   );
 
-  const depthPublicationCandidates = depthPosts
-    .map((post) => {
-      const structuredContent =
-        post.editedWhyItMattersStructured ?? post.publishedWhyItMattersStructured;
-      const humanEditorialText = selectApprovedEditorialWhyItMatters(post);
-      const depthText = normalizeEditorialText(
-        humanEditorialText
-          ? buildEditorialWhyItMattersText(
-              structuredContent,
-              humanEditorialText,
-            )
-          : "",
-      );
+  if (updateResults.some((result) => result.error)) {
+    await rollbackFailedFinalSlatePublish(context.client, {
+      previousLiveIds,
+      selectedPostIds,
+      now,
+    });
 
-      return {
-        post,
-        structuredContent,
-        depthText,
-        validation: depthText ? validateWhyItMatters(depthText) : null,
-      };
-    })
-    .filter((entry) => entry.depthText);
-  const invalidDepthCandidates = depthPublicationCandidates.flatMap((entry) =>
-    entry.validation && !entry.validation.passed
-      ? [{ ...entry, validation: entry.validation }]
-      : [],
-  );
-  const validDepthCandidates = depthPublicationCandidates.flatMap((entry) =>
-    entry.validation?.passed
-      ? [{ ...entry, validation: entry.validation }]
-      : [],
-  );
-
-  const depthValidationResults = await Promise.all(
-    invalidDepthCandidates.map(({ post, validation }) =>
-      context.client
-        .from("signal_posts")
-        .update({
-          editorial_status: "needs_review",
-          ...buildWhyItMattersValidationFields(validation, now),
-          updated_at: now,
-        })
-        .eq("id", post.id),
-    ),
-  );
-
-  const depthUpdateResults = await Promise.all(
-    validDepthCandidates.map(({ post, structuredContent, depthText, validation }) =>
-      context.client
-        .from("signal_posts")
-        .update({
-          published_why_it_matters: depthText,
-          published_why_it_matters_payload: structuredContent,
-          editorial_status: "published",
-          editorial_decision: "approved",
-          ...buildWhyItMattersValidationFields(validation, now),
-          is_live: true,
-          published_at: now,
-          updated_at: now,
-        })
-        .eq("id", post.id),
-    ),
-  );
-
-  if (
-    updateResults.some((result) => result.error) ||
-    depthUpdateResults.some((result) => result.error) ||
-    depthValidationResults.some((result) => result.error)
-  ) {
     captureRssEditorialStorageFailure({
       failureType: "rss_cache_write_failed",
       phase: "publish",
-      operation: "publish_signal_set",
+      operation: "publish_final_slate_signal_set",
       route: input.route ?? SIGNALS_EDITORIAL_ROUTE,
       briefingDate: latest.latestBriefingDate,
-      postCount: topFivePosts.length + depthPosts.length,
-      message: "RSS signal set could not be published completely.",
+      postCount: publicationCandidates.length,
+      message: "Final slate signal set could not be published completely.",
     });
 
     return {
       ok: false,
       code: "storage_error",
-      message: "The signal set could not be published completely.",
+      message: "The final slate could not be published completely. Previous live visibility was restored where possible.",
     };
   }
 
   return {
     ok: true,
     code: "published",
-    message: "Top 5 Signals published.",
+    message:
+      previousLiveIds.length > 0
+        ? `Published final slate: 5 Core + 2 Context rows are live. Archived ${previousLiveIds.length} previous live rows.`
+        : "Published final slate: 5 Core + 2 Context rows are live. No previous live slate was present to archive.",
   };
+}
+
+function buildFinalSlatePublishFailureMessage(failures: FinalSlateValidationFailure[]) {
+  const reasons = failures.slice(0, 3).map((failure) => failure.message);
+
+  if (reasons.length === 0) {
+    return "Final slate validation failed. No rows were changed.";
+  }
+
+  return `Final slate validation failed: ${reasons.join(" ")} No rows were changed.`;
+}
+
+async function rollbackFailedFinalSlatePublish(
+  client: EditorialClient,
+  input: {
+    previousLiveIds: string[];
+    selectedPostIds: string[];
+    now: string;
+  },
+) {
+  const rollbackResults = await Promise.all([
+    input.selectedPostIds.length > 0
+      ? client
+          .from("signal_posts")
+          .update({
+            editorial_status: "approved",
+            is_live: false,
+            published_at: null,
+            updated_at: input.now,
+          })
+          .in("id", input.selectedPostIds)
+      : Promise.resolve({ error: null }),
+    input.previousLiveIds.length > 0
+      ? client
+          .from("signal_posts")
+          .update({
+            is_live: true,
+            updated_at: input.now,
+          })
+          .in("id", input.previousLiveIds)
+      : Promise.resolve({ error: null }),
+  ]);
+
+  return rollbackResults.every((result) => !result.error);
 }
 
 export async function publishSignalPost(input: {
@@ -2402,7 +2413,7 @@ export async function publishSignalPost(input: {
   return {
     ok: false,
     code: "publish_blocked",
-    message: "Individual signal publishing is disabled. Use Publish Top 5 Signals after exactly five ranked posts are approved.",
+    message: "Individual signal publishing is disabled. Use Publish Final Slate after the 5 Core + 2 Context slate passes validation.",
   };
 }
 
@@ -2425,9 +2436,10 @@ async function loadPublishedSignalPosts(limit: number): Promise<EditorialSignalP
     .eq("is_live", true)
     .eq("editorial_status", "published")
     .not("published_at", "is", null)
-    .lt("rank", PUBLIC_SIGNAL_SET_SIZE + 1)
+    .order("briefing_date", { ascending: false })
+    .order("published_at", { ascending: false })
     .order("rank", { ascending: true })
-    .limit(limit);
+    .limit(100);
 
   if (result.error) {
     logServerEvent("warn", "Published signal posts could not be loaded", {
@@ -2437,9 +2449,17 @@ async function loadPublishedSignalPosts(limit: number): Promise<EditorialSignalP
     return [];
   }
 
-  return ((result.data ?? []) as unknown as StoredSignalPost[])
+  const publishedPosts = ((result.data ?? []) as unknown as StoredSignalPost[])
     .map(mapStoredSignalPost)
-    .filter((post) => selectPublishedEditorialWhyItMatters(post));
+    .filter(isPublicSlatePost);
+  const briefingDate = publishedPosts[0]?.briefingDate ?? null;
+
+  return briefingDate
+    ? selectPublicSlatePosts(
+        publishedPosts.filter((post) => post.briefingDate === briefingDate),
+        limit,
+      )
+    : [];
 }
 
 export async function getPublishedSignalPosts(): Promise<EditorialSignalPost[]> {


### PR DESCRIPTION
## 1. Effective change type

Feature implementation under the approved PRD-53 amendment.

## 2. Source of truth

Primary source of truth:

`docs/product/prd/prd-53-signals-admin-editorial-layer.md`

Supporting records:

- `docs/engineering/change-records/prd-53-minimal-final-slate-composer.md`
- `docs/engineering/change-records/prd-53-editorial-card-controls.md`
- `docs/operations/tracker-sync/2026-04-30-prd-53-card-level-editorial-authority.md`

## 3. Canonical PRD status

Canonical PRD coverage is already satisfied by merged PR #149.

Baseline implementation steps are already in place:

- PR #150: minimal final-slate composer
- PR #151: editorial card controls

No duplicate PRD was created.

## 4. What changed

- Hardened the existing admin publish action so it validates the current final slate immediately before writes.
- Publishes exactly the validated 5 Core + 2 Context rows.
- Archives previous live rows by setting `is_live = false` before selected-row publication.
- Keeps validation failures fail-closed: invalid slates return structured reasons and do not mutate rows.
- Keeps rank-8, held, rejected, rewrite-requested, removed, Depth/unpromoted, candidate, and non-selected rows hidden.
- Enables the admin Publish Final Slate button only when readiness passes.
- Adds publish warning, post-publish verification checklist, and rollback preparation copy to the composer.
- Updates public reads to keep requiring `is_live = true`, `editorial_status = 'published'`, and `published_at IS NOT NULL`, while ordering by `final_slate_rank` when present.
- Adds focused tests for publish blocking, exact seven-row publish behavior, previous-live archiving, public read safety, and admin readiness state.

## 5. What did not change

- No real production publish was performed.
- No cron run or cron re-enable.
- No pipeline run.
- No `dry_run`.
- No `draft_only`.
- No production database mutation.
- No source governance change.
- No source, ranking threshold, or WITM threshold change.
- No full historical snapshot/schema implementation.
- No Phase 2 architecture.
- No personalization.

## 6. Validation

Passed:

- `npm install`
- `git diff --check`
- `npm run lint`
- `npm run test -- src/lib/final-slate-readiness.test.ts src/lib/signals-editorial.test.ts src/app/dashboard/signals/editorial-review/page.test.tsx src/lib/homepage-editorial-overrides.test.ts`
- `npm run test`
- `npm run build`
- `python3 scripts/validate-feature-system-csv.py` (passed with pre-existing slug warnings only)
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-seven-row-publish-hardening --pr-title "PRD-53 seven-row publish hardening"`
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-seven-row-publish-hardening --pr-title "PRD-53 seven-row publish hardening"`
- `npm run dev` at `http://localhost:3000`
- `npx playwright test --project=chromium`
- `npx playwright test --project=webkit`

Additional local release wrapper attempted:

- `./scripts/release-check.sh --install=never`
  - Inner steps passed: dependency install, lint, unit tests, build, dev server rule, Chromium Playwright, WebKit Playwright.
  - Final wrapper route probe failed on `/` with HTTP 200 because the wrapper expected older homepage markers: `Why it matters`, `Details`.
  - The command also emitted npm warnings because `--install=never` was not forwarded by npm as intended.

## 7. Risks / follow-up

- Minimal audit/history remains next.
- Second controlled cycle remains after audit/history or after publish workflow review.
- Measurement instrumentation remains later.
- Final launch-readiness QA remains later.
- Cron remains last.

READINESS LABEL:

`ready_for_prd_53_seven_row_publish_hardening_review`
