### PR TITLE
PRD-53 minimal published-slate audit history

### DIFF
--- a/docs/engineering/SIGNAL_POSTS_OPERATIONAL_CONTRACT.md
+++ b/docs/engineering/SIGNAL_POSTS_OPERATIONAL_CONTRACT.md
@@ -13,6 +13,8 @@ This document defines the operational meaning of `public.signal_posts` until a c
 
 `signal_posts` represents an editorial/published Surface Placement plus Card copy and public read model. Rows may describe the current live Top 5, historical daily placement snapshots, and public depth-pool card rows, but those rows are not durable event or Signal identities.
 
+`published_slates` and `published_slate_items` are minimal audit/history companions for supported PRD-53 final-slate publishes. They snapshot the published Surface Placement and Card copy at publish time; they are not canonical Signal identity, a public archive surface, or the Phase 2 historical content model.
+
 `signal_posts.id`, `signal_posts.rank`, and `(briefing_date, rank)` must not be treated as stable event identity, durable Signal identity, or canonical cross-day lineage.
 
 `signal_posts` must not be used as the canonical foundation for Phase 2 progression, lineage, Signal history, event evolution, or duplicate suppression.
@@ -28,6 +30,7 @@ The current table is allowed to serve these purposes:
 - Live public Surface Placement state through `is_live`.
 - Daily placement archive through `briefing_date` and `rank`.
 - Public depth-pool rows for homepage/category rendering.
+- Internal published-slate audit references through `published_slate_items.signal_post_id`.
 
 The current table is not allowed to serve these purposes:
 
@@ -48,6 +51,8 @@ The current table is not allowed to serve these purposes:
   - maps homepage signal-post rows back into `BriefingItem` card objects.
 - `src/lib/homepage-editorial-overrides.ts`
   - applies published `signal_posts` copy as homepage card-copy overrides.
+- `public.published_slates` / `public.published_slate_items`
+  - store internal publish audit rows for the most recent and prior supported final-slate publishes.
 
 ## Required Future Constraint
 

--- a/docs/engineering/change-records/prd-53-minimal-published-slate-audit-history.md
+++ b/docs/engineering/change-records/prd-53-minimal-published-slate-audit-history.md
@@ -1,0 +1,64 @@
+# PRD-53 Minimal Published-Slate Audit History
+
+Date: 2026-04-30
+Branch: `codex/prd-53-minimal-published-slate-audit-history`
+Readiness label: `ready_for_prd_53_minimal_published_slate_audit_history_review`
+
+## Source of truth
+
+- `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+- `docs/engineering/change-records/prd-53-minimal-final-slate-composer.md`
+- `docs/engineering/change-records/prd-53-editorial-card-controls.md`
+- `docs/engineering/change-records/prd-53-seven-row-publish-hardening.md`
+
+## Summary
+
+This change adds the minimal internal audit/history layer for supported PRD-53 final-slate publishes.
+
+The implementation keeps the scope narrow:
+
+- adds `published_slates` as the publish-level audit record
+- adds `published_slate_items` as the seven-row item snapshot record
+- captures published row IDs and archived previous-live row IDs
+- snapshots final rank, final tier, title, Why It Matters, summary, source metadata, editorial decision, replacement relationship, and review metadata for published rows
+- blocks supported publish before public writes if audit storage is unavailable or audit creation fails
+- shows the latest audit record inside the private Signals editorial admin page
+- stores rollback preparation metadata without implementing rollback execution
+
+## Atomicity note
+
+The current Supabase client path does not expose a repository transaction helper for the final-slate publish operation.
+
+This implementation uses the safest existing repo-supported pattern:
+
+1. validate the final slate before writes
+2. verify audit tables before writes
+3. create the audit record and seven audit items before public visibility changes
+4. archive the previous live rows
+5. publish exactly the selected seven rows
+6. delete the pre-created audit record if later archive/publish writes fail and trigger the existing best-effort row rollback
+
+This prevents silent public publishing without audit when audit creation fails. Full transaction-backed publish batches and executable rollback remain follow-up work.
+
+## Object level
+
+This is Surface Placement plus Card snapshot audit history.
+
+It does not introduce canonical Signal identity, a public archive, Story Cluster persistence, semantic clustering, personalization, or the Phase 2 historical content model.
+
+## Decision-trace limitation
+
+This minimal audit layer snapshots published rows, archived previous-live rows, replacement relationships on published rows, and final decision metadata on published rows.
+
+It does not yet create a full immutable event log for rejected, held, rewrite-requested, promoted, demoted, or removed rows that were outside the final public slate. Full decision-event history remains a follow-up after the supported publish path is proven.
+
+## Non-actions
+
+- No production publish was performed.
+- No cron change was made.
+- No `dry_run`, `draft_only`, or pipeline write-mode run was performed.
+- No production database rows were mutated.
+- No source governance, source list, ranking threshold, or WITM threshold changed.
+- No public history/archive surface was implemented.
+- No full historical snapshot/schema layer was implemented.
+- No Phase 2 architecture or personalization work was started.

--- a/docs/operations/tracker-sync/2026-04-30-prd-53-minimal-published-slate-audit-history.md
+++ b/docs/operations/tracker-sync/2026-04-30-prd-53-minimal-published-slate-audit-history.md
@@ -1,0 +1,43 @@
+# Tracker Sync Fallback - PRD-53 Minimal Published-Slate Audit History
+
+Date: 2026-04-30
+Branch: `codex/prd-53-minimal-published-slate-audit-history`
+PRD: `PRD-53`
+Canonical PRD file: `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+Readiness label: `ready_for_prd_53_minimal_published_slate_audit_history_review`
+
+## Manual tracker update payload
+
+Use this fallback if live Google Sheets tracker access is unavailable.
+
+| Field | Value |
+| --- | --- |
+| `prd_id` | `PRD-53` |
+| `PRD File` | `docs/product/prd/prd-53-signals-admin-editorial-layer.md` |
+| `Status` | `In Review` |
+| `Decision` | `build` |
+| `Owner` | `Codex` |
+| `Last Updated` | `2026-04-30` |
+| `Notes` | Minimal internal published-slate audit/history implemented for PRD-53 supported final-slate publishes. Captures published row IDs, archived previous-live row IDs, final rank/tier, Card copy/source snapshots, replacement metadata, rollback preparation note, and admin latest-audit display. No production publish, cron, pipeline run, production database mutation, public archive surface, or full historical schema implementation performed. |
+
+## Scope completed
+
+- Added additive `published_slates` and `published_slate_items` audit tables.
+- Supported publish creates one audit record and seven item snapshots before public visibility writes.
+- Audit creation failure blocks publish before row mutation.
+- Audit records capture published rows, archived previous live rows, final rank/tier, Card copy/source snapshots, replacement metadata, and rollback preparation metadata.
+- Admin editorial page displays the latest published-slate audit record.
+- Public routes continue to read only live published `signal_posts` rows and do not expose audit history.
+
+## Explicit non-actions
+
+- No production publish.
+- No cron.
+- No `dry_run`.
+- No `draft_only`.
+- No pipeline write-mode.
+- No production database mutation.
+- No public archive/history surface.
+- No source governance, ranking threshold, or WITM threshold change.
+- No full historical snapshot/schema implementation.
+- No automatic public publishing.

--- a/docs/product/prd/prd-53-signals-admin-editorial-layer.md
+++ b/docs/product/prd/prd-53-signals-admin-editorial-layer.md
@@ -11,6 +11,8 @@
 - 2026-04-30 readiness label: `ready_for_prd_53_editorial_card_controls_review`
 - 2026-04-30 implementation checkpoint: seven-row publish workflow hardening in review
 - 2026-04-30 readiness label: `ready_for_prd_53_seven_row_publish_hardening_review`
+- 2026-04-30 implementation checkpoint: minimal published-slate audit/history in review
+- 2026-04-30 readiness label: `ready_for_prd_53_minimal_published_slate_audit_history_review`
 
 ## Objective
 
@@ -52,6 +54,7 @@ The site can produce ranked signal posts, but the final public “Why it matters
 - `src/lib/admin-auth.ts` parses comma-separated admin emails and checks the authenticated Supabase user email.
 - `src/lib/signals-editorial.ts` owns server-side editorial reads and mutations. Mutations require an authenticated admin/editor and use the Supabase service-role key only after that in-app authorization check.
 - `public.signal_posts` stores ranked signal metadata, AI draft reference copy, human edited copy, published copy, status, and edit/approval/publish metadata.
+- `public.published_slates` and `public.published_slate_items` store the minimal internal audit record for supported final-slate publishes: published row IDs, archived previous live row IDs, final rank/tier, Card copy snapshots, source snapshots, replacement metadata, and rollback preparation notes.
 - RLS does not grant direct anonymous table reads. The public `/signals` route reads published rows server-side and renders only sanitized public fields.
 - `/dashboard/signals/editorial-review` is noindexed and blocks unauthenticated and non-admin users.
 - `/signals` shows the final published editorial layer only when all five posts have been published.

--- a/src/app/dashboard/signals/editorial-review/page.test.tsx
+++ b/src/app/dashboard/signals/editorial-review/page.test.tsx
@@ -100,6 +100,9 @@ function createAuthorizedState(posts: typeof reviewPost[]) {
     pageSize: 20,
     totalMatchingPosts: posts.length,
     latestBriefingDate: "2026-04-24",
+    latestPublishedSlateAudit: null,
+    auditStorageReady: true,
+    auditWarning: null,
     appliedScope: "all" as const,
     appliedStatus: "all" as const,
     appliedQuery: "",
@@ -207,6 +210,77 @@ describe("signals editorial review page", () => {
     expect(screen.getByText("Rollback preparation")).toBeInTheDocument();
   });
 
+  it("renders the most recent published-slate audit section for admins", async () => {
+    const readySlate = Array.from({ length: 7 }, (_, index) => {
+      const slot = index + 1;
+
+      return {
+        ...approvedPost,
+        id: `ready-${slot}`,
+        rank: slot,
+        title: `Ready Signal ${slot}`,
+        editorialDecision: "approved" as const,
+        finalSlateRank: slot,
+        finalSlateTier: slot <= 5 ? ("core" as const) : ("context" as const),
+        editedWhyItMatters:
+          "This structurally changes how markets price cloud capacity, AI infrastructure, and platform dependency over the next year.",
+      };
+    });
+    getEditorialReviewState.mockResolvedValue({
+      ...createAuthorizedState(readySlate),
+      latestPublishedSlateAudit: {
+        id: "published-slate-1",
+        publishedAt: "2026-04-30T08:00:00.000Z",
+        publishedBy: "editor@example.com",
+        rowCount: 7,
+        coreCount: 5,
+        contextCount: 2,
+        previousLiveRowIds: ["old-live-1"],
+        publishedRowIds: readySlate.map((post) => post.id),
+        rollbackNote:
+          "Rollback execution is not implemented in this phase. This audit record identifies the rows needed for rollback.",
+        verificationChecklist: {
+          status: "not_run" as const,
+          items: ["Homepage returns 200 and shows Core slots 1-5."],
+        },
+        createdAt: "2026-04-30T08:00:00.000Z",
+        items: readySlate.map((post) => ({
+          id: `audit-item-${post.finalSlateRank}`,
+          publishedSlateId: "published-slate-1",
+          signalPostId: post.id,
+          finalSlateRank: post.finalSlateRank,
+          finalSlateTier: post.finalSlateTier,
+          titleSnapshot: post.title,
+          whyItMattersSnapshot: post.editedWhyItMatters,
+          summarySnapshot: post.summary,
+          sourceNameSnapshot: post.sourceName,
+          sourceUrlSnapshot: post.sourceUrl,
+          editorialDecisionSnapshot: post.editorialDecision,
+          replacementOfRowIdSnapshot: post.finalSlateRank === 5 ? "held-original" : null,
+          decisionNoteSnapshot: null,
+          heldReasonSnapshot: null,
+          rejectedReasonSnapshot: null,
+          reviewedBySnapshot: null,
+          reviewedAtSnapshot: null,
+          createdAt: "2026-04-30T08:00:00.000Z",
+        })),
+      },
+    });
+
+    const Page = (await import("@/app/dashboard/signals/editorial-review/page")).default;
+    render(await Page({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByRole("heading", { name: "Published Slate Audit" })).toBeInTheDocument();
+    expect(screen.getByText("By editor@example.com")).toBeInTheDocument();
+    expect(screen.getByText("7 rows")).toBeInTheDocument();
+    expect(screen.getByText("5 Core")).toBeInTheDocument();
+    expect(screen.getByText("2 Context")).toBeInTheDocument();
+    expect(screen.getByText("old-live-1")).toBeInTheDocument();
+    expect(screen.getAllByText("Ready Signal 5").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Approved · Replacement/)).toBeInTheDocument();
+    expect(screen.getByText("Status: Not run")).toBeInTheDocument();
+  });
+
   it("collapses each editorial panel by default and expands only the selected card", async () => {
     getEditorialReviewState.mockResolvedValue({
       ...createAuthorizedState([reviewPost, approvedPost]),
@@ -303,7 +377,7 @@ describe("signals editorial review page", () => {
 
     expect(Array.from(document.querySelectorAll("h2"))
       .map((heading) => heading.textContent)
-      .filter((heading) => heading !== "Final Slate Composer")).toEqual([
+      .filter((heading) => heading !== "Final Slate Composer" && heading !== "Published Slate Audit")).toEqual([
       "April 26 Higher Signal",
       "April 26 Lower Signal",
       "April 25 Signal",

--- a/src/app/dashboard/signals/editorial-review/page.tsx
+++ b/src/app/dashboard/signals/editorial-review/page.tsx
@@ -33,6 +33,7 @@ import {
   type EditorialScopeFilter,
   type EditorialPostStatusFilter,
   type EditorialSignalPost,
+  type PublishedSlateAudit,
 } from "@/lib/signals-editorial";
 
 export const dynamic = "force-dynamic";
@@ -107,7 +108,11 @@ export default async function SignalsEditorialReviewPage({ searchParams }: PageP
     .sort((left, right) => left.rank - right.rank)
     .slice(0, 5);
   const finalSlateReadiness = validateFinalSlateReadiness(currentCandidates);
-  const publishDisabledReason = getComposerPublishDisabledReason(finalSlateReadiness, state.storageReady);
+  const publishDisabledReason = getComposerPublishDisabledReason(
+    finalSlateReadiness,
+    state.storageReady,
+    state.auditStorageReady,
+  );
   const approveAllPosts = visiblePosts.filter(isBulkApprovablePost);
   const statusCounts = getStatusCounts(posts);
   const approveAllBlockedReason = getApproveAllBlockedReason(visiblePosts, state.storageReady, approveAllPosts.length);
@@ -134,7 +139,7 @@ export default async function SignalsEditorialReviewPage({ searchParams }: PageP
                 Signals Final-Slate Composer
               </h1>
               <p className="text-base leading-7 text-[var(--text-secondary)]">
-                Compose the reviewed 5 Core + 2 Context slate before publish hardening.
+                Compose, publish, and audit the reviewed 5 Core + 2 Context slate.
               </p>
             </div>
             <div className="grid gap-3 sm:grid-cols-2 xl:min-w-[34rem]">
@@ -180,11 +185,18 @@ export default async function SignalsEditorialReviewPage({ searchParams }: PageP
         {successMessage ? <StatusBanner tone="success" message={successMessage} /> : null}
         {errorMessage ? <StatusBanner tone="error" message={errorMessage} /> : null}
         {state.warning ? <StatusBanner tone="warning" message={state.warning} /> : null}
+        {state.auditWarning ? <StatusBanner tone="warning" message={state.auditWarning} /> : null}
 
         <FinalSlateComposer
           candidates={currentCandidates}
           readiness={finalSlateReadiness}
           storageReady={state.storageReady}
+          auditStorageReady={state.auditStorageReady}
+        />
+
+        <PublishedSlateAuditSummary
+          audit={state.latestPublishedSlateAudit}
+          auditStorageReady={state.auditStorageReady}
         />
 
         <section className="space-y-3">
@@ -322,15 +334,17 @@ function FinalSlateComposer({
   candidates,
   readiness,
   storageReady,
+  auditStorageReady,
 }: {
   candidates: EditorialSignalPost[];
   readiness: FinalSlateReadinessResult;
   storageReady: boolean;
+  auditStorageReady: boolean;
 }) {
   const selectedCount = readiness.selectedRows.length;
   const coreCount = readiness.selectedRows.filter((post) => post.finalSlateTier === "core").length;
   const contextCount = readiness.selectedRows.filter((post) => post.finalSlateTier === "context").length;
-  const publishDisabledReason = getComposerPublishDisabledReason(readiness, storageReady);
+  const publishDisabledReason = getComposerPublishDisabledReason(readiness, storageReady, auditStorageReady);
 
   return (
     <section className="space-y-4" aria-labelledby="final-slate-composer-title">
@@ -445,6 +459,111 @@ function FinalSlateComposer({
         ) : (
           <p className="text-sm leading-6 text-[var(--text-secondary)]">
             No current briefing candidates are available for slate composition.
+          </p>
+        )}
+      </Panel>
+    </section>
+  );
+}
+
+function PublishedSlateAuditSummary({
+  audit,
+  auditStorageReady,
+}: {
+  audit: PublishedSlateAudit | null;
+  auditStorageReady: boolean;
+}) {
+  return (
+    <section className="space-y-4" aria-labelledby="published-slate-audit-title">
+      <div className="space-y-2">
+        <h2 id="published-slate-audit-title" className="text-xl font-semibold tracking-normal text-[var(--text-primary)]">
+          Published Slate Audit
+        </h2>
+        <p className="max-w-3xl text-sm leading-6 text-[var(--text-secondary)]">
+          Internal record of the most recent published 5 Core + 2 Context slate. This is not a public archive surface.
+        </p>
+      </div>
+      <Panel className="p-4">
+        {!auditStorageReady ? (
+          <p className="text-sm leading-6 text-[var(--text-secondary)]">
+            Published-slate audit storage is not ready. Publishing is blocked until audit tables are available.
+          </p>
+        ) : audit ? (
+          <div className="space-y-4">
+            <div className="flex flex-wrap gap-2">
+              <Badge>Published {formatAuditTimestamp(audit.publishedAt)}</Badge>
+              <Badge>{audit.publishedBy ? `By ${audit.publishedBy}` : "Publisher unavailable"}</Badge>
+              <Badge>{audit.rowCount} rows</Badge>
+              <Badge>{audit.coreCount} Core</Badge>
+              <Badge>{audit.contextCount} Context</Badge>
+              <Badge>{audit.previousLiveRowIds.length} archived previous live rows</Badge>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[42rem] border-collapse text-left text-sm">
+                <thead>
+                  <tr className="border-b border-[var(--border)] text-xs uppercase tracking-normal text-[var(--text-secondary)]">
+                    <th className="py-2 pr-3 font-medium">Rank</th>
+                    <th className="py-2 pr-3 font-medium">Tier</th>
+                    <th className="py-2 pr-3 font-medium">Title</th>
+                    <th className="py-2 pr-3 font-medium">Source</th>
+                    <th className="py-2 pr-3 font-medium">Decision</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {audit.items.map((item) => (
+                    <tr key={item.id} className="border-b border-[var(--border)] last:border-0">
+                      <td className="py-2 pr-3 text-[var(--text-primary)]">{item.finalSlateRank}</td>
+                      <td className="py-2 pr-3 text-[var(--text-secondary)]">
+                        {item.finalSlateTier === "core" ? "Core" : "Context"}
+                      </td>
+                      <td className="py-2 pr-3 text-[var(--text-primary)]">{item.titleSnapshot}</td>
+                      <td className="py-2 pr-3 text-[var(--text-secondary)]">
+                        {item.sourceNameSnapshot || "Missing source"}
+                      </td>
+                      <td className="py-2 pr-3 text-[var(--text-secondary)]">
+                        {formatDecision(item.editorialDecisionSnapshot)}
+                        {item.replacementOfRowIdSnapshot ? " · Replacement" : ""}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="grid gap-4 lg:grid-cols-2">
+              <div className="space-y-2 rounded-card border border-[var(--border)] bg-[var(--card)] p-3">
+                <h3 className="text-sm font-semibold text-[var(--text-primary)]">Archived previous live rows</h3>
+                <p className="break-words text-xs leading-5 text-[var(--text-secondary)]">
+                  {audit.previousLiveRowIds.length > 0
+                    ? audit.previousLiveRowIds.join(", ")
+                    : "No previous live rows were present."}
+                </p>
+              </div>
+              <div className="space-y-2 rounded-card border border-[var(--border)] bg-[var(--card)] p-3">
+                <h3 className="text-sm font-semibold text-[var(--text-primary)]">Rollback preparation</h3>
+                <p className="text-xs leading-5 text-[var(--text-secondary)]">
+                  {audit.rollbackNote ?? "Rollback execution is not implemented in this phase."}
+                </p>
+              </div>
+            </div>
+            {audit.verificationChecklist ? (
+              <div className="space-y-2 border-t border-[var(--border)] pt-3">
+                <h3 className="text-sm font-semibold text-[var(--text-primary)]">
+                  Verification checklist
+                </h3>
+                <p className="text-xs leading-5 text-[var(--text-secondary)]">
+                  Status: {audit.verificationChecklist.status === "not_run" ? "Not run" : audit.verificationChecklist.status}
+                </p>
+                <ul className="space-y-1 text-xs leading-5 text-[var(--text-secondary)]">
+                  {audit.verificationChecklist.items.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <p className="text-sm leading-6 text-[var(--text-secondary)]">
+            No published slate audit record exists yet. The next successful supported publish will create one.
           </p>
         )}
       </Panel>
@@ -741,6 +860,16 @@ function formatDecision(decision: string | null) {
     : "Needs review";
 }
 
+function formatAuditTimestamp(value: string) {
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  return parsed.toISOString();
+}
+
 function normalizeStatusFilter(value: string | undefined): EditorialPostStatusFilter {
   if (
     value === "review" ||
@@ -999,9 +1128,14 @@ function getApproveAllBlockedReason(
 function getComposerPublishDisabledReason(
   readiness: FinalSlateReadinessResult,
   storageReady: boolean,
+  auditStorageReady: boolean,
 ): string | null {
   if (!storageReady) {
     return "Publishing is blocked until editorial storage is configured.";
+  }
+
+  if (!auditStorageReady) {
+    return "Publishing is blocked until published-slate audit storage is configured.";
   }
 
   if (!readiness.ready) {

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -40,6 +40,44 @@ type SignalPostRow = {
   updated_at: string | null;
 };
 
+type PublishedSlateRow = {
+  id: string;
+  published_at: string;
+  published_by: string | null;
+  row_count: number;
+  core_count: number;
+  context_count: number;
+  previous_live_row_ids: string[];
+  published_row_ids: string[];
+  rollback_note: string | null;
+  verification_checklist_json: unknown;
+  created_at: string | null;
+};
+
+type PublishedSlateItemRow = {
+  id: string;
+  published_slate_id: string;
+  signal_post_id: string;
+  final_slate_rank: number;
+  final_slate_tier: "core" | "context";
+  title_snapshot: string;
+  why_it_matters_snapshot: string;
+  summary_snapshot: string | null;
+  source_name_snapshot: string | null;
+  source_url_snapshot: string | null;
+  editorial_decision_snapshot: SignalPostRow["editorial_decision"];
+  replacement_of_row_id_snapshot: string | null;
+  decision_note_snapshot: string | null;
+  held_reason_snapshot: string | null;
+  rejected_reason_snapshot: string | null;
+  reviewed_by_snapshot: string | null;
+  reviewed_at_snapshot: string | null;
+  created_at: string | null;
+};
+
+type TestTableName = "signal_posts" | "published_slates" | "published_slate_items";
+type TestRow = SignalPostRow | PublishedSlateRow | PublishedSlateItemRow;
+
 const safeGetUser = vi.fn();
 const createSupabaseServiceRoleClient = vi.fn();
 const createSupabaseServerClient = vi.fn();
@@ -106,6 +144,48 @@ function createRow(overrides: Partial<SignalPostRow> = {}): SignalPostRow {
   };
 }
 
+function createPublishedSlateRow(overrides: Partial<PublishedSlateRow> = {}): PublishedSlateRow {
+  return {
+    id: overrides.id ?? "published-slate-1",
+    published_at: overrides.published_at ?? "2026-04-30T08:00:00.000Z",
+    published_by: overrides.published_by ?? "admin@example.com",
+    row_count: overrides.row_count ?? 7,
+    core_count: overrides.core_count ?? 5,
+    context_count: overrides.context_count ?? 2,
+    previous_live_row_ids: overrides.previous_live_row_ids ?? [],
+    published_row_ids: overrides.published_row_ids ?? [],
+    rollback_note: overrides.rollback_note ?? null,
+    verification_checklist_json: overrides.verification_checklist_json ?? {
+      status: "not_run",
+      items: ["Homepage returns 200 and shows Core slots 1-5."],
+    },
+    created_at: overrides.created_at ?? "2026-04-30T08:00:00.000Z",
+  };
+}
+
+function createPublishedSlateItemRow(overrides: Partial<PublishedSlateItemRow> = {}): PublishedSlateItemRow {
+  return {
+    id: overrides.id ?? "published-slate-item-1",
+    published_slate_id: overrides.published_slate_id ?? "published-slate-1",
+    signal_post_id: overrides.signal_post_id ?? "slate-1",
+    final_slate_rank: overrides.final_slate_rank ?? 1,
+    final_slate_tier: overrides.final_slate_tier ?? "core",
+    title_snapshot: overrides.title_snapshot ?? "Published Signal",
+    why_it_matters_snapshot: overrides.why_it_matters_snapshot ?? createValidWhyItMatters("Published"),
+    summary_snapshot: overrides.summary_snapshot ?? "Published summary",
+    source_name_snapshot: overrides.source_name_snapshot ?? "Source",
+    source_url_snapshot: overrides.source_url_snapshot ?? "https://example.com/source",
+    editorial_decision_snapshot: overrides.editorial_decision_snapshot ?? "approved",
+    replacement_of_row_id_snapshot: overrides.replacement_of_row_id_snapshot ?? null,
+    decision_note_snapshot: overrides.decision_note_snapshot ?? null,
+    held_reason_snapshot: overrides.held_reason_snapshot ?? null,
+    rejected_reason_snapshot: overrides.rejected_reason_snapshot ?? null,
+    reviewed_by_snapshot: overrides.reviewed_by_snapshot ?? null,
+    reviewed_at_snapshot: overrides.reviewed_at_snapshot ?? null,
+    created_at: overrides.created_at ?? "2026-04-30T08:00:00.000Z",
+  };
+}
+
 function createFinalSlateRow(slot: number, overrides: Partial<SignalPostRow> = {}) {
   return createRow({
     id: `slate-${slot}`,
@@ -156,43 +236,94 @@ function createBriefingItem(rank: number) {
 
 function createSupabaseMock(
   rows: SignalPostRow[],
-  options: { missingColumns?: string[]; preflightTransportErrorColumns?: string[] } = {},
+  options: {
+    missingColumns?: string[];
+    missingRelations?: TestTableName[];
+    preflightTransportErrorColumns?: string[];
+    publishedSlates?: PublishedSlateRow[];
+    publishedSlateItems?: PublishedSlateItemRow[];
+    insertErrors?: Partial<Record<TestTableName, string>>;
+    updateErrors?: Partial<Record<TestTableName, string>>;
+    deleteErrors?: Partial<Record<TestTableName, string>>;
+    onFrom?: (tableName: TestTableName) => void;
+  } = {},
 ) {
   const missingColumns = new Set(options.missingColumns ?? []);
+  const missingRelations = new Set(options.missingRelations ?? []);
   const preflightTransportErrorColumns = new Set(options.preflightTransportErrorColumns ?? []);
+  const publishedSlates = options.publishedSlates ?? [];
+  const publishedSlateItems = options.publishedSlateItems ?? [];
+
+  function getTableRows(tableName: TestTableName): TestRow[] {
+    if (tableName === "published_slates") {
+      return publishedSlates;
+    }
+
+    if (tableName === "published_slate_items") {
+      return publishedSlateItems;
+    }
+
+    return rows;
+  }
+
+  function createInsertedRow(tableName: TestTableName, value: Record<string, unknown>, index: number): TestRow {
+    if (tableName === "published_slates") {
+      return createPublishedSlateRow({
+        id: typeof value.id === "string" ? value.id : `published-slate-${publishedSlates.length + index + 1}`,
+        ...value,
+      } as Partial<PublishedSlateRow>);
+    }
+
+    if (tableName === "published_slate_items") {
+      return createPublishedSlateItemRow({
+        id: typeof value.id === "string" ? value.id : `published-slate-item-${publishedSlateItems.length + index + 1}`,
+        ...value,
+      } as Partial<PublishedSlateItemRow>);
+    }
+
+    return createRow({
+      id: typeof value.id === "string" ? value.id : `inserted-${index + 1}`,
+      ...value,
+    } as Partial<SignalPostRow>);
+  }
 
   return {
     rows,
-    from(tableName: string) {
-      expect(tableName).toBe("signal_posts");
+    publishedSlates,
+    publishedSlateItems,
+    from(tableName: TestTableName) {
+      expect(["signal_posts", "published_slates", "published_slate_items"]).toContain(tableName);
+      options.onFrom?.(tableName);
 
-      let operation: "select" | "update" | "insert" | null = null;
-      let updateValues: Partial<SignalPostRow> = {};
-      let insertedRows: SignalPostRow[] = [];
+      const tableRows = getTableRows(tableName);
+      let operation: "select" | "update" | "insert" | "delete" | null = null;
+      let updateValues: Record<string, unknown> = {};
+      let insertedRows: TestRow[] = [];
       let selectError: { message: string } | null = null;
       let selectedColumns: string[] = [];
-      const filters: Array<{ column: keyof SignalPostRow; value: unknown }> = [];
-      const inclusionFilters: Array<{ column: keyof SignalPostRow; values: unknown[] }> = [];
-      const lessThanFilters: Array<{ column: keyof SignalPostRow; value: unknown }> = [];
-      const notNullFilters: Array<{ column: keyof SignalPostRow }> = [];
+      const filters: Array<{ column: string; value: unknown }> = [];
+      const inclusionFilters: Array<{ column: string; values: unknown[] }> = [];
+      const lessThanFilters: Array<{ column: string; value: unknown }> = [];
+      const notNullFilters: Array<{ column: string }> = [];
       let orSearch = "";
-      const orderRules: Array<{ column: keyof SignalPostRow; ascending: boolean }> = [];
+      const orderRules: Array<{ column: string; ascending: boolean }> = [];
       let rangeStart: number | null = null;
       let rangeEnd: number | null = null;
 
       function applyFilters() {
-        return rows.filter((row) =>
-          filters.every((filter) => row[filter.column] === filter.value) &&
-          inclusionFilters.every((filter) => filter.values.includes(row[filter.column])) &&
+        return tableRows.filter((row) =>
+          filters.every((filter) => (row as Record<string, unknown>)[filter.column] === filter.value) &&
+          inclusionFilters.every((filter) => filter.values.includes((row as Record<string, unknown>)[filter.column])) &&
           lessThanFilters.every((filter) => {
-            const rowValue = row[filter.column];
+            const rowValue = (row as Record<string, unknown>)[filter.column];
             return typeof rowValue === "number" && typeof filter.value === "number"
               ? rowValue < filter.value
               : String(rowValue) < String(filter.value);
           }) &&
-          notNullFilters.every((filter) => row[filter.column] !== null) &&
+          notNullFilters.every((filter) => (row as Record<string, unknown>)[filter.column] !== null) &&
           (orSearch
-            ? row.title.toLowerCase().includes(orSearch) || row.source_name.toLowerCase().includes(orSearch)
+            ? String((row as Record<string, unknown>).title ?? "").toLowerCase().includes(orSearch) ||
+              String((row as Record<string, unknown>).source_name ?? "").toLowerCase().includes(orSearch)
             : true),
         );
       }
@@ -211,8 +342,8 @@ function createSupabaseMock(
         if (orderRules.length > 0) {
           data = data.slice().sort((left, right) => {
             for (const rule of orderRules) {
-              const leftValue = left[rule.column];
-              const rightValue = right[rule.column];
+              const leftValue = (left as Record<string, unknown>)[rule.column];
+              const rightValue = (right as Record<string, unknown>)[rule.column];
               const comparison =
                 typeof leftValue === "number" && typeof rightValue === "number"
                   ? leftValue - rightValue
@@ -247,17 +378,23 @@ function createSupabaseMock(
             .split(",")
             .map((column) => column.trim().split(/\s+/)[0])
             .filter(Boolean);
-          const missingSelectedColumns = selectedColumns.filter((column) => missingColumns.has(column));
+          const missingSelectedColumns = selectedColumns.filter(
+            (column) => missingColumns.has(column) || missingColumns.has(`${tableName}.${column}`),
+          );
 
-          if (missingSelectedColumns.length > 0) {
+          if (missingRelations.has(tableName)) {
             selectError = {
-              message: `column signal_posts.${missingSelectedColumns[0]} does not exist`,
+              message: `relation "${tableName}" does not exist`,
+            };
+          } else if (missingSelectedColumns.length > 0) {
+            selectError = {
+              message: `column ${tableName}.${missingSelectedColumns[0]} does not exist`,
             };
           }
 
           return builder;
         },
-        order(column: keyof SignalPostRow, options?: { ascending?: boolean }) {
+        order(column: string, options?: { ascending?: boolean }) {
           orderRules.push({ column, ascending: options?.ascending ?? true });
           return builder;
         },
@@ -281,41 +418,67 @@ function createSupabaseMock(
           return selectResult();
         },
         maybeSingle() {
+          if (selectError) {
+            return Promise.resolve({
+              data: null,
+              error: selectError,
+            });
+          }
+
+          if (operation === "insert") {
+            return Promise.resolve({
+              data: insertedRows[0] ?? null,
+              error: null,
+            });
+          }
+
           return Promise.resolve({
             data: applyFilters()[0] ?? null,
             error: null,
           });
         },
-        insert(values: Partial<SignalPostRow>[]) {
+        insert(values: Partial<TestRow> | Array<Partial<TestRow>>) {
           operation = "insert";
+          const insertError = options.insertErrors?.[tableName];
+
+          if (insertError) {
+            selectError = { message: insertError };
+            return builder;
+          }
+
           insertedRows = [];
-          values.forEach((value, index) => {
-            const row = createRow({ id: `inserted-${index + 1}`, ...value });
-            rows.push(row);
+          const normalizedValues = Array.isArray(values) ? values : [values];
+          normalizedValues.forEach((value, index) => {
+            const row = createInsertedRow(tableName, value as Record<string, unknown>, index);
+            tableRows.push(row);
             insertedRows.push(row);
           });
 
           return builder;
         },
-        update(values: Partial<SignalPostRow>) {
+        update(values: Record<string, unknown>) {
           operation = "update";
           updateValues = values;
           return builder;
         },
-        eq(column: keyof SignalPostRow, value: unknown) {
+        delete() {
+          operation = "delete";
+          return builder;
+        },
+        eq(column: string, value: unknown) {
           filters.push({ column, value });
 
           return builder;
         },
-        in(column: keyof SignalPostRow, values: unknown[]) {
+        in(column: string, values: unknown[]) {
           inclusionFilters.push({ column, values });
           return builder;
         },
-        lt(column: keyof SignalPostRow, value: unknown) {
+        lt(column: string, value: unknown) {
           lessThanFilters.push({ column, value });
           return builder;
         },
-        not(column: keyof SignalPostRow, operator: string, value: unknown) {
+        not(column: string, operator: string, value: unknown) {
           if (operator === "is" && value === null) {
             notNullFilters.push({ column });
           }
@@ -328,9 +491,13 @@ function createSupabaseMock(
           return builder;
         },
         then<TResult1 = unknown, TResult2 = never>(
-          onfulfilled?: ((value: { data: SignalPostRow[]; error: null; count: number }) => TResult1 | PromiseLike<TResult1>) | null,
+          onfulfilled?: ((value: { data: TestRow[]; error: { message: string } | null; count: number }) => TResult1 | PromiseLike<TResult1>) | null,
           onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
         ) {
+          if (selectError) {
+            return Promise.resolve({ data: [], error: selectError, count: 0 }).then(onfulfilled, onrejected);
+          }
+
           if (operation === "select" || operation === null) {
             return selectResult().then(onfulfilled, onrejected);
           }
@@ -344,9 +511,32 @@ function createSupabaseMock(
           }
 
           if (operation === "update") {
+            const updateError = options.updateErrors?.[tableName];
+
+            if (updateError) {
+              return Promise.resolve({ data: [], error: { message: updateError }, count: 0 }).then(onfulfilled, onrejected);
+            }
+
             applyFilters().forEach((row) => {
               Object.assign(row, updateValues);
             });
+
+            return Promise.resolve({ data: [], error: null, count: 0 }).then(onfulfilled, onrejected);
+          }
+
+          if (operation === "delete") {
+            const deleteError = options.deleteErrors?.[tableName];
+
+            if (deleteError) {
+              return Promise.resolve({ data: [], error: { message: deleteError }, count: 0 }).then(onfulfilled, onrejected);
+            }
+
+            const toDelete = new Set(applyFilters());
+            for (let index = tableRows.length - 1; index >= 0; index -= 1) {
+              if (toDelete.has(tableRows[index])) {
+                tableRows.splice(index, 1);
+              }
+            }
 
             return Promise.resolve({ data: [], error: null, count: 0 }).then(onfulfilled, onrejected);
           }
@@ -475,7 +665,8 @@ describe("signals editorial workflow", () => {
         updated_at: "2026-04-23T12:00:00.000Z",
       }),
     ];
-    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    const supabase = createSupabaseMock(rows);
+    createSupabaseServiceRoleClient.mockReturnValue(supabase);
     safeGetUser.mockResolvedValue({
       user: { id: "admin-1", email: "admin@example.com" },
       supabase: {},
@@ -495,9 +686,65 @@ describe("signals editorial workflow", () => {
     ]);
   });
 
+  it("loads the most recent published-slate audit history for admin review", async () => {
+    const rows = createValidFinalSlate();
+    const publishedSlates = [
+      createPublishedSlateRow({
+        id: "older-audit",
+        published_at: "2026-04-29T08:00:00.000Z",
+      }),
+      createPublishedSlateRow({
+        id: "latest-audit",
+        published_at: "2026-04-30T08:00:00.000Z",
+        published_by: "editor@example.com",
+        previous_live_row_ids: ["old-live-1", "old-live-2"],
+        published_row_ids: rows.map((row) => row.id),
+      }),
+    ];
+    const publishedSlateItems = rows.map((row) =>
+      createPublishedSlateItemRow({
+        id: `audit-item-${row.final_slate_rank}`,
+        published_slate_id: "latest-audit",
+        signal_post_id: row.id,
+        final_slate_rank: row.final_slate_rank ?? row.rank,
+        final_slate_tier: row.final_slate_tier ?? "core",
+        title_snapshot: row.title,
+        why_it_matters_snapshot: row.edited_why_it_matters ?? "",
+        source_name_snapshot: row.source_name,
+        replacement_of_row_id_snapshot: row.rank === 5 ? "held-original" : null,
+      }),
+    );
+    createSupabaseServiceRoleClient.mockReturnValue(
+      createSupabaseMock(rows, {
+        publishedSlates,
+        publishedSlateItems,
+      }),
+    );
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { getEditorialReviewState } = await loadEditorialModule();
+    const state = await getEditorialReviewState();
+
+    expect(state.kind).toBe("authorized");
+    if (state.kind !== "authorized") return;
+    expect(state.auditStorageReady).toBe(true);
+    expect(state.latestPublishedSlateAudit?.id).toBe("latest-audit");
+    expect(state.latestPublishedSlateAudit?.publishedBy).toBe("editor@example.com");
+    expect(state.latestPublishedSlateAudit?.previousLiveRowIds).toEqual(["old-live-1", "old-live-2"]);
+    expect(state.latestPublishedSlateAudit?.publishedRowIds).toEqual(rows.map((row) => row.id));
+    expect(state.latestPublishedSlateAudit?.items).toHaveLength(7);
+    expect(state.latestPublishedSlateAudit?.items.map((item) => item.finalSlateRank)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(state.latestPublishedSlateAudit?.items[4].replacementOfRowIdSnapshot).toBe("held-original");
+  });
+
   it("lets an admin save a draft", async () => {
     const rows = [createRow({ id: "signal-1" })];
-    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    const supabase = createSupabaseMock(rows);
+    createSupabaseServiceRoleClient.mockReturnValue(supabase);
     safeGetUser.mockResolvedValue({
       user: { id: "admin-1", email: "admin@example.com" },
       supabase: {},
@@ -520,7 +767,8 @@ describe("signals editorial workflow", () => {
 
   it("stores structured editorial draft content while preserving legacy text output", async () => {
     const rows = [createRow({ id: "signal-1" })];
-    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    const supabase = createSupabaseMock(rows);
+    createSupabaseServiceRoleClient.mockReturnValue(supabase);
     safeGetUser.mockResolvedValue({
       user: { id: "admin-1", email: "admin@example.com" },
       supabase: {},
@@ -778,7 +1026,8 @@ describe("signals editorial workflow", () => {
 
   it("blocks final-slate publishing when fewer than seven rows are selected", async () => {
     const rows = createValidFinalSlate().slice(0, 3);
-    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    const supabase = createSupabaseMock(rows);
+    createSupabaseServiceRoleClient.mockReturnValue(supabase);
     safeGetUser.mockResolvedValue({
       user: { id: "admin-1", email: "admin@example.com" },
       supabase: {},
@@ -796,6 +1045,60 @@ describe("signals editorial workflow", () => {
     expect(rows.every((row) => row.editorial_status === "approved")).toBe(true);
     expect(rows.every((row) => row.is_live === false)).toBe(true);
     expect(rows.every((row) => row.published_at === null)).toBe(true);
+    expect(supabase.publishedSlates).toHaveLength(0);
+    expect(supabase.publishedSlateItems).toHaveLength(0);
+  });
+
+  it("blocks final-slate publishing before writes when audit storage is unavailable", async () => {
+    const rows = createValidFinalSlate();
+    const supabase = createSupabaseMock(rows, {
+      missingRelations: ["published_slates"],
+    });
+    createSupabaseServiceRoleClient.mockReturnValue(supabase);
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { publishApprovedSignals } = await loadEditorialModule();
+    const result = await publishApprovedSignals();
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("storage_unavailable");
+    expect(result.message).toContain("published_slate audit schema preflight failed");
+    expect(rows.every((row) => row.editorial_status === "approved")).toBe(true);
+    expect(rows.every((row) => row.is_live === false)).toBe(true);
+    expect(rows.every((row) => row.published_at === null)).toBe(true);
+    expect(supabase.publishedSlates).toHaveLength(0);
+    expect(supabase.publishedSlateItems).toHaveLength(0);
+  });
+
+  it("fails closed when audit creation fails before public publish writes", async () => {
+    const rows = createValidFinalSlate();
+    const supabase = createSupabaseMock(rows, {
+      insertErrors: {
+        published_slates: "audit insert failed",
+      },
+    });
+    createSupabaseServiceRoleClient.mockReturnValue(supabase);
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { publishApprovedSignals } = await loadEditorialModule();
+    const result = await publishApprovedSignals();
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("storage_error");
+    expect(result.message).toContain("The published slate audit record could not be created.");
+    expect(rows.every((row) => row.editorial_status === "approved")).toBe(true);
+    expect(rows.every((row) => row.is_live === false)).toBe(true);
+    expect(rows.every((row) => row.published_at === null)).toBe(true);
+    expect(supabase.publishedSlates).toHaveLength(0);
+    expect(supabase.publishedSlateItems).toHaveLength(0);
   });
 
   it.each([
@@ -933,7 +1236,8 @@ describe("signals editorial workflow", () => {
         editorial_decision: "approved",
       }),
     ];
-    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    const supabase = createSupabaseMock(rows);
+    createSupabaseServiceRoleClient.mockReturnValue(supabase);
     safeGetUser.mockResolvedValue({
       user: { id: "admin-1", email: "admin@example.com" },
       supabase: {},
@@ -954,6 +1258,26 @@ describe("signals editorial workflow", () => {
     expect(rows[8].editorial_status).toBe("approved");
     expect(rows[8].published_why_it_matters).toBeNull();
     expect(rows[8].is_live).toBe(false);
+    expect(supabase.publishedSlates).toHaveLength(1);
+    expect(supabase.publishedSlateItems).toHaveLength(7);
+    expect(supabase.publishedSlates[0]).toMatchObject({
+      published_by: "admin@example.com",
+      row_count: 7,
+      core_count: 5,
+      context_count: 2,
+      previous_live_row_ids: [],
+      published_row_ids: rows.slice(0, 7).map((row) => row.id),
+    });
+    expect(supabase.publishedSlateItems.map((item) => item.final_slate_rank)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(supabase.publishedSlateItems[4]).toMatchObject({
+      signal_post_id: "promoted-rank-8",
+      final_slate_rank: 5,
+      final_slate_tier: "core",
+      title_snapshot: "Signal 8",
+      why_it_matters_snapshot: createValidWhyItMatters("Promoted replacement"),
+      source_name_snapshot: "Source",
+      editorial_decision_snapshot: "approved",
+    });
   });
 
   it("keeps live-set replacement inside the explicit publish workflow", async () => {
@@ -981,7 +1305,8 @@ describe("signals editorial workflow", () => {
       ),
     );
     const rows = [...oldLiveRows, ...approvedRows];
-    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    const supabase = createSupabaseMock(rows);
+    createSupabaseServiceRoleClient.mockReturnValue(supabase);
     safeGetUser.mockResolvedValue({
       user: { id: "admin-1", email: "admin@example.com" },
       supabase: {},
@@ -992,12 +1317,20 @@ describe("signals editorial workflow", () => {
     const result = await publishApprovedSignals();
 
     expect(result.ok).toBe(true);
-    expect(result.message).toBe("Published final slate: 5 Core + 2 Context rows are live. Archived 7 previous live rows.");
+    expect(result.message).toBe(
+      "Published final slate: 5 Core + 2 Context rows are live. Archived 7 previous live rows. Audit record published-slate-1.",
+    );
+    expect(result.publishedSlateId).toBe("published-slate-1");
     expect(oldLiveRows.every((row) => row.is_live === false)).toBe(true);
     expect(approvedRows.every((row) => row.editorial_status === "published")).toBe(true);
     expect(approvedRows.every((row) => row.is_live === true)).toBe(true);
     expect(approvedRows.every((row) => row.published_at !== null)).toBe(true);
     expect(approvedRows[0].published_why_it_matters).toBe(createValidWhyItMatters("New Google 1"));
+    expect(supabase.publishedSlates).toHaveLength(1);
+    expect(supabase.publishedSlates[0].previous_live_row_ids).toEqual(oldLiveRows.map((row) => row.id));
+    expect(supabase.publishedSlates[0].published_row_ids).toEqual(approvedRows.map((row) => row.id));
+    expect(supabase.publishedSlateItems).toHaveLength(7);
+    expect(supabase.publishedSlateItems.map((item) => item.signal_post_id)).toEqual(approvedRows.map((row) => row.id));
     await expect(getPublishedSignalPosts()).resolves.toHaveLength(7);
   });
 
@@ -1713,6 +2046,33 @@ describe("signals editorial workflow", () => {
       depthPosts: [],
       briefingDate: null,
     });
+  });
+
+  it("keeps published-slate audit tables out of public read helpers", async () => {
+    const tableCalls: TestTableName[] = [];
+    const rows = createValidFinalSlate().map((row) => ({
+      ...row,
+      editorial_status: "published" as const,
+      published_why_it_matters: row.edited_why_it_matters,
+      is_live: true,
+      published_at: "2026-04-30T08:00:00.000Z",
+    }));
+    createSupabaseServiceRoleClient.mockReturnValue(
+      createSupabaseMock(rows, {
+        publishedSlates: [createPublishedSlateRow({ id: "audit-should-not-be-public" })],
+        onFrom: (tableName) => tableCalls.push(tableName),
+      }),
+    );
+
+    const { getPublishedSignalPosts, getHomepageSignalSnapshot } = await loadEditorialModule();
+    await getPublishedSignalPosts();
+    await getHomepageSignalSnapshot({
+      today: new Date("2026-04-30T12:00:00.000Z"),
+    });
+
+    expect(tableCalls).toContain("signal_posts");
+    expect(tableCalls).not.toContain("published_slates");
+    expect(tableCalls).not.toContain("published_slate_items");
   });
 
   it("keeps rejected, held, and rewrite-requested rows out of public signal reads", async () => {

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -72,6 +72,44 @@ const SIGNAL_POST_REQUIRED_COLUMNS = [
 
 const SIGNAL_POST_SELECT = SIGNAL_POST_REQUIRED_COLUMNS.join(", ");
 
+const PUBLISHED_SLATE_REQUIRED_COLUMNS = [
+  "id",
+  "published_at",
+  "published_by",
+  "row_count",
+  "core_count",
+  "context_count",
+  "previous_live_row_ids",
+  "published_row_ids",
+  "rollback_note",
+  "verification_checklist_json",
+  "created_at",
+];
+
+const PUBLISHED_SLATE_ITEM_REQUIRED_COLUMNS = [
+  "id",
+  "published_slate_id",
+  "signal_post_id",
+  "final_slate_rank",
+  "final_slate_tier",
+  "title_snapshot",
+  "why_it_matters_snapshot",
+  "summary_snapshot",
+  "source_name_snapshot",
+  "source_url_snapshot",
+  "editorial_decision_snapshot",
+  "replacement_of_row_id_snapshot",
+  "decision_note_snapshot",
+  "held_reason_snapshot",
+  "rejected_reason_snapshot",
+  "reviewed_by_snapshot",
+  "reviewed_at_snapshot",
+  "created_at",
+];
+
+const PUBLISHED_SLATE_SELECT = PUBLISHED_SLATE_REQUIRED_COLUMNS.join(", ");
+const PUBLISHED_SLATE_ITEM_SELECT = PUBLISHED_SLATE_ITEM_REQUIRED_COLUMNS.join(", ");
+
 const EDITORIAL_PAGE_SIZE = 20;
 const SIGNAL_POST_CANDIDATE_DEPTH_LIMIT = 20;
 const TOP_SIGNAL_SET_SIZE = 5;
@@ -123,6 +161,48 @@ type StoredSignalPost = {
   updated_at: string | null;
 };
 
+type StoredPublishedSlate = {
+  id: string;
+  published_at: string;
+  published_by: string | null;
+  row_count: number;
+  core_count: number;
+  context_count: number;
+  previous_live_row_ids: unknown;
+  published_row_ids: unknown;
+  rollback_note: string | null;
+  verification_checklist_json: unknown;
+  created_at: string | null;
+};
+
+type StoredPublishedSlateItem = {
+  id: string;
+  published_slate_id: string;
+  signal_post_id: string;
+  final_slate_rank: number;
+  final_slate_tier: FinalSlateTier;
+  title_snapshot: string;
+  why_it_matters_snapshot: string;
+  summary_snapshot: string | null;
+  source_name_snapshot: string | null;
+  source_url_snapshot: string | null;
+  editorial_decision_snapshot: EditorialDecision | null;
+  replacement_of_row_id_snapshot: string | null;
+  decision_note_snapshot: string | null;
+  held_reason_snapshot: string | null;
+  rejected_reason_snapshot: string | null;
+  reviewed_by_snapshot: string | null;
+  reviewed_at_snapshot: string | null;
+  created_at: string | null;
+};
+
+type FinalSlatePublicationCandidate = {
+  post: EditorialSignalPost;
+  structuredContent: EditorialWhyItMattersContent | null;
+  text: string;
+  validation: WhyItMattersValidationResult;
+};
+
 export type EditorialSignalPost = {
   id: string;
   briefingDate: string | null;
@@ -164,6 +244,47 @@ export type EditorialSignalPost = {
   persisted: boolean;
 };
 
+export type PublishedSlateVerificationChecklist = {
+  status: "not_run";
+  items: string[];
+};
+
+export type PublishedSlateAuditItem = {
+  id: string;
+  publishedSlateId: string;
+  signalPostId: string;
+  finalSlateRank: number;
+  finalSlateTier: FinalSlateTier;
+  titleSnapshot: string;
+  whyItMattersSnapshot: string;
+  summarySnapshot: string;
+  sourceNameSnapshot: string;
+  sourceUrlSnapshot: string;
+  editorialDecisionSnapshot: EditorialDecision | null;
+  replacementOfRowIdSnapshot: string | null;
+  decisionNoteSnapshot: string | null;
+  heldReasonSnapshot: string | null;
+  rejectedReasonSnapshot: string | null;
+  reviewedBySnapshot: string | null;
+  reviewedAtSnapshot: string | null;
+  createdAt: string | null;
+};
+
+export type PublishedSlateAudit = {
+  id: string;
+  publishedAt: string;
+  publishedBy: string | null;
+  rowCount: number;
+  coreCount: number;
+  contextCount: number;
+  previousLiveRowIds: string[];
+  publishedRowIds: string[];
+  rollbackNote: string | null;
+  verificationChecklist: PublishedSlateVerificationChecklist | null;
+  createdAt: string | null;
+  items: PublishedSlateAuditItem[];
+};
+
 export type EditorialPostStatusFilter = "all" | "review" | EditorialStatus;
 export type EditorialScopeFilter = "all" | "current" | "historical";
 
@@ -196,6 +317,9 @@ export type EditorialReviewState =
       pageSize: number;
       totalMatchingPosts: number;
       latestBriefingDate: string | null;
+      latestPublishedSlateAudit: PublishedSlateAudit | null;
+      auditStorageReady: boolean;
+      auditWarning: string | null;
       appliedScope: EditorialScopeFilter;
       appliedStatus: EditorialPostStatusFilter;
       appliedQuery: string;
@@ -205,6 +329,7 @@ export type EditorialReviewState =
 export type EditorialMutationResult = {
   ok: boolean;
   message: string;
+  publishedSlateId?: string;
   code:
     | "approved"
     | "bulk_approved"
@@ -255,18 +380,28 @@ type SignalPostsSchemaPreflightResult =
     };
 
 let signalPostsSchemaPreflightPromise: Promise<SignalPostsSchemaPreflightResult> | null = null;
+let publishedSlateAuditSchemaPreflightPromise: Promise<SignalPostsSchemaPreflightResult> | null = null;
 
-function buildSignalPostsSchemaPreflightFailure(missingColumns: string[]): SignalPostsSchemaPreflightResult {
+function buildSchemaPreflightFailure(label: string, missingColumns: string[]): SignalPostsSchemaPreflightResult {
   return {
     ok: false,
     missingColumns,
-    message: `signal_posts schema preflight failed. Missing expected columns: ${missingColumns.join(", ")}.`,
+    message: `${label} schema preflight failed. Missing expected columns: ${missingColumns.join(", ")}.`,
   };
 }
 
-function isMissingColumnError(error: unknown, column: string) {
+function buildSignalPostsSchemaPreflightFailure(missingColumns: string[]): SignalPostsSchemaPreflightResult {
+  return buildSchemaPreflightFailure("signal_posts", missingColumns);
+}
+
+function buildPublishedSlateAuditSchemaPreflightFailure(missingColumns: string[]): SignalPostsSchemaPreflightResult {
+  return buildSchemaPreflightFailure("published_slate audit", missingColumns);
+}
+
+function isMissingColumnError(error: unknown, column: string, tableName = "signal_posts") {
   const maybeError = error as { code?: unknown; message?: unknown; details?: unknown; hint?: unknown };
   const normalizedColumn = column.toLowerCase();
+  const normalizedTableName = tableName.toLowerCase();
   const haystack = [
     maybeError.code,
     maybeError.message,
@@ -280,10 +415,30 @@ function isMissingColumnError(error: unknown, column: string) {
   return (
     haystack.includes("42703") ||
     (haystack.includes("does not exist") &&
-      (haystack.includes(normalizedColumn) || haystack.includes(`signal_posts.${normalizedColumn}`))) ||
+      (haystack.includes(normalizedColumn) || haystack.includes(`${normalizedTableName}.${normalizedColumn}`))) ||
     (haystack.includes("could not find") &&
       haystack.includes(normalizedColumn) &&
       haystack.includes("column"))
+  );
+}
+
+function isMissingRelationError(error: unknown, tableName: string) {
+  const maybeError = error as { code?: unknown; message?: unknown; details?: unknown; hint?: unknown };
+  const normalizedTableName = tableName.toLowerCase();
+  const haystack = [
+    maybeError.code,
+    maybeError.message,
+    maybeError.details,
+    maybeError.hint,
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ")
+    .toLowerCase();
+
+  return (
+    haystack.includes("42p01") ||
+    (haystack.includes("does not exist") && haystack.includes(normalizedTableName)) ||
+    (haystack.includes("could not find") && haystack.includes(normalizedTableName))
   );
 }
 
@@ -334,6 +489,74 @@ function getSignalPostsSchemaPreflight(
 ): Promise<SignalPostsSchemaPreflightResult> {
   signalPostsSchemaPreflightPromise ??= runSignalPostsSchemaPreflight(client);
   return signalPostsSchemaPreflightPromise;
+}
+
+async function runPublishedSlateAuditSchemaPreflight(
+  client: EditorialClient,
+): Promise<SignalPostsSchemaPreflightResult> {
+  const missingColumns: string[] = [];
+  const errorMessages: string[] = [];
+  const nonSchemaErrorMessages: string[] = [];
+  const requiredChecks = [
+    {
+      tableName: "published_slates",
+      columns: PUBLISHED_SLATE_REQUIRED_COLUMNS,
+    },
+    {
+      tableName: "published_slate_items",
+      columns: PUBLISHED_SLATE_ITEM_REQUIRED_COLUMNS,
+    },
+  ];
+
+  for (const check of requiredChecks) {
+    for (const column of check.columns) {
+      const result = await client.from(check.tableName).select(column).limit(0);
+      const qualifiedColumn = `${check.tableName}.${column}`;
+
+      if (result.error && isMissingRelationError(result.error, check.tableName)) {
+        missingColumns.push(`${check.tableName}.*`);
+        errorMessages.push(`${check.tableName}: ${result.error.message}`);
+        break;
+      }
+
+      if (result.error && isMissingColumnError(result.error, column, check.tableName)) {
+        missingColumns.push(qualifiedColumn);
+        errorMessages.push(`${qualifiedColumn}: ${result.error.message}`);
+      } else if (result.error) {
+        nonSchemaErrorMessages.push(`${qualifiedColumn}: ${result.error.message}`);
+      }
+    }
+  }
+
+  if (nonSchemaErrorMessages.length > 0 && missingColumns.length === 0) {
+    logServerEvent("warn", "published slate audit schema preflight could not verify columns", {
+      errorMessages: nonSchemaErrorMessages,
+    });
+  }
+
+  if (missingColumns.length === 0) {
+    return {
+      ok: true,
+      missingColumns: [],
+      message: null,
+    };
+  }
+
+  const failure = buildPublishedSlateAuditSchemaPreflightFailure(missingColumns);
+
+  logServerEvent("error", "published slate audit schema preflight failed", {
+    missingColumns,
+    errorMessages,
+  });
+
+  return failure;
+}
+
+function getPublishedSlateAuditSchemaPreflight(
+  client: EditorialClient,
+): Promise<SignalPostsSchemaPreflightResult> {
+  publishedSlateAuditSchemaPreflightPromise ??= runPublishedSlateAuditSchemaPreflight(client);
+  return publishedSlateAuditSchemaPreflightPromise;
 }
 
 function normalizeEditorialText(value: string | null | undefined) {
@@ -435,6 +658,86 @@ function mapStoredSignalPost(row: StoredSignalPost): EditorialSignalPost {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     persisted: true,
+  };
+}
+
+function normalizeStringArrayFromJson(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === "string");
+  }
+
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      return normalizeStringArrayFromJson(parsed);
+    } catch {
+      return [];
+    }
+  }
+
+  return [];
+}
+
+function parsePublishedSlateVerificationChecklist(value: unknown): PublishedSlateVerificationChecklist | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const candidate = value as { status?: unknown; items?: unknown };
+
+  if (candidate.status !== "not_run" || !Array.isArray(candidate.items)) {
+    return null;
+  }
+
+  return {
+    status: "not_run",
+    items: candidate.items.filter((item): item is string => typeof item === "string"),
+  };
+}
+
+function mapStoredPublishedSlateItem(row: StoredPublishedSlateItem): PublishedSlateAuditItem {
+  return {
+    id: row.id,
+    publishedSlateId: row.published_slate_id,
+    signalPostId: row.signal_post_id,
+    finalSlateRank: row.final_slate_rank,
+    finalSlateTier: row.final_slate_tier,
+    titleSnapshot: row.title_snapshot,
+    whyItMattersSnapshot: row.why_it_matters_snapshot,
+    summarySnapshot: row.summary_snapshot ?? "",
+    sourceNameSnapshot: row.source_name_snapshot ?? "",
+    sourceUrlSnapshot: row.source_url_snapshot ?? "",
+    editorialDecisionSnapshot: row.editorial_decision_snapshot,
+    replacementOfRowIdSnapshot: row.replacement_of_row_id_snapshot,
+    decisionNoteSnapshot: row.decision_note_snapshot,
+    heldReasonSnapshot: row.held_reason_snapshot,
+    rejectedReasonSnapshot: row.rejected_reason_snapshot,
+    reviewedBySnapshot: row.reviewed_by_snapshot,
+    reviewedAtSnapshot: row.reviewed_at_snapshot,
+    createdAt: row.created_at,
+  };
+}
+
+function mapStoredPublishedSlate(
+  row: StoredPublishedSlate,
+  items: StoredPublishedSlateItem[],
+): PublishedSlateAudit {
+  return {
+    id: row.id,
+    publishedAt: row.published_at,
+    publishedBy: row.published_by,
+    rowCount: row.row_count,
+    coreCount: row.core_count,
+    contextCount: row.context_count,
+    previousLiveRowIds: normalizeStringArrayFromJson(row.previous_live_row_ids),
+    publishedRowIds: normalizeStringArrayFromJson(row.published_row_ids),
+    rollbackNote: row.rollback_note,
+    verificationChecklist: parsePublishedSlateVerificationChecklist(row.verification_checklist_json),
+    createdAt: row.created_at,
+    items: items
+      .slice()
+      .sort((left, right) => left.final_slate_rank - right.final_slate_rank)
+      .map(mapStoredPublishedSlateItem),
   };
 }
 
@@ -874,6 +1177,54 @@ async function loadCurrentSignalDepth(client: EditorialClient, briefingDate: str
   return ((result.data ?? []) as unknown as StoredSignalPost[]).map(mapStoredSignalPost);
 }
 
+async function loadLatestPublishedSlateAudit(client: EditorialClient): Promise<{
+  audit: PublishedSlateAudit | null;
+  errorMessage: string | null;
+}> {
+  const slateResult = await client
+    .from("published_slates")
+    .select(PUBLISHED_SLATE_SELECT)
+    .order("published_at", { ascending: false })
+    .limit(1);
+
+  if (slateResult.error) {
+    return {
+      audit: null,
+      errorMessage: slateResult.error.message,
+    };
+  }
+
+  const slate = ((slateResult.data ?? []) as unknown as StoredPublishedSlate[])[0];
+
+  if (!slate) {
+    return {
+      audit: null,
+      errorMessage: null,
+    };
+  }
+
+  const itemResult = await client
+    .from("published_slate_items")
+    .select(PUBLISHED_SLATE_ITEM_SELECT)
+    .eq("published_slate_id", slate.id)
+    .order("final_slate_rank", { ascending: true });
+
+  if (itemResult.error) {
+    return {
+      audit: null,
+      errorMessage: itemResult.error.message,
+    };
+  }
+
+  return {
+    audit: mapStoredPublishedSlate(
+      slate,
+      (itemResult.data ?? []) as unknown as StoredPublishedSlateItem[],
+    ),
+    errorMessage: null,
+  };
+}
+
 function selectPublishedEditorialWhyItMatters(post: EditorialSignalPost) {
   if (post.editorialStatus !== "published") {
     return "";
@@ -1077,6 +1428,9 @@ export async function getEditorialReviewState(
       pageSize: EDITORIAL_PAGE_SIZE,
       totalMatchingPosts: 0,
       latestBriefingDate: null,
+      latestPublishedSlateAudit: null,
+      auditStorageReady: false,
+      auditWarning: context.message,
       appliedScope: normalizedScope,
       appliedStatus: normalizedStatus,
       appliedQuery: normalizedQuery,
@@ -1099,6 +1453,9 @@ export async function getEditorialReviewState(
       pageSize: EDITORIAL_PAGE_SIZE,
       totalMatchingPosts: 0,
       latestBriefingDate: null,
+      latestPublishedSlateAudit: null,
+      auditStorageReady: false,
+      auditWarning: schemaPreflight.message,
       appliedScope: normalizedScope,
       appliedStatus: normalizedStatus,
       appliedQuery: normalizedQuery,
@@ -1108,6 +1465,10 @@ export async function getEditorialReviewState(
 
   const latest = await getLatestBriefingDate(context.client);
   const latestBriefingDate = latest.latestBriefingDate;
+  const auditSchemaPreflight = await getPublishedSlateAuditSchemaPreflight(context.client);
+  const latestAudit = auditSchemaPreflight.ok
+    ? await loadLatestPublishedSlateAudit(context.client)
+    : { audit: null, errorMessage: auditSchemaPreflight.message };
   const loaded = await loadStoredSignalPosts(context.client, {
     status: normalizedStatus,
     scope: normalizedScope,
@@ -1121,6 +1482,13 @@ export async function getEditorialReviewState(
     logServerEvent("warn", "Editorial latest briefing date could not be loaded", {
       route,
       errorMessage: latest.errorMessage,
+    });
+  }
+
+  if (latestAudit.errorMessage) {
+    logServerEvent("warn", "Published slate audit history could not be loaded", {
+      route,
+      errorMessage: latestAudit.errorMessage,
     });
   }
 
@@ -1142,6 +1510,11 @@ export async function getEditorialReviewState(
       pageSize: EDITORIAL_PAGE_SIZE,
       totalMatchingPosts: 0,
       latestBriefingDate,
+      latestPublishedSlateAudit: latestAudit.audit,
+      auditStorageReady: auditSchemaPreflight.ok,
+      auditWarning: latestAudit.errorMessage
+        ? `Published slate audit history could not be read: ${latestAudit.errorMessage}`
+        : null,
       appliedScope: normalizedScope,
       appliedStatus: normalizedStatus,
       appliedQuery: normalizedQuery,
@@ -1157,6 +1530,9 @@ export async function getEditorialReviewState(
       : null,
     getEditorialStorageWarning(loaded.totalCount, normalizedScope),
   ].filter(Boolean);
+  const auditWarning = latestAudit.errorMessage
+    ? `Published slate audit history could not be read: ${latestAudit.errorMessage}`
+    : null;
 
   return {
     kind: "authorized",
@@ -1170,6 +1546,9 @@ export async function getEditorialReviewState(
     pageSize: EDITORIAL_PAGE_SIZE,
     totalMatchingPosts: loaded.totalCount,
     latestBriefingDate,
+    latestPublishedSlateAudit: latestAudit.audit,
+    auditStorageReady: auditSchemaPreflight.ok,
+    auditWarning,
     appliedScope: normalizedScope,
     appliedStatus: normalizedStatus,
     appliedQuery: normalizedQuery,
@@ -2159,6 +2538,16 @@ export async function publishApprovedSignals(input: {
     };
   }
 
+  const auditSchemaPreflight = await getPublishedSlateAuditSchemaPreflight(context.client);
+
+  if (!auditSchemaPreflight.ok) {
+    return {
+      ok: false,
+      code: "storage_unavailable",
+      message: auditSchemaPreflight.message,
+    };
+  }
+
   const latest = await getLatestBriefingDate(context.client);
 
   if (latest.errorMessage) {
@@ -2272,6 +2661,30 @@ export async function publishApprovedSignals(input: {
     .map((row) => row.id)
     .filter((id): id is string => Boolean(id));
   const selectedPostIds = publicationCandidates.map((entry) => entry.post.id);
+  const auditResult = await createPublishedSlateAudit(context.client, {
+    publicationCandidates,
+    previousLiveIds,
+    publishedAt: now,
+    publishedBy: context.user.email ?? null,
+  });
+
+  if (!auditResult.ok) {
+    captureRssEditorialStorageFailure({
+      failureType: "rss_cache_write_failed",
+      phase: "publish",
+      operation: "create_published_slate_audit",
+      route: input.route ?? SIGNALS_EDITORIAL_ROUTE,
+      briefingDate: latest.latestBriefingDate,
+      postCount: publicationCandidates.length,
+      message: "Published slate audit record could not be created before publishing.",
+    });
+
+    return {
+      ok: false,
+      code: "storage_error",
+      message: `The published slate audit record could not be created. No rows were changed. ${auditResult.message}`,
+    };
+  }
 
   if (previousLiveIds.length > 0) {
     const deactivateOldLiveSet = await context.client
@@ -2291,6 +2704,7 @@ export async function publishApprovedSignals(input: {
         briefingDate: latest.latestBriefingDate,
         message: "Previous live RSS signal set could not be archived before publishing.",
       });
+      await deletePublishedSlateAudit(context.client, auditResult.publishedSlateId);
 
       return {
         ok: false,
@@ -2324,6 +2738,7 @@ export async function publishApprovedSignals(input: {
       selectedPostIds,
       now,
     });
+    await deletePublishedSlateAudit(context.client, auditResult.publishedSlateId);
 
     captureRssEditorialStorageFailure({
       failureType: "rss_cache_write_failed",
@@ -2345,10 +2760,11 @@ export async function publishApprovedSignals(input: {
   return {
     ok: true,
     code: "published",
+    publishedSlateId: auditResult.publishedSlateId,
     message:
       previousLiveIds.length > 0
-        ? `Published final slate: 5 Core + 2 Context rows are live. Archived ${previousLiveIds.length} previous live rows.`
-        : "Published final slate: 5 Core + 2 Context rows are live. No previous live slate was present to archive.",
+        ? `Published final slate: 5 Core + 2 Context rows are live. Archived ${previousLiveIds.length} previous live rows. Audit record ${auditResult.publishedSlateId}.`
+        : `Published final slate: 5 Core + 2 Context rows are live. No previous live slate was present to archive. Audit record ${auditResult.publishedSlateId}.`,
   };
 }
 
@@ -2394,6 +2810,136 @@ async function rollbackFailedFinalSlatePublish(
   ]);
 
   return rollbackResults.every((result) => !result.error);
+}
+
+function buildPublishedSlateVerificationChecklist(): PublishedSlateVerificationChecklist {
+  return {
+    status: "not_run",
+    items: [
+      "Homepage returns 200 and shows Core slots 1-5.",
+      "/signals returns 200 and shows Core slots 1-5 plus Context slots 6-7.",
+      "Database has exactly 7 live rows for the new slate.",
+      "Held, rejected, rewrite-requested, Depth, rank-8, and unpublished rows stay hidden.",
+      "Cron remains disabled.",
+    ],
+  };
+}
+
+function buildRollbackPreparationNote(input: {
+  publishedRowIds: string[];
+  previousLiveRowIds: string[];
+}) {
+  return input.previousLiveRowIds.length > 0
+    ? "Rollback execution is not implemented in this phase. This audit record identifies the newly published rows to un-live and the archived previous live rows to restore."
+    : "Rollback execution is not implemented in this phase. This audit record identifies the newly published rows to un-live; no previous live slate existed at publish time.";
+}
+
+async function deletePublishedSlateAudit(client: EditorialClient, publishedSlateId: string) {
+  const deleteResult = await client
+    .from("published_slates")
+    .delete()
+    .eq("id", publishedSlateId);
+
+  if (deleteResult.error) {
+    logServerEvent("warn", "Published slate audit cleanup failed after publish rollback", {
+      publishedSlateId,
+      errorMessage: deleteResult.error.message,
+    });
+  }
+}
+
+async function createPublishedSlateAudit(
+  client: EditorialClient,
+  input: {
+    publicationCandidates: FinalSlatePublicationCandidate[];
+    previousLiveIds: string[];
+    publishedAt: string;
+    publishedBy: string | null;
+  },
+): Promise<
+  | {
+      ok: true;
+      publishedSlateId: string;
+    }
+  | {
+      ok: false;
+      message: string;
+    }
+> {
+  const publishedRowIds = input.publicationCandidates.map((entry) => entry.post.id);
+  const coreCount = input.publicationCandidates.filter((entry) => entry.post.finalSlateTier === "core").length;
+  const contextCount = input.publicationCandidates.filter((entry) => entry.post.finalSlateTier === "context").length;
+  const insertSlateResult = await client
+    .from("published_slates")
+    .insert({
+      published_at: input.publishedAt,
+      published_by: input.publishedBy,
+      row_count: input.publicationCandidates.length,
+      core_count: coreCount,
+      context_count: contextCount,
+      previous_live_row_ids: input.previousLiveIds,
+      published_row_ids: publishedRowIds,
+      rollback_note: buildRollbackPreparationNote({
+        publishedRowIds,
+        previousLiveRowIds: input.previousLiveIds,
+      }),
+      verification_checklist_json: buildPublishedSlateVerificationChecklist(),
+      created_at: input.publishedAt,
+    })
+    .select("id")
+    .maybeSingle();
+
+  if (insertSlateResult.error || !insertSlateResult.data) {
+    return {
+      ok: false,
+      message: insertSlateResult.error?.message ?? "The published slate audit record did not return an id.",
+    };
+  }
+
+  const publishedSlateId = ((insertSlateResult.data ?? {}) as { id?: string | null }).id;
+
+  if (!publishedSlateId) {
+    return {
+      ok: false,
+      message: "The published slate audit record did not return an id.",
+    };
+  }
+
+  const itemRows = input.publicationCandidates.map((entry) => ({
+    published_slate_id: publishedSlateId,
+    signal_post_id: entry.post.id,
+    final_slate_rank: entry.post.finalSlateRank,
+    final_slate_tier: entry.post.finalSlateTier,
+    title_snapshot: entry.post.title,
+    why_it_matters_snapshot: entry.text,
+    summary_snapshot: entry.post.summary || null,
+    source_name_snapshot: entry.post.sourceName || null,
+    source_url_snapshot: entry.post.sourceUrl || null,
+    editorial_decision_snapshot: entry.post.editorialDecision,
+    replacement_of_row_id_snapshot: entry.post.replacementOfRowId,
+    decision_note_snapshot: entry.post.decisionNote,
+    held_reason_snapshot: entry.post.heldReason,
+    rejected_reason_snapshot: entry.post.rejectedReason,
+    reviewed_by_snapshot: entry.post.reviewedBy,
+    reviewed_at_snapshot: entry.post.reviewedAt,
+    created_at: input.publishedAt,
+  }));
+
+  const insertItemsResult = await client.from("published_slate_items").insert(itemRows);
+
+  if (insertItemsResult.error) {
+    await deletePublishedSlateAudit(client, publishedSlateId);
+
+    return {
+      ok: false,
+      message: insertItemsResult.error.message,
+    };
+  }
+
+  return {
+    ok: true,
+    publishedSlateId,
+  };
 }
 
 export async function publishSignalPost(input: {

--- a/supabase/migrations/20260430120000_published_slates_minimal_audit_history.sql
+++ b/supabase/migrations/20260430120000_published_slates_minimal_audit_history.sql
@@ -1,0 +1,88 @@
+create table if not exists public.published_slates (
+  id uuid primary key default gen_random_uuid(),
+  published_at timestamptz not null,
+  published_by text,
+  row_count integer not null check (row_count >= 0),
+  core_count integer not null check (core_count >= 0),
+  context_count integer not null check (context_count >= 0),
+  previous_live_row_ids jsonb not null default '[]'::jsonb,
+  published_row_ids jsonb not null default '[]'::jsonb,
+  rollback_note text,
+  verification_checklist_json jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.published_slate_items (
+  id uuid primary key default gen_random_uuid(),
+  published_slate_id uuid not null references public.published_slates(id) on delete cascade,
+  signal_post_id uuid not null references public.signal_posts(id) on delete restrict,
+  final_slate_rank integer not null check (final_slate_rank between 1 and 7),
+  final_slate_tier text not null check (final_slate_tier in ('core', 'context')),
+  title_snapshot text not null,
+  why_it_matters_snapshot text not null default '',
+  summary_snapshot text,
+  source_name_snapshot text,
+  source_url_snapshot text,
+  editorial_decision_snapshot text,
+  replacement_of_row_id_snapshot uuid,
+  decision_note_snapshot text,
+  held_reason_snapshot text,
+  rejected_reason_snapshot text,
+  reviewed_by_snapshot text,
+  reviewed_at_snapshot timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create unique index if not exists published_slate_items_slate_rank_key
+on public.published_slate_items (published_slate_id, final_slate_rank);
+
+create index if not exists published_slate_items_signal_post_id_idx
+on public.published_slate_items (signal_post_id);
+
+create index if not exists published_slates_published_at_idx
+on public.published_slates (published_at desc);
+
+alter table public.published_slates enable row level security;
+alter table public.published_slate_items enable row level security;
+
+drop policy if exists "Service role reads published slates" on public.published_slates;
+create policy "Service role reads published slates"
+on public.published_slates
+for select
+to service_role
+using (true);
+
+drop policy if exists "Service role writes published slates" on public.published_slates;
+create policy "Service role writes published slates"
+on public.published_slates
+for insert
+to service_role
+with check (true);
+
+drop policy if exists "Service role deletes published slates" on public.published_slates;
+create policy "Service role deletes published slates"
+on public.published_slates
+for delete
+to service_role
+using (true);
+
+drop policy if exists "Service role reads published slate items" on public.published_slate_items;
+create policy "Service role reads published slate items"
+on public.published_slate_items
+for select
+to service_role
+using (true);
+
+drop policy if exists "Service role writes published slate items" on public.published_slate_items;
+create policy "Service role writes published slate items"
+on public.published_slate_items
+for insert
+to service_role
+with check (true);
+
+drop policy if exists "Service role deletes published slate items" on public.published_slate_items;
+create policy "Service role deletes published slate items"
+on public.published_slate_items
+for delete
+to service_role
+using (true);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -192,6 +192,50 @@ create unique index if not exists signal_posts_briefing_date_final_slate_rank_ke
 on public.signal_posts (briefing_date, final_slate_rank)
 where final_slate_rank is not null;
 
+create table if not exists public.published_slates (
+  id uuid primary key default gen_random_uuid(),
+  published_at timestamptz not null,
+  published_by text,
+  row_count integer not null check (row_count >= 0),
+  core_count integer not null check (core_count >= 0),
+  context_count integer not null check (context_count >= 0),
+  previous_live_row_ids jsonb not null default '[]'::jsonb,
+  published_row_ids jsonb not null default '[]'::jsonb,
+  rollback_note text,
+  verification_checklist_json jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.published_slate_items (
+  id uuid primary key default gen_random_uuid(),
+  published_slate_id uuid not null references public.published_slates(id) on delete cascade,
+  signal_post_id uuid not null references public.signal_posts(id) on delete restrict,
+  final_slate_rank integer not null check (final_slate_rank between 1 and 7),
+  final_slate_tier text not null check (final_slate_tier in ('core', 'context')),
+  title_snapshot text not null,
+  why_it_matters_snapshot text not null default '',
+  summary_snapshot text,
+  source_name_snapshot text,
+  source_url_snapshot text,
+  editorial_decision_snapshot text,
+  replacement_of_row_id_snapshot uuid,
+  decision_note_snapshot text,
+  held_reason_snapshot text,
+  rejected_reason_snapshot text,
+  reviewed_by_snapshot text,
+  reviewed_at_snapshot timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create unique index if not exists published_slate_items_slate_rank_key
+on public.published_slate_items (published_slate_id, final_slate_rank);
+
+create index if not exists published_slate_items_signal_post_id_idx
+on public.published_slate_items (signal_post_id);
+
+create index if not exists published_slates_published_at_idx
+on public.published_slates (published_at desc);
+
 create table if not exists public.pipeline_article_candidates (
   id uuid primary key default gen_random_uuid(),
   run_id text not null,
@@ -256,6 +300,8 @@ alter table public.daily_briefings enable row level security;
 alter table public.briefing_items enable row level security;
 alter table public.user_event_state enable row level security;
 alter table public.signal_posts enable row level security;
+alter table public.published_slates enable row level security;
+alter table public.published_slate_items enable row level security;
 alter table public.pipeline_article_candidates enable row level security;
 
 create policy "Users manage their own profile" on public.user_profiles
@@ -319,6 +365,24 @@ create policy "Service role updates pipeline article candidates" on public.pipel
   for update to service_role using (true) with check (true);
 
 create policy "Service role deletes pipeline article candidates" on public.pipeline_article_candidates
+  for delete to service_role using (true);
+
+create policy "Service role reads published slates" on public.published_slates
+  for select to service_role using (true);
+
+create policy "Service role writes published slates" on public.published_slates
+  for insert to service_role with check (true);
+
+create policy "Service role deletes published slates" on public.published_slates
+  for delete to service_role using (true);
+
+create policy "Service role reads published slate items" on public.published_slate_items
+  for select to service_role using (true);
+
+create policy "Service role writes published slate items" on public.published_slate_items
+  for insert to service_role with check (true);
+
+create policy "Service role deletes published slate items" on public.published_slate_items
   for delete to service_role using (true);
 
 drop trigger if exists set_signal_posts_updated_at on public.signal_posts;


### PR DESCRIPTION
## Summary

This PR implements the minimal internal published-slate audit/history layer for PRD-53.

It adds:
- additive `published_slates` and `published_slate_items` audit tables
- audit creation on successful supported final-slate publish
- seven published-slate item snapshots with final rank/tier, title, Why It Matters, summary, source metadata, decision metadata, and replacement metadata
- previous-live-row archive trace and published-row ID trace
- rollback preparation note and verification checklist metadata
- latest published-slate audit display inside the private Signals editorial admin page
- focused tests for audit creation, audit failure blocking, admin rendering, and public-read safety

## Effective change type

Feature implementation under the approved PRD-53 amendment.

## Source of truth

`docs/product/prd/prd-53-signals-admin-editorial-layer.md`

## Canonical PRD status

- PR #149 satisfied the canonical PRD-53 amendment requirement.
- PR #150 implemented the minimal final-slate composer.
- PR #151 implemented editorial card controls.
- PR #152 implemented seven-row publish hardening.
- No duplicate PRD was created.

## What changed

- Added minimal published-slate audit model.
- Wired audit creation into successful supported publish before public visibility writes.
- Added published-slate item snapshots for the exact 5 Core + 2 Context rows.
- Captured previous live row IDs for rollback preparation.
- Added admin latest-audit/history display.
- Added rollback preparation metadata/copy.
- Added tests for audit creation, audit blocking, admin display, and public-read isolation.

## What did not change

- No real production publish was performed.
- No cron change.
- No pipeline run.
- No `dry_run`.
- No `draft_only`.
- No production database mutation.
- No public history/archive surface.
- No source governance, ranking threshold, or WITM threshold change.
- No full historical snapshot/schema implementation.
- No Phase 2 architecture.
- No personalization.

## Validation

Passed:
- `git diff --check`
- `npm install` (completed; npm reported 2 existing vulnerability notices)
- `npm run lint`
- `npm run test -- src/lib/final-slate-readiness.test.ts src/lib/signals-editorial.test.ts src/app/dashboard/signals/editorial-review/page.test.tsx src/lib/homepage-editorial-overrides.test.ts` (97 tests passed)
- `npm run test` (572 tests passed)
- `npm run build`
- `python3 scripts/validate-feature-system-csv.py` (passed with pre-existing slug warnings)
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-minimal-published-slate-audit-history --pr-title "PRD-53 minimal published-slate audit history"`
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-minimal-published-slate-audit-history --pr-title "PRD-53 minimal published-slate audit history"`
- local dev server at `http://localhost:3000`
- `npx playwright test --project=chromium` (33 passed)
- `npx playwright test --project=webkit` after rerun (33 passed)

Caveat:
- First full WebKit run had one transient existing dashboard navigation failure; targeted rerun and full WebKit rerun passed.
- `./scripts/release-check.sh --install=never` passed dependency install, lint, and unit tests, then failed during build with local `ENOSPC: no space left on device` while writing webpack cache. After clearing generated local artifacts in this worktree, standalone `npm run build` passed again.

## Risks / follow-up

- This is minimal audit/history, not a full immutable editorial decision event log.
- Full rejected/held/rewrite/promote/demote event history remains later scope.
- Second controlled cycle remains next.
- MVP measurement instrumentation remains later.
- Final launch-readiness QA remains later.
- Cron remains last.

## Readiness label

`ready_for_prd_53_minimal_published_slate_audit_history_review`