### PR TITLE
PRD-53 second controlled cycle validation

### DIFF
--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-second-controlled-cycle.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-second-controlled-cycle.md
@@ -1,0 +1,349 @@
+# PRD-53 Second Controlled Cycle Validation
+
+Date: 2026-04-30
+Branch: `codex/prd-53-second-controlled-cycle-validation`
+Readiness label: `second_controlled_cycle_blocked`
+
+## Effective change type
+
+Remediation / alignment validation under the approved PRD-53 Signals admin editorial workflow.
+
+This validation packet does not implement a new feature and does not create a new PRD.
+
+## Source of truth
+
+Primary source:
+
+- `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+
+Secondary sources:
+
+- `docs/operations/tracker-sync/2026-04-30-prd-53-card-level-editorial-authority.md`
+- `docs/engineering/change-records/prd-53-minimal-final-slate-composer.md`
+- `docs/engineering/change-records/prd-53-editorial-card-controls.md`
+- `docs/engineering/change-records/prd-53-seven-row-publish-hardening.md`
+- `docs/engineering/change-records/prd-53-minimal-published-slate-audit-history.md`
+
+## Canonical PRD status
+
+PR #149 through PR #153 completed the PRD-53 implementation path for:
+
+- card-level editorial authority amendment
+- minimal final-slate composer
+- editorial card controls
+- supported seven-row publish hardening
+- minimal internal published-slate audit/history
+
+No new PRD was created for this validation cycle.
+
+## Production publish authorization
+
+Production publish was not authorized.
+
+`CONTROLLED_PRODUCTION_PUBLISH_APPROVED=true` was absent from the local operator environment, so this cycle stopped before any supported public publish.
+
+## Workspace baseline
+
+| Field | Value |
+| --- | --- |
+| Worktree | `/Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-second-controlled-cycle-validation` |
+| Branch | `codex/prd-53-second-controlled-cycle-validation` |
+| Starting commit | `a3890b8` |
+| Commit description | `Merge pull request #153 from brandonma25/codex/prd-53-minimal-published-slate-audit-history` |
+| UTC capture time | `2026-04-30T04:25:28Z` |
+| Local capture time | `2026-04-30 12:25:28 CST` |
+| Production URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+
+## Baseline production checks
+
+| Check | Result |
+| --- | --- |
+| Homepage `/` | HTTP 200 |
+| `/signals` | HTTP 200 |
+| Editorial admin route | HTTP 200, unauthenticated sign-in gate shown |
+| Cron endpoint `/api/cron/fetch-news` | HTTP 401 unauthorized |
+| Production publish authorization | Absent |
+
+The homepage is serving release `a3890b8`, but it is not healthy for the PRD-53 workflow. The page displays this schema preflight failure:
+
+```text
+signal_posts schema preflight failed. Missing expected columns: final_slate_rank, final_slate_tier, editorial_decision, decision_note, rejected_reason, held_reason, replacement_of_row_id, reviewed_by, reviewed_at.
+```
+
+`/signals` currently returns the expected page shell but reports `0 signals` and says the public signal page will appear after an editor approves and publishes the current Signal slate.
+
+The editorial admin route returns the sign-in gate:
+
+```text
+Admin sign-in required
+Sign in with an authorized Google account to review Top 5 Signals.
+```
+
+The cron endpoint returned an unauthorized response and was not run:
+
+```text
+{"success":false,"timestamp":"2026-04-30T04:25:46.448Z","summary":{"message":"Unauthorized"}}
+```
+
+## Available controlled commands
+
+The repo exposes `npm run pipeline:controlled-test`, backed by `scripts/pipeline-controlled-test.ts`.
+
+The controlled pipeline modes identified in the code and prior change records are:
+
+| Mode | Behavior |
+| --- | --- |
+| `dry_run` | Runs the controlled pipeline without Supabase writes. |
+| `draft_only` | Creates non-live review rows only when production guard variables are explicit. |
+
+Production `draft_only` requires explicit guard variables, including `PIPELINE_RUN_MODE=draft_only`, `PIPELINE_TARGET_ENV=production`, `ALLOW_PRODUCTION_PIPELINE_TEST=true`, `BRIEFING_DATE_OVERRIDE`, `PIPELINE_TEST_RUN_ID`, and `PIPELINE_CRON_DISABLED_CONFIRMED=true`.
+
+`draft_only` was not run in this cycle because production is missing PRD-53 schema columns and there is no local `.env.local` or `.env` available for a safe non-production admin workflow rehearsal.
+
+## Candidate generation
+
+The safe controlled dry run was executed:
+
+```bash
+PIPELINE_RUN_MODE=dry_run \
+PIPELINE_TARGET_ENV=production \
+PIPELINE_CRON_DISABLED_CONFIRMED=true \
+BRIEFING_DATE_OVERRIDE=2026-04-30 \
+PIPELINE_TEST_RUN_ID=prd53-second-controlled-cycle-dryrun-20260430T0429Z \
+npm run pipeline:controlled-test
+```
+
+Result:
+
+- dry run completed successfully
+- no Supabase writes were performed
+- `insertedCount` was `0`
+- `insertedPostIds` was empty
+- artifact created at `.pipeline-runs/controlled-pipeline-dry_run-prd53-second-controlled-cycle-dryrun-20260430T0429Z-2026-04-30T04-26-52-825Z.json`
+
+Dry-run summary:
+
+| Field | Value |
+| --- | --- |
+| `mode` | `dry_run` |
+| `briefingDate` | `2026-04-30` |
+| `sourcePlan` | `public_manifest` |
+| `sourcePlanSourceCount` | `39` |
+| `candidateCount` | `97` |
+| `clusterCount` | `97` |
+| `activeSourceCount` | `39` |
+| `eligibleCoreCount` | `5` |
+| `contextEligibleCount` | `2` |
+| `depthOnlyCount` | `13` |
+| `excludedWeakCandidateCount` | `137` |
+| `candidate_pool_insufficient` | `false` |
+| `sourceScarcityLikely` | `false` |
+| `sourceAccessibilityLikely` | `true` |
+
+Dry-run warnings:
+
+- `source_accessibility_thin`
+- `source_health_warning`
+- `source_accessibility_constrained_selection`
+- Reuters Business feed fetch failed with `rss_retry_exhausted`; the controlled dry run continued.
+
+## Proposed dry-run final slate
+
+| Rank | Tier | Title | Source | WITM status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| 1 | Core | Powell to remain on Fed board after term ends, preventing Trump appointment | France24 | passed | Candidate score `75.65`. |
+| 2 | Core | Economic Letter Countdown: Most Read Topics from 2025 | SF Fed Research and Insights | requires_human_rewrite | Failure: `unsupported_structural_claim`. |
+| 3 | Core | Democrats Need a Critical Minerals Policy Beyond Anti-Trumpism | Heatmap | passed | Candidate score `67.62`. |
+| 4 | Core | Republicans unlock filibuster-skirting power to pump billions of dollars to ICE | Politico Congress | passed | Candidate score `66.93`. |
+| 5 | Core | A Closer Look at Emerging Market Resilience During Recent Shocks | Liberty Street Economics | passed | Candidate score `66.56`. |
+| 6 | Context | The headache that wont go away for Mike Johnson | Politico Congress | passed | Candidate score `63.18`. |
+| 7 | Context | Microsoft reports sinking Xbox revenue as its cloud business climbs | The Verge | requires_human_rewrite | Failure: `evidence_accessibility_mismatch`. |
+
+## Readiness validation result
+
+The final-slate readiness validator was run locally against the dry-run proposed seven rows.
+
+Result: not ready.
+
+Global failure reasons:
+
+- Row 2 has WITM status `requires_human_rewrite`.
+- Row 2 has unresolved WITM failure details.
+- Row 7 has WITM status `requires_human_rewrite`.
+- Row 7 has unresolved WITM failure details.
+
+Row-level failure reasons:
+
+| Rank | Reason |
+| --- | --- |
+| 2 | `witm_failed`: Row 2 has WITM status `requires_human_rewrite`. |
+| 2 | `witm_failure_details`: Core WITM is attached to a retrospective or meta-story that needs selection review before publication. |
+| 7 | `witm_failed`: Row 7 has WITM status `requires_human_rewrite`. |
+| 7 | `witm_failure_details`: Core/Context WITM makes a structural claim without enough accessible source evidence. |
+
+## Admin review workflow
+
+The full supported admin review workflow was not executed against production data.
+
+Blockers:
+
+1. Production is missing the PRD-53 schema columns required by the composer and editorial controls.
+2. The dry-run proposed seven-row slate is not publish-ready because two selected rows require human rewrite.
+3. Production publish authorization was absent.
+4. No local safe Supabase environment was available for a non-production mutation rehearsal.
+
+No direct SQL row surgery was performed.
+No admin action was simulated through direct database edits.
+No candidate rows were created.
+No rows were approved, rejected, held, replaced, promoted, demoted, reordered, or removed in production.
+
+Expected editorial decisions for a later authorized cycle:
+
+| Candidate | Expected action before publish |
+| --- | --- |
+| Economic Letter Countdown: Most Read Topics from 2025 | Request rewrite or hold; do not publish while `unsupported_structural_claim` remains unresolved. |
+| Microsoft reports sinking Xbox revenue as its cloud business climbs | Request rewrite or replace; do not publish while `evidence_accessibility_mismatch` remains unresolved. |
+
+## Source concentration notes
+
+The proposed Top 5 Core rows came from five distinct sources.
+
+The proposed seven-row slate included two Politico Congress rows. This should be visible to the editor as a concentration consideration, but the dry-run evidence did not show a same-source count above two.
+
+## Public verification result
+
+Only pre-publish public safety checks were performed.
+
+| Surface | Result |
+| --- | --- |
+| Homepage | HTTP 200, but empty/degraded because production schema preflight failed. |
+| `/signals` | HTTP 200, shows 0 signals and no public candidate leak. |
+| Cron endpoint | HTTP 401 unauthorized; no cron run. |
+
+Public pages did not show held, rejected, rewrite-requested, Depth, rank-8, or non-selected candidate rows during this validation.
+
+## Publish result
+
+No publish was performed.
+
+Reasons:
+
+- `CONTROLLED_PRODUCTION_PUBLISH_APPROVED=true` was absent.
+- Production schema was not ready for the PRD-53 workflow.
+- The dry-run proposed final slate was not WITM-ready.
+
+## Audit/history verification
+
+No new published-slate audit record was expected or created because no publish occurred.
+
+The latest-audit admin display could not be validated in production because the route requires authorized sign-in and production schema readiness.
+
+The published-slate audit tables from PR #153 should be verified after production migrations are applied and before the next controlled publish attempt.
+
+## Rollback preparation
+
+No rollback target was exercised because no publish occurred.
+
+The supported publish action should identify archived previous-live rows once the PRD-53 schema is present and a validated slate is published through the admin workflow.
+
+## Deviations from expected workflow
+
+This cycle stopped earlier than the target end-to-end proof.
+
+The primary deviation is that production code is deployed at the PR #153 merge, but the production database schema does not yet contain the PRD-53 additive columns required by PR #150, PR #151, and PR #153.
+
+The secondary deviation is that the dry-run candidate slate requires editorial intervention before any publish-ready final slate can exist.
+
+## Blockers
+
+1. Apply and verify the PRD-53 additive Supabase migrations in the target production Supabase environment:
+   - `signal_posts.final_slate_rank`
+   - `signal_posts.final_slate_tier`
+   - `signal_posts.editorial_decision`
+   - `signal_posts.decision_note`
+   - `signal_posts.rejected_reason`
+   - `signal_posts.held_reason`
+   - `signal_posts.replacement_of_row_id`
+   - `signal_posts.reviewed_by`
+   - `signal_posts.reviewed_at`
+   - `published_slates`
+   - `published_slate_items`
+2. Rerun the second controlled cycle after schema verification.
+3. Use the supported admin workflow to handle the two WITM-failed dry-run candidates before publish.
+4. Stop before publish again unless `CONTROLLED_PRODUCTION_PUBLISH_APPROVED=true` is explicitly present.
+
+## Commands run
+
+```bash
+pwd
+git branch --show-current
+git status --short --branch
+git worktree list
+git worktree add /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-second-controlled-cycle-validation -b codex/prd-53-second-controlled-cycle-validation origin/main
+git log --oneline -5
+sed -n '1,220p' AGENTS.md
+sed -n '1,220p' docs/engineering/protocols/engineering-protocol.md
+sed -n '1,220p' docs/engineering/protocols/test-checklist.md
+sed -n '1,220p' docs/engineering/protocols/prd-template.md
+sed -n '1,220p' docs/engineering/protocols/release-machine.md
+sed -n '1,220p' docs/engineering/protocols/release-automation-operating-guide.md
+sed -n '1,180p' docs/product/prd/prd-53-signals-admin-editorial-layer.md
+rg -n "dry_run|draft_only|pipeline:controlled|CONTROLLED_PRODUCTION_PUBLISH_APPROVED|publish|cron" .
+gh variable list --repo brandonma25/daily-intelligence-aggregator
+curl -L -sS -o /tmp/bootup-home.html -w '%{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/
+curl -L -sS -o /tmp/bootup-signals.html -w '%{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/signals
+curl -L -sS -o /tmp/bootup-cron.txt -w '%{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/api/cron/fetch-news
+node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+npm install
+PIPELINE_RUN_MODE=dry_run PIPELINE_TARGET_ENV=production PIPELINE_CRON_DISABLED_CONFIRMED=true BRIEFING_DATE_OVERRIDE=2026-04-30 PIPELINE_TEST_RUN_ID=prd53-second-controlled-cycle-dryrun-20260430T0429Z npm run pipeline:controlled-test
+npx tsx -e "<local dry-run artifact parser and final-slate readiness validator invocation>"
+rg -n "Sign in|not authorized|Published Slate Audit|schema preflight|Login|Admin|Signals Editorial" /tmp/bootup-editorial-admin.html | head -40
+git diff --check --cached
+npm run lint
+python3 scripts/validate-feature-system-csv.py
+python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-second-controlled-cycle-validation --pr-title "PRD-53 second controlled cycle validation"
+python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-second-controlled-cycle-validation --pr-title "PRD-53 second controlled cycle validation"
+npm run test
+npm run build
+```
+
+## Local validation results
+
+| Command | Result |
+| --- | --- |
+| `git diff --check --cached` | Passed. |
+| `npm run lint` | Passed. |
+| `python3 scripts/validate-feature-system-csv.py` | Passed with pre-existing PRD slug warnings for PRD-32, PRD-37, and PRD-38. |
+| `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-second-controlled-cycle-validation --pr-title "PRD-53 second controlled cycle validation"` | Passed. Classified as docs-only baseline. |
+| `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-second-controlled-cycle-validation --pr-title "PRD-53 second controlled cycle validation"` | Passed. Classified as docs-only baseline. |
+| `npm run test` | Passed: 73 files, 572 tests. |
+| `npm run build` | Passed. |
+
+## Commands not run
+
+| Command or action | Reason |
+| --- | --- |
+| Production `draft_only` | Blocked by missing production PRD-53 schema columns and no safe local Supabase environment. |
+| Supported admin publish | Not authorized and validation did not pass. |
+| Direct SQL update | Explicitly out of scope. |
+| Cron run | Explicitly out of scope. |
+| Pipeline write-mode | Explicitly out of scope. |
+| Playwright | No code or UI change was made; public checks used HTTP probes. |
+
+## Result
+
+`second_controlled_cycle_blocked`
+
+The workflow did not reach a supported publish or audit-history verification. The stop was correct: production schema is not aligned with the deployed PRD-53 code, and the dry-run proposed slate contains WITM-failed rows.
+
+## Exact next task
+
+Apply and verify the PRD-53 production database migrations, then rerun the second controlled cycle from latest `main`.
+
+After migration verification, rerun controlled `dry_run`, run safe non-live candidate creation only if the dry run is clean, use the supported admin workflow to resolve WITM failures and compose the final 5 Core + 2 Context slate, and stop before publish unless explicit production publish authorization is present.
+
+## Risks / follow-up
+
+- MVP measurement instrumentation remains after a successful controlled cycle.
+- Final launch-readiness QA remains after measurement.
+- Cron remains last.

--- a/docs/operations/tracker-sync/2026-04-30-prd-53-second-controlled-cycle.md
+++ b/docs/operations/tracker-sync/2026-04-30-prd-53-second-controlled-cycle.md
@@ -1,0 +1,68 @@
+# Tracker Sync Fallback - PRD-53 Second Controlled Cycle Validation
+
+Date: 2026-04-30
+Branch: `codex/prd-53-second-controlled-cycle-validation`
+PRD: `PRD-53`
+Canonical PRD file: `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+Readiness label: `second_controlled_cycle_blocked`
+
+## Manual tracker update payload
+
+Use this fallback if live Google Sheets tracker access is unavailable.
+
+| Field | Value |
+| --- | --- |
+| `prd_id` | `PRD-53` |
+| `PRD File` | `docs/product/prd/prd-53-signals-admin-editorial-layer.md` |
+| `Status` | `In Review` |
+| `Decision` | `build` |
+| `Owner` | `Codex` |
+| `Last Updated` | `2026-04-30` |
+| `Notes` | Second controlled PRD-53 cycle stopped before publish. Production code is at PR #153 merge `a3890b8`, but production schema preflight reports missing PRD-53 additive columns on `signal_posts`; controlled dry run succeeded without writes but proposed seven-row slate had WITM failures at ranks 2 and 7. No direct SQL, no ad hoc DB publish, no cron, no production publish, no `draft_only`, and no production database mutation were performed. |
+
+## Validation outcome
+
+- Change type: remediation / alignment validation.
+- Controlled `dry_run` completed with no Supabase writes.
+- Candidate pool was sufficient: 5 eligible Core and 2 Context candidates.
+- Proposed final slate was not publish-ready because two selected rows had `requires_human_rewrite`.
+- Production homepage returned HTTP 200 but showed a schema preflight failure for missing PRD-53 columns.
+- `/signals` returned HTTP 200 and showed no public candidate leak.
+- Editorial admin route returned the unauthenticated sign-in gate.
+- Cron endpoint returned HTTP 401 unauthorized and was not run.
+- Production publish authorization was absent.
+
+## Required next action
+
+Apply and verify the PRD-53 additive database migrations in the target production Supabase environment, then rerun the second controlled cycle from latest `main`.
+
+Required schema verification before rerun:
+
+- `signal_posts.final_slate_rank`
+- `signal_posts.final_slate_tier`
+- `signal_posts.editorial_decision`
+- `signal_posts.decision_note`
+- `signal_posts.rejected_reason`
+- `signal_posts.held_reason`
+- `signal_posts.replacement_of_row_id`
+- `signal_posts.reviewed_by`
+- `signal_posts.reviewed_at`
+- `published_slates`
+- `published_slate_items`
+
+## Explicit non-actions
+
+- No feature implementation.
+- No new PRD.
+- No source governance change.
+- No source addition.
+- No ranking threshold change.
+- No WITM threshold change.
+- No public URL, domain, environment, or Vercel setting change.
+- No direct DB intervention.
+- No production publish.
+- No `draft_only`.
+- No cron.
+- No automatic public publishing.
+- No Phase 2 architecture.
+- No personalization.


### PR DESCRIPTION
## Summary

This docs-only validation PR records the second PRD-53 controlled-cycle attempt after the final-slate composer, card controls, supported seven-row publish path, and minimal audit/history work merged.

Result: `second_controlled_cycle_blocked`.

The cycle stopped before publish because production is serving the PR #153 code at `a3890b8`, but the production schema preflight reports missing PRD-53 additive columns on `signal_posts`. The safe controlled `dry_run` completed with no writes, but its proposed 5 Core + 2 Context slate also had WITM failures at ranks 2 and 7.

## Effective Change Type

Remediation / alignment validation under the approved PRD-53 workflow.

## Source Of Truth

`docs/product/prd/prd-53-signals-admin-editorial-layer.md`

## Canonical PRD Status

PR #149 through PR #153 completed the required PRD-53 workflow implementation path. No new PRD was created.

## What Was Validated

- Latest `main` at PR #153 merge commit `a3890b8`
- Production homepage, `/signals`, editorial admin route, and cron endpoint baseline
- Controlled `dry_run` candidate generation path with no Supabase writes
- Final-slate readiness validator against the proposed dry-run seven-row slate
- Public pre-publish safety state
- Production publish authorization state

## What Did Not Change

- No feature implementation
- No source, ranking, or WITM threshold changes
- No cron run or cron re-enable
- No automatic publish
- No direct DB intervention
- No production publish
- No `draft_only`
- No production database mutation
- No Phase 2 architecture
- No personalization

## Validation

- `git diff --check --cached` - passed
- `npm run lint` - passed
- `python3 scripts/validate-feature-system-csv.py` - passed with pre-existing PRD slug warnings only
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-second-controlled-cycle-validation --pr-title "PRD-53 second controlled cycle validation"` - passed
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-second-controlled-cycle-validation --pr-title "PRD-53 second controlled cycle validation"` - passed
- `npm run test` - passed, 73 files and 572 tests
- `npm run build` - passed

## Result

`second_controlled_cycle_blocked`

Blockers:

1. Production database schema is missing PRD-53 additive columns required by the deployed workflow.
2. The dry-run proposed slate is not publish-ready because ranks 2 and 7 require human rewrite.
3. Production publish authorization was absent, so no publish was attempted.

## Next Task

Apply and verify the PRD-53 production database migrations, then rerun the second controlled cycle from latest `main`. Cron remains last.

READINESS LABEL: `second_controlled_cycle_blocked`
