### PR TITLE
Hotfix public schema preflight fallback

### DIFF
--- a/docs/engineering/bug-fixes/public-schema-preflight-fallback.md
+++ b/docs/engineering/bug-fixes/public-schema-preflight-fallback.md
@@ -1,0 +1,85 @@
+# Public Schema Preflight Fallback - Bug-Fix Record
+
+## Summary
+
+- Problem addressed: public production pages exposed internal `signal_posts` schema-preflight failures while PRD-53 production schema alignment remained blocked.
+- Root cause: public read helpers reused the full admin/editorial PRD-53 `signal_posts` schema preflight, so missing admin/final-slate columns blocked public rendering of already-published live rows.
+- Effective change type: hotfix / remediation, not net-new feature work.
+
+## Source Of Truth
+
+- Product position: Boot Up is a curated daily intelligence briefing, not a feed.
+- Public product target: Top 5 Core Signals plus Next 2 Context Signals with no false freshness.
+- PRD-53: `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+- PRD-53 diagnostics from PR #158 through PR #161, which record unresolved migration-history drift and missing PRD-53 production schema.
+
+## Fix
+
+- Split public-read schema safety from admin/publish schema readiness.
+- Public read paths now check only the fields needed to render reviewed live published rows.
+- Public read paths no longer require PRD-53 admin/final-slate columns:
+  - `final_slate_rank`
+  - `final_slate_tier`
+  - `editorial_decision`
+  - `decision_note`
+  - `rejected_reason`
+  - `held_reason`
+  - `replacement_of_row_id`
+  - `reviewed_by`
+  - `reviewed_at`
+- Admin/editorial workflows still require the full PRD-53 schema and still surface the detailed schema blocker.
+- `/signals` now has a public-safe temporary-unavailable state for public read failures and no longer shows a misleading `0 signals` badge for schema failure.
+- Homepage empty/error fallback sanitizes internal schema details before rendering public copy.
+
+## Public Visibility Rules Preserved
+
+Public rows still require:
+
+- `is_live = true`
+- `editorial_status = 'published'`
+- `published_at IS NOT NULL`
+- public-safe `published_why_it_matters`
+- WITM validation not marked `requires_human_rewrite`
+
+When optional PRD-53 placement fields are available, public helpers may use them for final-slate ordering and blocking decisions. When those optional fields are missing, public helpers fall back to legacy rank ordering so existing live published rows can still render safely.
+
+## What Did Not Change
+
+- No production migration.
+- No migration-history repair.
+- No production row mutation.
+- No direct SQL mutation.
+- No `draft_only`.
+- No publish.
+- No cron.
+- No source, ranking, or WITM threshold change.
+- No MVP measurement.
+- No Phase 2 architecture.
+- No personalization.
+- No masking of admin/operator schema blockers.
+
+## Validation
+
+- `git diff --check` - passed.
+- `npm run lint` - passed.
+- `npm run test -- src/lib/signals-editorial.test.ts src/lib/data.test.ts src/app/signals/page.test.tsx src/app/page.test.tsx src/lib/homepage-editorial-overrides.test.ts` - passed: 5 files, 72 tests.
+- `npm run test` - passed: 73 files, 575 tests.
+- `npm run build` - passed.
+- `python3 scripts/validate-feature-system-csv.py` - passed with pre-existing PRD slug warnings for PRD-32, PRD-37, and PRD-38.
+- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/hotfix-public-schema-preflight-fallback --pr-title "Hotfix public schema preflight fallback"` - passed.
+- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/hotfix-public-schema-preflight-fallback --pr-title "Hotfix public schema preflight fallback"` - passed.
+- Local dev server on `http://localhost:3000` - verified with Codex computer browser inspection:
+  - `/` rendered public-safe briefing-prepared copy and did not expose internal schema details.
+  - `/signals` rendered `Briefing pending` and a public-safe temporary-unavailable state.
+- `PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:e2e:chromium` - passed: 33 tests.
+- `PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:e2e:webkit` - first run had one transient WebKit locator miss, immediate rerun passed: 33 tests.
+
+## Production Note
+
+This hotfix does not resolve production schema alignment. The next operational task remains stable read-only catalog access and database-owner review before any migration repair or apply step.
+
+Readiness label for this hotfix:
+
+```text
+ready_for_hotfix_public_schema_preflight_fallback_review
+```

--- a/docs/operations/tracker-sync/2026-04-30-hotfix-public-schema-preflight-fallback.md
+++ b/docs/operations/tracker-sync/2026-04-30-hotfix-public-schema-preflight-fallback.md
@@ -1,0 +1,65 @@
+# Tracker Sync Fallback - Public Schema Preflight Fallback
+
+Date: 2026-04-30
+Branch: `codex/hotfix-public-schema-preflight-fallback`
+Readiness label: `ready_for_hotfix_public_schema_preflight_fallback_review`
+
+## Manual Tracker Update Payload
+
+Use this fallback if live Google Sheets tracker access is unavailable.
+
+| Field | Value |
+| --- | --- |
+| `prd_id` | `PRD-53` |
+| `PRD File` | `docs/product/prd/prd-53-signals-admin-editorial-layer.md` |
+| `Status` | `In Review` |
+| `Decision` | `build` |
+| `Owner` | `Codex` |
+| `Last Updated` | `2026-04-30` |
+| `Notes` | Hotfix/remediation separates public read safety from PRD-53 admin/publish schema readiness. Public homepage and `/signals` no longer require PRD-53 admin/final-slate columns before rendering existing live published rows or a user-safe unavailable state. Admin schema blockers remain visible. No production migration, migration repair, production row mutation, `draft_only`, publish, cron, source/ranking/WITM threshold change, MVP measurement, Phase 2 architecture, or personalization occurred. |
+
+## Validation Outcome
+
+- Change type: hotfix / remediation.
+- Source of truth: PRD-53 plus PR #158 through PR #161 diagnostic records.
+- Public read preflight no longer requires missing PRD-53 admin/final-slate columns.
+- Admin PRD-53 preflight still requires full schema and remains blocking when PRD-53 fields are missing.
+- Targeted tests passed: `src/lib/signals-editorial.test.ts`, `src/lib/data.test.ts`, `src/app/signals/page.test.tsx`, `src/app/page.test.tsx`, `src/lib/homepage-editorial-overrides.test.ts`.
+- Full tests passed: `npm run test` reported 73 files and 575 tests passed.
+- Production build passed: `npm run build`.
+- Governance validation passed:
+  - `python3 scripts/validate-feature-system-csv.py`
+  - `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/hotfix-public-schema-preflight-fallback --pr-title "Hotfix public schema preflight fallback"`
+  - `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/hotfix-public-schema-preflight-fallback --pr-title "Hotfix public schema preflight fallback"`
+- Browser validation passed against local dev server:
+  - Codex computer inspection of `/` and `/signals`
+  - `PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:e2e:chromium`
+  - `PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:e2e:webkit` after one transient locator miss on the first WebKit attempt
+
+## Required Next Action
+
+After review and merge, production schema alignment is still blocked. The next operational task remains:
+
+1. Provide `SUPABASE_DB_PASSWORD` or equivalent stable read-only production catalog access.
+2. Rerun catalog-level database-owner inspection only.
+3. Do not authorize migration repair, migration apply, `draft_only`, production publish, cron, MVP measurement, final launch-readiness QA, Phase 2 architecture, or personalization in that same prompt.
+
+## Explicit Non-Actions
+
+- No new feature.
+- No new PRD.
+- No production migration apply.
+- No migration-history repair.
+- No direct SQL mutation.
+- No production row mutation.
+- No `draft_only`.
+- No production publish.
+- No cron.
+- No source governance change.
+- No source addition.
+- No ranking threshold change.
+- No WITM threshold change.
+- No MVP measurement instrumentation.
+- No final launch-readiness QA.
+- No Phase 2 architecture.
+- No personalization.

--- a/src/app/signals/page.test.tsx
+++ b/src/app/signals/page.test.tsx
@@ -1,11 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getPublishedSignalPosts = vi.fn();
+const getPublicSignalsPageState = vi.fn();
 
 vi.mock("@/lib/signals-editorial", () => {
   return {
-    getPublishedSignalPosts,
+    getPublicSignalsPageState,
   };
 });
 
@@ -58,13 +58,14 @@ function createPublishedPost(index: number, overrides: Partial<PublishedPostFixt
 
 describe("public signals page", () => {
   beforeEach(() => {
-    getPublishedSignalPosts.mockReset();
+    getPublicSignalsPageState.mockReset();
   });
 
   it("renders published editorial copy instead of the raw AI draft", async () => {
-    getPublishedSignalPosts.mockResolvedValue(
-      Array.from({ length: 5 }, (_, index) => createPublishedPost(index + 1)),
-    );
+    getPublicSignalsPageState.mockResolvedValue({
+      kind: "published",
+      posts: Array.from({ length: 5 }, (_, index) => createPublishedPost(index + 1)),
+    });
 
     const Page = (await import("@/app/signals/page")).default;
     render(await Page());
@@ -74,21 +75,24 @@ describe("public signals page", () => {
   }, 10000);
 
   it("renders Core and Context sections for the published seven-signal slate", async () => {
-    getPublishedSignalPosts.mockResolvedValue([
-      ...Array.from({ length: 5 }, (_, index) => createPublishedPost(index + 1)),
-      createPublishedPost(6, {
-        id: "context-1",
-        rank: 6,
-        title: "Published context signal 1",
-        publishedWhyItMatters: "Human final context version 1",
-      }),
-      createPublishedPost(7, {
-        id: "context-2",
-        rank: 7,
-        title: "Published context signal 2",
-        publishedWhyItMatters: "Human final context version 2",
-      }),
-    ]);
+    getPublicSignalsPageState.mockResolvedValue({
+      kind: "published",
+      posts: [
+        ...Array.from({ length: 5 }, (_, index) => createPublishedPost(index + 1)),
+        createPublishedPost(6, {
+          id: "context-1",
+          rank: 6,
+          title: "Published context signal 1",
+          publishedWhyItMatters: "Human final context version 1",
+        }),
+        createPublishedPost(7, {
+          id: "context-2",
+          rank: 7,
+          title: "Published context signal 2",
+          publishedWhyItMatters: "Human final context version 2",
+        }),
+      ],
+    });
 
     const Page = (await import("@/app/signals/page")).default;
     render(await Page());
@@ -99,5 +103,21 @@ describe("public signals page", () => {
     expect(screen.getByText("Published context signal 2")).toBeInTheDocument();
     expect(screen.getByText("Human final context version 1")).toBeInTheDocument();
     expect(screen.getByText("Human final context version 2")).toBeInTheDocument();
+  }, 10000);
+
+  it("shows a public-safe unavailable state without internal schema details", async () => {
+    getPublicSignalsPageState.mockResolvedValue({
+      kind: "temporarily_unavailable",
+      posts: [],
+    });
+
+    const Page = (await import("@/app/signals/page")).default;
+    render(await Page());
+
+    expect(screen.getByText("Published briefing is temporarily unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Briefing pending")).toBeInTheDocument();
+    expect(screen.queryByText("0 signals")).not.toBeInTheDocument();
+    expect(screen.queryByText(/schema preflight/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/final_slate_rank|editorial_decision|reviewed_at/i)).not.toBeInTheDocument();
   }, 10000);
 });

--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Panel } from "@/components/ui/panel";
 import {
-  getPublishedSignalPosts,
+  getPublicSignalsPageState,
   type EditorialSignalPost,
 } from "@/lib/signals-editorial";
 
@@ -18,10 +18,11 @@ export const metadata: Metadata = {
 };
 
 export default async function PublicSignalsPage() {
-  const posts = await getPublishedSignalPosts();
+  const state = await getPublicSignalsPageState();
+  const posts = state.kind === "published" ? state.posts : [];
   const corePosts = posts.filter((post) => post.rank >= 1 && post.rank <= 5);
   const contextPosts = posts.filter((post) => post.rank >= 6 && post.rank <= 7);
-  const hasPublishedPosts = posts.length > 0;
+  const hasPublishedPosts = state.kind === "published";
 
   return (
     <main className="mx-auto min-h-screen w-full max-w-6xl px-4 py-6 md:px-6">
@@ -29,7 +30,7 @@ export default async function PublicSignalsPage() {
         <header className="space-y-4 border-b border-[var(--border)] pb-5">
           <div className="flex flex-wrap items-center gap-2">
             <Badge>Published editorial layer</Badge>
-            <Badge>{posts.length} signals</Badge>
+            {hasPublishedPosts ? <Badge>{posts.length} signals</Badge> : <Badge>Briefing pending</Badge>}
           </div>
           <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
             <div className="max-w-3xl space-y-3">
@@ -61,6 +62,15 @@ export default async function PublicSignalsPage() {
               />
             ) : null}
           </div>
+        ) : state.kind === "temporarily_unavailable" ? (
+          <Panel className="p-6">
+            <p className="text-base font-semibold text-[var(--text-primary)]">
+              Published briefing is temporarily unavailable
+            </p>
+            <p className="mt-2 text-sm leading-6 text-[var(--text-secondary)]">
+              The reviewed briefing is being kept offline until it can be read safely. Check back shortly.
+            </p>
+          </Panel>
         ) : (
           <Panel className="p-6">
             <p className="text-base font-semibold text-[var(--text-primary)]">

--- a/src/lib/data.test.ts
+++ b/src/lib/data.test.ts
@@ -278,7 +278,7 @@ describe("homepage read model", () => {
     expect(serializedOutput).not.toMatch(/placeholder|stored public signal snapshot|rail readable|sample slot/i);
   });
 
-  it("surfaces signal_posts schema preflight failures instead of a generic empty state", async () => {
+  it("sanitizes public homepage schema failures into a safe unavailable state", async () => {
     getHomepageSignalSnapshot.mockResolvedValue({
       source: "none",
       briefingDate: null,
@@ -293,13 +293,14 @@ describe("homepage read model", () => {
 
     expect(state.data.briefing.items).toEqual([]);
     expect(state.data.briefing.intro).toBe(
-      "signal_posts schema preflight failed. Missing expected columns: why_it_matters_validation_status.",
+      "The published briefing is temporarily unavailable while the latest edition is verified.",
     );
     expect(state.data.homepageFreshnessNotice).toEqual({
       kind: "empty",
-      text: "signal_posts schema preflight failed. Missing expected columns: why_it_matters_validation_status.",
+      text: "The published briefing is temporarily unavailable while the latest edition is verified.",
       briefingDate: null,
     });
+    expect(JSON.stringify(state.data)).not.toMatch(/schema preflight|why_it_matters_validation_status/i);
   });
 });
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -232,6 +232,8 @@ type BriefingSummaryFields = Pick<
 
 const LLM_SUMMARY_TIMEOUT_MS = 7000;
 const DEFAULT_ACCOUNT_CATEGORIES: AccountCategoryPreference[] = ["tech", "finance", "politics"];
+const PUBLIC_BRIEFING_TEMPORARILY_UNAVAILABLE_MESSAGE =
+  "The published briefing is temporarily unavailable while the latest edition is verified.";
 
 function createEmptyBriefing(): DailyBriefing {
   return {
@@ -515,7 +517,9 @@ async function buildPublicHomepageData(): Promise<DashboardData> {
   const sources = getSourcesForPublicSurface("public.home");
 
   if (homepageSignalSnapshot.posts.length === 0) {
-    return buildEmptyPublicHomepageData(homepageSignalSnapshot.errorMessage);
+    return buildEmptyPublicHomepageData(
+      homepageSignalSnapshot.errorMessage ? PUBLIC_BRIEFING_TEMPORARILY_UNAVAILABLE_MESSAGE : undefined,
+    );
   }
 
   const firstBriefingDate = homepageSignalSnapshot.briefingDate ?? homepageSignalSnapshot.posts[0]?.briefingDate;

--- a/src/lib/homepage-editorial-overrides.ts
+++ b/src/lib/homepage-editorial-overrides.ts
@@ -7,14 +7,14 @@ import type { BriefingItem, DashboardData } from "@/lib/types";
 
 type PublishedSignalPostRow = {
   rank: number | null;
-  final_slate_rank: number | null;
-  final_slate_tier: string | null;
+  final_slate_rank?: number | null;
+  final_slate_tier?: string | null;
   title: string | null;
   source_url: string | null;
   published_why_it_matters: string | null;
   published_why_it_matters_payload: unknown | null;
   editorial_status: string | null;
-  editorial_decision: string | null;
+  editorial_decision?: string | null;
   published_at: string | null;
 };
 
@@ -130,7 +130,7 @@ export async function getPublishedHomepageEditorialOverrides(): Promise<
 
   const result = await client
     .from("signal_posts")
-    .select("rank, final_slate_rank, final_slate_tier, title, source_url, published_why_it_matters, published_why_it_matters_payload, editorial_status, editorial_decision, published_at")
+    .select("rank, title, source_url, published_why_it_matters, published_why_it_matters_payload, editorial_status, published_at")
     .eq("is_live", true)
     .eq("editorial_status", "published")
     .not("published_at", "is", null)

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -1941,6 +1941,88 @@ describe("signals editorial workflow", () => {
     expect(posts.map((post) => post.rank)).toEqual([1, 2, 3, 4, 5, 6, 7]);
   });
 
+  it("loads public rows when PRD-53 admin placement columns are missing", async () => {
+    const rows = Array.from({ length: 7 }, (_, index) =>
+      createRow({
+        id: `legacy-live-${index + 1}`,
+        rank: index + 1,
+        briefing_date: "2026-04-24",
+        editorial_status: "published",
+        published_why_it_matters: createValidWhyItMatters(`Legacy ${index + 1}`),
+        why_it_matters_validation_status: "passed",
+        why_it_matters_validation_failures: [],
+        why_it_matters_validation_details: [],
+        is_live: true,
+        published_at: `2026-04-24T08:0${index}:00.000Z`,
+      }),
+    );
+    createSupabaseServiceRoleClient.mockReturnValue(
+      createSupabaseMock(rows, {
+        missingColumns: [
+          "final_slate_rank",
+          "final_slate_tier",
+          "editorial_decision",
+          "decision_note",
+          "rejected_reason",
+          "held_reason",
+          "replacement_of_row_id",
+          "reviewed_by",
+          "reviewed_at",
+        ],
+      }),
+    );
+
+    const { getPublishedSignalPosts, getPublicSignalsPageState, getHomepageSignalSnapshot } = await loadEditorialModule();
+    const publicSignals = await getPublishedSignalPosts();
+    const pageState = await getPublicSignalsPageState();
+    const homepageSnapshot = await getHomepageSignalSnapshot({
+      today: new Date("2026-04-24T12:00:00.000Z"),
+    });
+
+    expect(publicSignals.map((post) => post.id)).toEqual([
+      "legacy-live-1",
+      "legacy-live-2",
+      "legacy-live-3",
+      "legacy-live-4",
+      "legacy-live-5",
+      "legacy-live-6",
+      "legacy-live-7",
+    ]);
+    expect(pageState.kind).toBe("published");
+    expect(homepageSnapshot.source).toBe("published_live");
+    expect(homepageSnapshot.posts.map((post) => post.id)).toEqual([
+      "legacy-live-1",
+      "legacy-live-2",
+      "legacy-live-3",
+      "legacy-live-4",
+      "legacy-live-5",
+    ]);
+    expect(homepageSnapshot.errorMessage).toBeUndefined();
+  });
+
+  it("keeps admin review blocked when PRD-53 admin placement columns are missing", async () => {
+    createSupabaseServiceRoleClient.mockReturnValue(
+      createSupabaseMock([], {
+        missingColumns: ["final_slate_rank", "editorial_decision", "reviewed_at"],
+      }),
+    );
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { getEditorialReviewState } = await loadEditorialModule();
+    const state = await getEditorialReviewState();
+
+    expect(state.kind).toBe("authorized");
+    if (state.kind !== "authorized") return;
+    expect(state.storageReady).toBe(false);
+    expect(state.warning).toBe(
+      "signal_posts schema preflight failed. Missing expected columns: final_slate_rank, editorial_decision, reviewed_at.",
+    );
+  });
+
   it("uses final-slate placement for public order while keeping visibility gated by live published state", async () => {
     const rows = [
       createRow({
@@ -2346,7 +2428,7 @@ describe("signals editorial workflow", () => {
     });
   });
 
-  it("returns a homepage snapshot schema error instead of silently emptying public results", async () => {
+  it("returns an internal homepage snapshot error only when public-read columns are missing", async () => {
     createSupabaseServiceRoleClient.mockReturnValue(
       createSupabaseMock([], {
         missingColumns: ["why_it_matters_validation_failures"],
@@ -2363,7 +2445,7 @@ describe("signals editorial workflow", () => {
       posts: [],
       depthPosts: [],
       briefingDate: null,
-      errorMessage: "signal_posts schema preflight failed. Missing expected columns: why_it_matters_validation_failures.",
+      errorMessage: "public signal_posts schema preflight failed. Missing expected columns: why_it_matters_validation_failures.",
     });
   });
 });

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -30,7 +30,37 @@ import {
 export const SIGNALS_EDITORIAL_ROUTE = "/dashboard/signals/editorial-review";
 export const PUBLIC_SIGNALS_ROUTE = "/signals";
 
-const SIGNAL_POST_REQUIRED_COLUMNS = [
+const PUBLIC_SIGNAL_POST_REQUIRED_COLUMNS = [
+  "id",
+  "briefing_date",
+  "rank",
+  "title",
+  "source_name",
+  "source_url",
+  "summary",
+  "tags",
+  "signal_score",
+  "selection_reason",
+  "published_why_it_matters",
+  "published_why_it_matters_payload",
+  "why_it_matters_validation_status",
+  "why_it_matters_validation_failures",
+  "why_it_matters_validation_details",
+  "why_it_matters_validated_at",
+  "editorial_status",
+  "published_at",
+  "is_live",
+  "created_at",
+  "updated_at",
+];
+
+const PUBLIC_SIGNAL_POST_OPTIONAL_PLACEMENT_COLUMNS = [
+  "final_slate_rank",
+  "final_slate_tier",
+  "editorial_decision",
+];
+
+const ADMIN_SIGNAL_POST_REQUIRED_COLUMNS = [
   "id",
   "briefing_date",
   "rank",
@@ -70,7 +100,12 @@ const SIGNAL_POST_REQUIRED_COLUMNS = [
   "updated_at",
 ];
 
-const SIGNAL_POST_SELECT = SIGNAL_POST_REQUIRED_COLUMNS.join(", ");
+const SIGNAL_POST_SELECT = ADMIN_SIGNAL_POST_REQUIRED_COLUMNS.join(", ");
+const PUBLIC_SIGNAL_POST_BASE_SELECT = PUBLIC_SIGNAL_POST_REQUIRED_COLUMNS.join(", ");
+const PUBLIC_SIGNAL_POST_WITH_OPTIONAL_PLACEMENT_SELECT = [
+  ...PUBLIC_SIGNAL_POST_REQUIRED_COLUMNS,
+  ...PUBLIC_SIGNAL_POST_OPTIONAL_PLACEMENT_COLUMNS,
+].join(", ");
 
 const PUBLISHED_SLATE_REQUIRED_COLUMNS = [
   "id",
@@ -367,6 +402,20 @@ export type HomepageSignalSnapshot = {
   errorMessage?: string;
 };
 
+export type PublicSignalsPageState =
+  | {
+      kind: "published";
+      posts: EditorialSignalPost[];
+    }
+  | {
+      kind: "empty";
+      posts: [];
+    }
+  | {
+      kind: "temporarily_unavailable";
+      posts: [];
+    };
+
 type SignalPostsSchemaPreflightResult =
   | {
       ok: true;
@@ -380,6 +429,8 @@ type SignalPostsSchemaPreflightResult =
     };
 
 let signalPostsSchemaPreflightPromise: Promise<SignalPostsSchemaPreflightResult> | null = null;
+let publicSignalPostsSchemaPreflightPromise: Promise<SignalPostsSchemaPreflightResult> | null = null;
+let publicSignalPostsOptionalPlacementPreflightPromise: Promise<SignalPostsSchemaPreflightResult> | null = null;
 let publishedSlateAuditSchemaPreflightPromise: Promise<SignalPostsSchemaPreflightResult> | null = null;
 
 function buildSchemaPreflightFailure(label: string, missingColumns: string[]): SignalPostsSchemaPreflightResult {
@@ -444,12 +495,20 @@ function isMissingRelationError(error: unknown, tableName: string) {
 
 async function runSignalPostsSchemaPreflight(
   client: EditorialClient,
+  input: {
+    columns?: string[];
+    label?: string;
+    failureBuilder?: (missingColumns: string[]) => SignalPostsSchemaPreflightResult;
+    logLevel?: "warn" | "error";
+  } = {},
 ): Promise<SignalPostsSchemaPreflightResult> {
+  const columns = input.columns ?? ADMIN_SIGNAL_POST_REQUIRED_COLUMNS;
+  const label = input.label ?? "signal_posts schema preflight";
   const missingColumns: string[] = [];
   const errorMessages: string[] = [];
   const nonSchemaErrorMessages: string[] = [];
 
-  for (const column of SIGNAL_POST_REQUIRED_COLUMNS) {
+  for (const column of columns) {
     const result = await client.from("signal_posts").select(column).limit(0);
 
     if (result.error && isMissingColumnError(result.error, column)) {
@@ -461,7 +520,7 @@ async function runSignalPostsSchemaPreflight(
   }
 
   if (nonSchemaErrorMessages.length > 0 && missingColumns.length === 0) {
-    logServerEvent("warn", "signal_posts schema preflight could not verify columns", {
+    logServerEvent("warn", `${label} could not verify columns`, {
       errorMessages: nonSchemaErrorMessages,
     });
   }
@@ -474,9 +533,11 @@ async function runSignalPostsSchemaPreflight(
     };
   }
 
-  const failure = buildSignalPostsSchemaPreflightFailure(missingColumns);
+  const failure = input.failureBuilder
+    ? input.failureBuilder(missingColumns)
+    : buildSignalPostsSchemaPreflightFailure(missingColumns);
 
-  logServerEvent("error", "signal_posts schema preflight failed", {
+  logServerEvent(input.logLevel ?? "error", `${label} failed`, {
     missingColumns,
     errorMessages,
   });
@@ -489,6 +550,31 @@ function getSignalPostsSchemaPreflight(
 ): Promise<SignalPostsSchemaPreflightResult> {
   signalPostsSchemaPreflightPromise ??= runSignalPostsSchemaPreflight(client);
   return signalPostsSchemaPreflightPromise;
+}
+
+function getPublicSignalPostsSchemaPreflight(
+  client: EditorialClient,
+): Promise<SignalPostsSchemaPreflightResult> {
+  publicSignalPostsSchemaPreflightPromise ??= runSignalPostsSchemaPreflight(client, {
+    columns: PUBLIC_SIGNAL_POST_REQUIRED_COLUMNS,
+    label: "public signal_posts schema preflight",
+    failureBuilder: (missingColumns) => buildSchemaPreflightFailure("public signal_posts", missingColumns),
+    logLevel: "warn",
+  });
+  return publicSignalPostsSchemaPreflightPromise;
+}
+
+function getPublicSignalPostsOptionalPlacementPreflight(
+  client: EditorialClient,
+): Promise<SignalPostsSchemaPreflightResult> {
+  publicSignalPostsOptionalPlacementPreflightPromise ??= runSignalPostsSchemaPreflight(client, {
+    columns: PUBLIC_SIGNAL_POST_OPTIONAL_PLACEMENT_COLUMNS,
+    label: "public optional signal_posts placement preflight",
+    failureBuilder: (missingColumns) =>
+      buildSchemaPreflightFailure("public optional signal_posts placement", missingColumns),
+    logLevel: "warn",
+  });
+  return publicSignalPostsOptionalPlacementPreflightPromise;
 }
 
 async function runPublishedSlateAuditSchemaPreflight(
@@ -659,6 +745,51 @@ function mapStoredSignalPost(row: StoredSignalPost): EditorialSignalPost {
     updatedAt: row.updated_at,
     persisted: true,
   };
+}
+
+function mapStoredPublicSignalPost(row: Partial<StoredSignalPost> & Pick<
+  StoredSignalPost,
+  | "id"
+  | "briefing_date"
+  | "rank"
+  | "title"
+  | "source_name"
+  | "source_url"
+  | "summary"
+  | "tags"
+  | "signal_score"
+  | "selection_reason"
+  | "published_why_it_matters"
+  | "published_why_it_matters_payload"
+  | "why_it_matters_validation_status"
+  | "why_it_matters_validation_failures"
+  | "why_it_matters_validation_details"
+  | "why_it_matters_validated_at"
+  | "editorial_status"
+  | "published_at"
+  | "is_live"
+  | "created_at"
+  | "updated_at"
+>) {
+  return mapStoredSignalPost({
+    ai_why_it_matters: "",
+    edited_why_it_matters: null,
+    edited_why_it_matters_payload: null,
+    final_slate_rank: null,
+    final_slate_tier: null,
+    editorial_decision: null,
+    decision_note: null,
+    rejected_reason: null,
+    held_reason: null,
+    replacement_of_row_id: null,
+    reviewed_by: null,
+    reviewed_at: null,
+    edited_by: null,
+    edited_at: null,
+    approved_by: null,
+    approved_at: null,
+    ...row,
+  });
 }
 
 function normalizeStringArrayFromJson(value: unknown): string[] {
@@ -1275,6 +1406,7 @@ async function loadPublishedHomepageSnapshotForDate(
   client: EditorialClient,
   briefingDate: string | null,
   limit: number,
+  selectColumns: string,
 ) {
   if (!briefingDate) {
     return [];
@@ -1282,7 +1414,7 @@ async function loadPublishedHomepageSnapshotForDate(
 
   const result = await client
     .from("signal_posts")
-    .select(SIGNAL_POST_SELECT)
+    .select(selectColumns)
     .eq("briefing_date", briefingDate)
     .eq("is_live", true)
     .eq("editorial_status", "published")
@@ -1295,7 +1427,8 @@ async function loadPublishedHomepageSnapshotForDate(
   }
 
   return selectPublicSlatePosts(
-    ((result.data ?? []) as unknown as StoredSignalPost[]).map(mapStoredSignalPost),
+    ((result.data ?? []) as unknown as Array<Parameters<typeof mapStoredPublicSignalPost>[0]>)
+      .map(mapStoredPublicSignalPost),
     limit,
   );
 }
@@ -1303,10 +1436,11 @@ async function loadPublishedHomepageSnapshotForDate(
 async function loadMostRecentPublishedHomepageSnapshot(
   client: EditorialClient,
   limit: number,
+  selectColumns: string,
 ) {
   const result = await client
     .from("signal_posts")
-    .select(SIGNAL_POST_SELECT)
+    .select(selectColumns)
     .eq("is_live", true)
     .eq("editorial_status", "published")
     .not("published_at", "is", null)
@@ -1322,8 +1456,8 @@ async function loadMostRecentPublishedHomepageSnapshot(
     };
   }
 
-  const publishedPosts = ((result.data ?? []) as unknown as StoredSignalPost[])
-    .map(mapStoredSignalPost)
+  const publishedPosts = ((result.data ?? []) as unknown as Array<Parameters<typeof mapStoredPublicSignalPost>[0]>)
+    .map(mapStoredPublicSignalPost)
     .filter(isPublicSlatePost);
   const briefingDate = publishedPosts[0]?.briefingDate ?? null;
 
@@ -1335,6 +1469,28 @@ async function loadMostRecentPublishedHomepageSnapshot(
           limit,
         )
       : [],
+  };
+}
+
+async function getPublicSignalPostSelect(client: EditorialClient) {
+  const schemaPreflight = await getPublicSignalPostsSchemaPreflight(client);
+
+  if (!schemaPreflight.ok) {
+    return {
+      ok: false as const,
+      selectColumns: null,
+      errorMessage: schemaPreflight.message,
+    };
+  }
+
+  const optionalPlacementPreflight = await getPublicSignalPostsOptionalPlacementPreflight(client);
+
+  return {
+    ok: true as const,
+    selectColumns: optionalPlacementPreflight.ok
+      ? PUBLIC_SIGNAL_POST_WITH_OPTIONAL_PLACEMENT_SELECT
+      : PUBLIC_SIGNAL_POST_BASE_SELECT,
+    errorMessage: null,
   };
 }
 
@@ -2963,22 +3119,28 @@ export async function publishSignalPost(input: {
   };
 }
 
-async function loadPublishedSignalPosts(limit: number): Promise<EditorialSignalPost[]> {
+async function loadPublishedSignalPostsState(limit: number): Promise<PublicSignalsPageState> {
   const supabase = createSupabaseServiceRoleClient();
 
   if (!supabase) {
-    return [];
+    return {
+      kind: "temporarily_unavailable",
+      posts: [],
+    };
   }
 
-  const schemaPreflight = await getSignalPostsSchemaPreflight(supabase);
+  const publicSelect = await getPublicSignalPostSelect(supabase);
 
-  if (!schemaPreflight.ok) {
-    return [];
+  if (!publicSelect.ok) {
+    return {
+      kind: "temporarily_unavailable",
+      posts: [],
+    };
   }
 
   const result = await supabase
     .from("signal_posts")
-    .select(SIGNAL_POST_SELECT)
+    .select(publicSelect.selectColumns)
     .eq("is_live", true)
     .eq("editorial_status", "published")
     .not("published_at", "is", null)
@@ -2992,24 +3154,43 @@ async function loadPublishedSignalPosts(limit: number): Promise<EditorialSignalP
       route: PUBLIC_SIGNALS_ROUTE,
       errorMessage: result.error.message,
     });
-    return [];
+    return {
+      kind: "temporarily_unavailable",
+      posts: [],
+    };
   }
 
-  const publishedPosts = ((result.data ?? []) as unknown as StoredSignalPost[])
-    .map(mapStoredSignalPost)
+  const publishedPosts = ((result.data ?? []) as unknown as Array<Parameters<typeof mapStoredPublicSignalPost>[0]>)
+    .map(mapStoredPublicSignalPost)
     .filter(isPublicSlatePost);
   const briefingDate = publishedPosts[0]?.briefingDate ?? null;
 
-  return briefingDate
+  const posts = briefingDate
     ? selectPublicSlatePosts(
         publishedPosts.filter((post) => post.briefingDate === briefingDate),
         limit,
       )
     : [];
+
+  return posts.length > 0
+    ? {
+        kind: "published",
+        posts,
+      }
+    : {
+        kind: "empty",
+        posts: [],
+      };
 }
 
 export async function getPublishedSignalPosts(): Promise<EditorialSignalPost[]> {
-  return (await loadPublishedSignalPosts(PUBLIC_SIGNAL_SET_SIZE)).slice(0, PUBLIC_SIGNAL_SET_SIZE);
+  const state = await loadPublishedSignalPostsState(PUBLIC_SIGNAL_SET_SIZE);
+
+  return state.kind === "published" ? state.posts.slice(0, PUBLIC_SIGNAL_SET_SIZE) : [];
+}
+
+export async function getPublicSignalsPageState(): Promise<PublicSignalsPageState> {
+  return loadPublishedSignalPostsState(PUBLIC_SIGNAL_SET_SIZE);
 }
 
 export async function getHomepageSignalSnapshot(input: { today?: Date } = {}): Promise<HomepageSignalSnapshot> {
@@ -3024,15 +3205,15 @@ export async function getHomepageSignalSnapshot(input: { today?: Date } = {}): P
     };
   }
 
-  const schemaPreflight = await getSignalPostsSchemaPreflight(supabase);
+  const publicSelect = await getPublicSignalPostSelect(supabase);
 
-  if (!schemaPreflight.ok) {
+  if (!publicSelect.ok) {
     return {
       source: "none",
       posts: [],
       depthPosts: [],
       briefingDate: null,
-      errorMessage: schemaPreflight.message,
+      errorMessage: publicSelect.errorMessage,
     };
   }
 
@@ -3041,6 +3222,7 @@ export async function getHomepageSignalSnapshot(input: { today?: Date } = {}): P
     supabase,
     todayKey,
     PUBLIC_SIGNAL_SET_SIZE,
+    publicSelect.selectColumns,
   );
   const todayPosts = todayDepthPosts.slice(0, TOP_SIGNAL_SET_SIZE);
 
@@ -3056,6 +3238,7 @@ export async function getHomepageSignalSnapshot(input: { today?: Date } = {}): P
   const recentSnapshot = await loadMostRecentPublishedHomepageSnapshot(
     supabase,
     PUBLIC_SIGNAL_SET_SIZE,
+    publicSelect.selectColumns,
   );
   const recentPosts = recentSnapshot.posts.slice(0, TOP_SIGNAL_SET_SIZE);
 


### PR DESCRIPTION
## Effective change type

Hotfix / remediation.

## Source of truth

- Product position: Boot Up is a curated daily intelligence briefing, not a feed.
- Public behavior requirement: no false freshness; render the most recent safe published briefing when available, otherwise show user-safe unavailable/prepared copy.
- PRD-53 admin/editorial workflow remains the schema-readiness source of truth.
- PR #158 through PR #161 remain the diagnostic record for blocked production schema alignment and migration-history drift.

## What changed

- Split public-read schema safety from the full PRD-53 admin/publish schema preflight.
- Public homepage read paths no longer require PRD-53 admin/final-slate columns just to render existing live published rows.
- `/signals` now uses a public page state that distinguishes published, verified-empty, and temporarily unavailable states.
- Public fallback copy no longer exposes raw `signal_posts` schema-preflight failures or missing column names.
- Public visibility gates remain in place: `is_live = true`, `editorial_status = 'published'`, and `published_at IS NOT NULL`.
- Admin/editorial review still requires the full PRD-53 schema and remains blocked when PRD-53 schema is missing.
- Added a bug-fix record and tracker-sync fallback.

## What did not change

- No production migration.
- No migration-history repair.
- No production schema mutation.
- No production row mutation.
- No direct SQL mutation.
- No `draft_only`.
- No publish.
- No cron.
- No source/ranking/WITM threshold changes.
- No MVP measurement.
- No final launch-readiness QA.
- No Phase 2 architecture or personalization.
- No masking of admin/operator schema blockers.

## Validation

- `git diff --check` - passed.
- `npm run lint` - passed.
- `npm run test -- src/lib/signals-editorial.test.ts src/lib/data.test.ts src/app/signals/page.test.tsx src/app/page.test.tsx src/lib/homepage-editorial-overrides.test.ts` - passed: 5 files, 72 tests.
- `npm run test` - passed: 73 files, 575 tests.
- `npm run build` - passed.
- `python3 scripts/validate-feature-system-csv.py` - passed with pre-existing PRD slug warnings for PRD-32, PRD-37, and PRD-38.
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/hotfix-public-schema-preflight-fallback --pr-title "Hotfix public schema preflight fallback"` - passed.
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/hotfix-public-schema-preflight-fallback --pr-title "Hotfix public schema preflight fallback"` - passed.
- Local dev server: `http://localhost:3000`.
- Codex computer browser inspection:
  - `/` rendered public-safe briefing-prepared copy and did not expose schema details.
  - `/signals` rendered `Briefing pending` and public-safe temporary-unavailable copy.
- `PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:e2e:chromium` - passed: 33 tests.
- `PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:e2e:webkit` - first run had one transient WebKit locator miss; immediate rerun passed: 33 tests.

## Production note

Production schema alignment remains blocked. The next operational task remains stable read-only production catalog access / database-owner review before any migration repair or apply step.

This PR only restores a safe public surface while that operational work remains blocked.

Readiness label: `ready_for_hotfix_public_schema_preflight_fallback_review`
