### PR TITLE
PRD-53 second controlled cycle rerun

### DIFF
--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-second-controlled-cycle-rerun.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-second-controlled-cycle-rerun.md
@@ -1,0 +1,440 @@
+# PRD-53 Second Controlled Cycle Rerun
+
+Date: 2026-04-30
+Branch: `codex/prd-53-second-controlled-cycle-rerun`
+Readiness label: `ready_for_authorized_controlled_draft_only`
+
+## Effective Change Type
+
+Operations validation / remediation alignment under the approved PRD-53 Signals admin editorial workflow.
+
+This packet does not implement a new feature, create a new PRD, change product scope, run migration repair, apply schema migrations, run direct SQL row surgery, create production draft rows, publish, run cron, or start MVP measurement.
+
+Object level: Boot Up remains a curated daily intelligence briefing, not a feed. The public target remains Top 5 Core Signals plus Next 2 Context Signals with explicit structural Why it matters reasoning, no false freshness, and human editorial review as the Phase 1 quality backbone.
+
+## Source Of Truth
+
+Primary source:
+
+- `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+
+Secondary sources:
+
+- `docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-schema-apply.md`
+- `docs/operations/tracker-sync/2026-04-30-prd-53-authorized-schema-apply.md`
+- `docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-migration-history-repair.md`
+- `docs/operations/tracker-sync/2026-04-30-prd-53-authorized-migration-history-repair.md`
+- `docs/operations/controlled-cycles/2026-04-30-prd-53-catalog-access-confirmed-inspection.md`
+- `docs/operations/tracker-sync/2026-04-30-prd-53-catalog-access-confirmed-inspection.md`
+- `docs/engineering/change-records/prd-53-minimal-final-slate-composer.md`
+- `docs/engineering/change-records/prd-53-editorial-card-controls.md`
+- `docs/engineering/change-records/prd-53-seven-row-publish-hardening.md`
+- `docs/engineering/change-records/prd-53-minimal-published-slate-audit-history.md`
+
+## Why This Rerun Was Needed
+
+PR #167 repaired production Supabase migration history for four earlier already-catalog-present migrations. PR #168 applied the three PRD-53 additive schema migrations. The next required proof was therefore the second controlled PRD-53 cycle rerun from the aligned production schema.
+
+This run was authorized for dry-run and read-only validation only. It was not authorized to create production draft rows or publish.
+
+## Workspace Baseline
+
+| Field | Value |
+| --- | --- |
+| Worktree | `/Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-second-controlled-cycle-rerun` |
+| Branch | `codex/prd-53-second-controlled-cycle-rerun` |
+| Starting commit | `b7c20594b0fea70870146e0c3d184ad9ed0df94c` |
+| Commit description | `Merge pull request #168 from brandonma25/codex/prd-53-authorized-schema-apply` |
+| PR #168 merged at | `2026-05-01T03:37:24Z` |
+| UTC capture time | `2026-05-01T03:45:34Z` |
+| Local capture time | `2026-05-01 11:45:34 CST` |
+| Production project ref | `fwkqjeumreaznfhnlzev` |
+| Production app URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production deployment SHA | `b7c20594b0fea70870146e0c3d184ad9ed0df94c` |
+| Supabase CLI version | `2.90.0` |
+
+The canonical checkout at `/Users/bm/dev/daily-intelligence-aggregator` remained on its existing branch and was not disturbed. This validation used the dedicated worktree above.
+
+## Authorization
+
+Prompt-level authorization present:
+
+- dry-run validation
+- read-only production schema/catalog validation
+
+Prompt-level authorization absent:
+
+- `CONTROLLED_PRODUCTION_DRAFT_ONLY_APPROVED=true`
+- `CONTROLLED_PRODUCTION_PUBLISH_APPROVED=true`
+- migration-history repair authorization
+- schema migration apply authorization
+- cron authorization
+- MVP measurement authorization
+
+The shell did not export `CONTROLLED_PRODUCTION_DRAFT_ONLY_APPROVED=true` or `CONTROLLED_PRODUCTION_PUBLISH_APPROVED=true`. No secrets, database passwords, connection strings, browser cookies, API tokens, or session data were printed, logged, persisted into docs, or committed.
+
+## Commands Run
+
+Workspace and source-of-truth inspection:
+
+```bash
+pwd
+git branch --show-current
+git status --short --branch
+git worktree list
+gh pr view 168 --json number,state,mergeable,headRefName,headRefOid,baseRefName,url
+gh pr checks 168
+gh pr merge 168 --merge --delete-branch=false
+gh pr view 168 --json number,state,mergeCommit,mergedAt,url
+git fetch origin main
+git worktree add /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-second-controlled-cycle-rerun -b codex/prd-53-second-controlled-cycle-rerun origin/main
+sed -n '1,220p' AGENTS.md
+sed -n '1,220p' docs/engineering/protocols/engineering-protocol.md
+sed -n '1,220p' docs/engineering/protocols/test-checklist.md
+sed -n '1,220p' docs/engineering/protocols/prd-template.md
+sed -n '1,220p' docs/engineering/protocols/release-machine.md
+sed -n '1,240p' docs/engineering/protocols/release-automation-operating-guide.md
+sed -n '1,220p' docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md
+sed -n '1,360p' docs/product/prd/prd-53-signals-admin-editorial-layer.md
+sed -n '1,260p' docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-schema-apply.md
+sed -n '1,260p' docs/operations/controlled-cycles/2026-04-30-prd-53-second-controlled-cycle.md
+```
+
+Read-only Supabase and production checks:
+
+```bash
+supabase projects list --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-second-controlled-cycle-rerun
+supabase link --project-ref fwkqjeumreaznfhnlzev --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-second-controlled-cycle-rerun
+supabase migration list --linked --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-second-controlled-cycle-rerun
+supabase db push --dry-run --linked --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-second-controlled-cycle-rerun
+supabase db query "<read-only PRD-53 catalog verification select>" --linked --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-second-controlled-cycle-rerun --output table
+supabase db query "<read-only aggregate public/audit count select>" --linked --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-second-controlled-cycle-rerun --output table
+python3 <public route smoke script>
+node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+gh api repos/brandonma25/daily-intelligence-aggregator/deployments --jq "<latest production deployment jq>"
+```
+
+Controlled dry-run and local dry-run artifact inspection:
+
+```bash
+npm install
+PIPELINE_RUN_MODE=dry_run \
+PIPELINE_TARGET_ENV=production \
+PIPELINE_CRON_DISABLED_CONFIRMED=true \
+BRIEFING_DATE_OVERRIDE=2026-05-01 \
+PIPELINE_TEST_RUN_ID=prd53-second-controlled-cycle-rerun-dryrun-20260501T0342Z \
+npm run pipeline:controlled-test
+
+node <dry-run artifact summary script>
+npx tsx -e "<local dry-run final-slate readiness validation>"
+```
+
+An additional repeat `supabase db push --dry-run --linked` attempt after the controlled dry-run hit Supabase temporary role authentication failures and then `ECIRCUITBREAKER`; it was terminated after retries hung. Earlier in the same run, the required pre-cycle `supabase db push --dry-run --linked` completed successfully and reported the remote database was up to date.
+
+## Commands Intentionally Not Run
+
+- `supabase migration repair`
+- schema migration apply
+- `supabase db push` outside dry-run
+- direct SQL row surgery
+- ad hoc DDL
+- application-table DML
+- production row mutation outside supported workflows
+- `draft_only`
+- pipeline write-mode
+- production publish
+- admin approve/reject/hold/replace/promote/demote/publish actions
+- cron
+- MVP measurement
+- final launch-readiness QA
+
+## Schema Alignment Status
+
+Post-PR #168, `supabase migration list --linked` showed all eleven local migration versions recorded on remote, including:
+
+- `20260430100000`
+- `20260430110000`
+- `20260430120000`
+
+The required pre-cycle `supabase db push --dry-run --linked` reported:
+
+```text
+Remote database is up to date.
+```
+
+Read-only catalog verification confirmed the PRD-53 schema objects are present:
+
+- `signal_posts.final_slate_rank`
+- `signal_posts.final_slate_tier`
+- `signal_posts.editorial_decision`
+- `signal_posts.decision_note`
+- `signal_posts.rejected_reason`
+- `signal_posts.held_reason`
+- `signal_posts.replacement_of_row_id`
+- `signal_posts.reviewed_by`
+- `signal_posts.reviewed_at`
+- `published_slates`
+- `published_slate_items`
+
+Schema absence is no longer the blocker for the controlled PRD-53 workflow.
+
+## Baseline Production Checks
+
+| Check | Result |
+| --- | --- |
+| Homepage `/` | HTTP 200 |
+| `/signals` | HTTP 200 |
+| Editorial admin route | HTTP 200, unauthenticated sign-in gate shown |
+| Cron endpoint `/api/cron/fetch-news` | HTTP 401 unauthorized |
+| Live published `signal_posts` count | `7` |
+| `published_slates` audit row count | `0` |
+| Latest `published_slates.published_at` | `none` |
+| Production publish authorization | Absent |
+| Draft-only authorization | Absent |
+
+Public route checks confirmed:
+
+- `/` did not expose `signal_posts schema preflight failed`
+- `/` did not expose PRD-53 internal column names
+- `/` showed the last clean public briefing date, `Wednesday, April 29, 2026`
+- `/signals` did not expose schema-preflight errors or internal column names
+- `/signals` showed `Published Signals`, `Top 5 Core Signals`, and `Next 2 Context Signals`
+- `/signals` did not show a misleading `0 signals` state
+
+Current public title markers included:
+
+- `White House plans workshops to bring Anthropic back into federal AI planning`
+- `Democrats need a critical-minerals policy beyond anti-Trumpism`
+- `Why some emerging markets are proving resilient to recent shocks`
+- `How labor's share of income can change the Fed's neutral-rate estimate`
+- `What homeowners insurance contracts reveal about risk sharing`
+
+## Controlled Dry Run
+
+The supported controlled dry run was executed:
+
+```bash
+PIPELINE_RUN_MODE=dry_run \
+PIPELINE_TARGET_ENV=production \
+PIPELINE_CRON_DISABLED_CONFIRMED=true \
+BRIEFING_DATE_OVERRIDE=2026-05-01 \
+PIPELINE_TEST_RUN_ID=prd53-second-controlled-cycle-rerun-dryrun-20260501T0342Z \
+npm run pipeline:controlled-test
+```
+
+Result:
+
+- dry run completed successfully
+- no Supabase writes were performed
+- `insertedCount` was `0`
+- `insertedPostIds` was empty
+- no public rows changed
+- no cron ran
+- artifact created at `.pipeline-runs/controlled-pipeline-dry_run-prd53-second-controlled-cycle-rerun-dryrun-20260501T0342Z-2026-05-01T03-41-32-272Z.json`
+
+Dry-run summary:
+
+| Field | Value |
+| --- | --- |
+| `mode` | `dry_run` |
+| `runId` | `pipeline-1777606887022` |
+| `briefingDate` | `2026-05-01` |
+| `sourcePlan` | `public_manifest` |
+| `sourcePlanSourceCount` | `39` |
+| `candidateCount` | `103` |
+| `clusterCount` | `103` |
+| `activeSourceCount` | `39` |
+| `eligibleCoreCount` | `5` |
+| `contextEligibleCount` | `2` |
+| `depthOnlyCount` | `13` |
+| `excludedWeakCandidateCount` | `142` |
+| `candidate_pool_insufficient` | `false` |
+| `sourceScarcityLikely` | `false` |
+| `sourceAccessibilityLikely` | `true` |
+
+Dry-run warnings:
+
+- `source_accessibility_thin`
+- `source_health_warning`
+- `source_accessibility_constrained_selection`
+- Reuters Business feed fetch failed with `rss_retry_exhausted`; the controlled dry run continued.
+
+## Proposed Dry-Run Slate
+
+| Rank | Tier | Title | Source | WITM status | Score | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | Core | Trump signs DHS legislation, ending record-breaking shutdown | Politico Congress | passed | `74.04` | Full text available; source count `4`. |
+| 2 | Core | Economic Letter Countdown: Most Read Topics from 2025 | SF Fed Research and Insights | requires_human_rewrite | `68.52` | Failure: `unsupported_structural_claim`. |
+| 3 | Core | A Closer Look at Emerging Market Resilience During Recent Shocks | Liberty Street Economics | passed | `66.56` | Full text available. |
+| 4 | Core | The R*-Labor Share Nexus | Liberty Street Economics | passed | `65.94` | Full text available. |
+| 5 | Core | Congress passes short-term FISA extension | Axios | passed | `65.60` | Full text available. |
+| 6 | Context | Anthropic, OpenAI back Warner-Budd workforce data bill | Politico Congress | passed | `66.05` | Full text available. |
+| 7 | Context | Congress keeps kicking surveillance reform down the road | The Verge | requires_human_rewrite | `63.37` | Failure: `evidence_accessibility_mismatch`; partial text available. |
+
+Source concentration:
+
+| Source | Selected count |
+| --- | --- |
+| Politico Congress | `2` |
+| Liberty Street Economics | `2` |
+| SF Fed Research and Insights | `1` |
+| Axios | `1` |
+| The Verge | `1` |
+
+Depth sample:
+
+| Depth rank | Title | Source | WITM status |
+| --- | --- | --- | --- |
+| 8 | Oil prices surge again as Trump weighs options to end Iran war and Hegseth faces lawmakers | PBS NewsHour | passed |
+| 9 | Chinese manufacturing activity expands for second month | Semafor | passed |
+| 10 | Jihadists urge united front against Mali junta as Bamako blockade begins | France24 | requires_human_rewrite |
+| 11 | Apple&#8217;s iPhone revenue jumps to $57 billion despite chip shortages | The Verge | passed |
+| 12 | AI just killed your last excuse for not starting a business | Axios | passed |
+
+## Final-Slate Readiness Validation
+
+The final-slate readiness validator was run locally against the dry-run proposed seven rows with hypothetical approved editorial status, only to evaluate structural and WITM readiness. It did not create or mutate production rows.
+
+Result: not ready.
+
+Global failure reasons:
+
+- Row 2 has WITM status `requires_human_rewrite`.
+- Row 2 has unresolved WITM failure details.
+- Row 7 has WITM status `requires_human_rewrite`.
+- Row 7 has unresolved WITM failure details.
+
+Row-level failure reasons:
+
+| Rank | Reason |
+| --- | --- |
+| 2 | `witm_failed`: Row 2 has WITM status `requires_human_rewrite`. |
+| 2 | `witm_failure_details`: Core WITM is attached to a retrospective or meta-story that needs selection review before publication. |
+| 7 | `witm_failed`: Row 7 has WITM status `requires_human_rewrite`. |
+| 7 | `witm_failure_details`: Core/Context WITM makes a structural claim without enough accessible source evidence. |
+
+The dry run is suitable for the next authorized `draft_only` step because it produced the expected 5 Core plus 2 Context candidate set without production writes and without candidate pool insufficiency. It is not publish-ready: the editor must resolve or replace the two WITM-failed rows before any controlled publish can be considered.
+
+## Draft-Only Gate
+
+`draft_only` was not run.
+
+Reason:
+
+- `CONTROLLED_PRODUCTION_DRAFT_ONLY_APPROVED=true` was absent.
+
+No production rows were created. No `signal_posts` rows were inserted, approved, rejected, held, rewritten, replaced, promoted, demoted, published, archived, or otherwise mutated.
+
+## Admin Workflow Validation
+
+The full supported admin workflow was not executed.
+
+Reasons:
+
+- no non-live production candidate rows were created because draft-only authorization was absent
+- the browser/admin route only provided unauthenticated evidence in this environment
+- the dry-run slate has two WITM-failed rows that require editor action before readiness
+
+Non-mutating evidence:
+
+- `/dashboard/signals/editorial-review` returned HTTP 200
+- the unauthenticated admin sign-in gate rendered
+- public/admin route smoke did not expose schema-preflight failures or missing PRD-53 column names
+- read-only schema/catalog checks confirmed the PRD-53 schema blocker is resolved
+
+Expected editor work in the next authorized cycle:
+
+| Candidate | Expected action before publish |
+| --- | --- |
+| Economic Letter Countdown: Most Read Topics from 2025 | Request rewrite or hold; do not publish while `unsupported_structural_claim` remains unresolved. |
+| Congress keeps kicking surveillance reform down the road | Request rewrite or replace; do not publish while `evidence_accessibility_mismatch` remains unresolved. |
+
+## Publish Gate
+
+Production publish was not run.
+
+Reasons:
+
+- `CONTROLLED_PRODUCTION_PUBLISH_APPROVED=true` was absent.
+- no draft rows were created.
+- no admin final slate was composed.
+- two dry-run selected rows require human rewrite before publish readiness.
+
+No `is_live` value was changed. No `published_at` value was set. Previous live rows were not archived. No published-slate audit record was created.
+
+## Public Verification Result
+
+Post-dry-run public safety checks passed:
+
+| Surface | Result |
+| --- | --- |
+| Homepage `/` | HTTP 200, last clean briefing date visible, no raw schema error |
+| `/signals` | HTTP 200, Published Signals / Top 5 Core / Next 2 Context visible, no raw schema error |
+| Admin route | HTTP 200 unauthenticated sign-in gate, no public schema details |
+| Cron endpoint | HTTP 401 unauthorized |
+
+Public pages did not expose held, rejected, rewrite-requested, Depth, rank-8, or non-selected candidate rows during this validation.
+
+## Audit/History Verification
+
+No new published-slate audit record was expected or created because no publish occurred.
+
+Read-only aggregate verification showed:
+
+| Field | Value |
+| --- | --- |
+| Live published public rows | `7` |
+| Published-slate audit rows | `0` |
+| Latest published-slate timestamp | `none` |
+
+The published-slate audit path still needs verification after an explicitly authorized controlled publish.
+
+## Cron Status
+
+Cron remained disabled/not runnable from this validation context.
+
+The unauthenticated cron endpoint returned HTTP `401` with an unauthorized response. No cron execution was triggered.
+
+## Validation
+
+| Command | Result |
+| --- | --- |
+| `git diff --check` | Passed. |
+| `python3 scripts/validate-feature-system-csv.py` | Passed with pre-existing PRD slug warnings for PRD-32, PRD-37, and PRD-38. |
+| `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-second-controlled-cycle-rerun --pr-title "PRD-53 second controlled cycle rerun"` | Passed. |
+| `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-second-controlled-cycle-rerun --pr-title "PRD-53 second controlled cycle rerun"` | Passed. |
+| `npm run lint` | Passed. |
+| `npm run test` | Passed: 73 test files and 575 tests. |
+| `npm run build` | Passed. |
+
+Validation notes:
+
+- `npm install` was run because the dedicated worktree did not have `node_modules` installed before the controlled pipeline command. It completed with npm audit warnings reporting 2 vulnerabilities; no dependency or lockfile changes were committed.
+- `npm run test` emitted repeated `--localstorage-file` warnings from the test environment, but all tests passed.
+- `npm run build` emitted the existing multiple-lockfile workspace-root warning and a module-type warning for `tailwind.config.ts`, but the production build passed.
+
+## Blockers Remaining
+
+1. Draft-only production candidate creation is still blocked by missing authorization.
+2. The dry-run candidate slate is not publish-ready because two selected rows require human rewrite.
+3. Authenticated admin workflow validation was not completed in this run.
+4. Production publish remains blocked until an explicitly authorized cycle creates, reviews, composes, validates, and publishes a final slate through the supported workflow.
+5. MVP measurement, final launch-readiness QA, and cron remain blocked until the controlled workflow succeeds.
+
+## Exact Next Task
+
+Authorize and run the controlled `draft_only` step only:
+
+```text
+CONTROLLED_PRODUCTION_DRAFT_ONLY_APPROVED=true
+```
+
+Do not include production publish authorization in the same prompt unless the operator intentionally wants to allow the supported publish action after admin readiness passes.
+
+Expected next readiness target after draft/admin/final-slate readiness succeeds:
+
+```text
+ready_for_authorized_second_controlled_publish
+```
+
+MVP measurement remains blocked.

--- a/docs/operations/tracker-sync/2026-04-30-prd-53-second-controlled-cycle-rerun.md
+++ b/docs/operations/tracker-sync/2026-04-30-prd-53-second-controlled-cycle-rerun.md
@@ -1,0 +1,84 @@
+# Tracker Sync Fallback - PRD-53 Second Controlled Cycle Rerun
+
+Date: 2026-04-30
+Branch: `codex/prd-53-second-controlled-cycle-rerun`
+Readiness label: `ready_for_authorized_controlled_draft_only`
+
+## Manual Tracker Update Payload
+
+| Field | Value |
+| --- | --- |
+| Record | PRD-53 Signals admin editorial layer |
+| Status | Blocked |
+| Decision | keep |
+| PRD File | `docs/product/prd/prd-53-signals-admin-editorial-layer.md` |
+| Latest validation packet | `docs/operations/controlled-cycles/2026-04-30-prd-53-second-controlled-cycle-rerun.md` |
+| Notes | PR #168 schema alignment is merged and production schema readiness is confirmed. The second controlled-cycle rerun completed the supported production `dry_run` without Supabase writes: `candidateCount=103`, `eligibleCoreCount=5`, `contextEligibleCount=2`, `depthOnlyCount=13`, `candidate_pool_insufficient=false`, and `insertedCount=0`. The dry-run proposed 5 Core plus 2 Context rows, but two selected rows require human rewrite before publish readiness. `draft_only` was not run because `CONTROLLED_PRODUCTION_DRAFT_ONLY_APPROVED=true` was absent. No publish, no cron, no row mutation, no migration repair/apply, and no MVP measurement occurred. Public `/` and `/signals` remained safe. |
+| Next task | Authorize the controlled production `draft_only` step only, then validate admin review/final-slate readiness. Do not authorize publish in the same prompt unless intentionally permitting the supported publish after readiness passes. |
+
+## Source Of Truth
+
+- `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+- `docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-schema-apply.md`
+- `docs/operations/tracker-sync/2026-04-30-prd-53-authorized-schema-apply.md`
+- `docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-migration-history-repair.md`
+- `docs/operations/tracker-sync/2026-04-30-prd-53-authorized-migration-history-repair.md`
+- `docs/operations/controlled-cycles/2026-04-30-prd-53-catalog-access-confirmed-inspection.md`
+- `docs/operations/tracker-sync/2026-04-30-prd-53-catalog-access-confirmed-inspection.md`
+- `docs/operations/controlled-cycles/2026-04-30-prd-53-second-controlled-cycle-rerun.md`
+
+## Commands Run
+
+- Workspace identity and branch ownership checks.
+- PR #168 check review and merge.
+- Required engineering protocol reads.
+- Supabase project listing and local project link for production project ref `fwkqjeumreaznfhnlzev`.
+- `supabase migration list --linked`.
+- Required pre-cycle `supabase db push --dry-run --linked`, which reported the remote database was up to date.
+- Read-only catalog verification for the PRD-53 columns and audit tables.
+- Read-only aggregate public/audit count verification.
+- Public safety smoke for `/` and `/signals`.
+- Unauthenticated admin route smoke for `/dashboard/signals/editorial-review`.
+- Unauthenticated cron endpoint smoke, which returned HTTP `401`.
+- Supported production `dry_run` through `npm run pipeline:controlled-test`.
+- Dry-run artifact summary.
+- Local final-slate readiness validation against dry-run rows.
+
+## Commands Not Run
+
+- `supabase migration repair`
+- schema migration apply
+- direct SQL row surgery
+- ad hoc DDL
+- application-table DML
+- production row mutation outside supported workflows
+- `draft_only`
+- pipeline write-mode
+- production publish
+- authenticated admin mutation actions
+- cron
+- MVP measurement
+
+## Validation
+
+- `git diff --check`: passed.
+- `python3 scripts/validate-feature-system-csv.py`: passed with pre-existing PRD slug warnings.
+- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-second-controlled-cycle-rerun --pr-title "PRD-53 second controlled cycle rerun"`: passed.
+- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-second-controlled-cycle-rerun --pr-title "PRD-53 second controlled cycle rerun"`: passed.
+- `npm run lint`: passed.
+- `npm run test`: passed, 73 test files and 575 tests.
+- `npm run build`: passed.
+
+## Result
+
+```text
+ready_for_authorized_controlled_draft_only
+```
+
+## Next Authorization Needed
+
+```text
+CONTROLLED_PRODUCTION_DRAFT_ONLY_APPROVED=true
+```
+
+Do not include `CONTROLLED_PRODUCTION_PUBLISH_APPROVED=true` unless intentionally authorizing the supported production publish after admin/final-slate readiness passes.


### PR DESCRIPTION
## Effective change type

- operations validation / remediation alignment under the approved PRD-53 workflow

## Source of truth

- `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
- PR #168 schema-apply packet and prior PRD-53 migration/schema diagnostic packets

## What was validated

- PR #168 production schema alignment is merged and remote migration history is up to date.
- PRD-53 `signal_posts` final-slate/editorial columns plus `published_slates` and `published_slate_items` are present.
- Production `/` and `/signals` return 200 and do not expose schema-preflight failures or missing PRD-53 column names.
- Supported production `dry_run` completed with no Supabase writes: `candidateCount=103`, `eligibleCoreCount=5`, `contextEligibleCount=2`, `depthOnlyCount=13`, `candidate_pool_insufficient=false`, `insertedCount=0`.
- Dry run proposed 5 Core + 2 Context rows, but two selected rows require human rewrite before publish readiness.
- Cron endpoint stayed unauthorized; no cron run occurred.

## What did not change

- No `draft_only` because `CONTROLLED_PRODUCTION_DRAFT_ONLY_APPROVED=true` was absent.
- No publish because `CONTROLLED_PRODUCTION_PUBLISH_APPROVED=true` was absent.
- No migration repair or schema apply.
- No direct SQL row surgery, row mutation, source/ranking/WITM threshold changes, cron, or MVP measurement.

## Validation

- `git diff --check`: passed.
- `python3 scripts/validate-feature-system-csv.py`: passed with pre-existing PRD slug warnings.
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-second-controlled-cycle-rerun --pr-title "PRD-53 second controlled cycle rerun"`: passed.
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-second-controlled-cycle-rerun --pr-title "PRD-53 second controlled cycle rerun"`: passed.
- `npm run lint`: passed.
- `npm run test`: passed, 73 test files and 575 tests.
- `npm run build`: passed.

## Result

`ready_for_authorized_controlled_draft_only`

Next authorization needed: `CONTROLLED_PRODUCTION_DRAFT_ONLY_APPROVED=true` only. Do not include publish authorization unless intentionally permitting supported production publish after admin/final-slate readiness passes.