### PR TITLE
PRD-53 admin review final slate validation

### DIFF
--- a/docs/operations/controlled-cycles/2026-05-01-prd-53-admin-review-final-slate-validation.md
+++ b/docs/operations/controlled-cycles/2026-05-01-prd-53-admin-review-final-slate-validation.md
@@ -1,0 +1,326 @@
+# PRD-53 Admin Review Final Slate Validation
+
+Date: 2026-05-01
+Branch: `codex/prd-53-admin-review-final-slate-validation`
+Readiness label: `second_controlled_cycle_blocked_witm_rewrite_required`
+
+## Effective Change Type
+
+Operations validation / remediation alignment under the approved PRD-53 Signals admin editorial workflow.
+
+This packet does not implement a new feature, create a new PRD, change product scope, publish, run cron, apply schema migrations, run migration repair, run direct SQL row surgery, run `draft_only`, change source/ranking/WITM thresholds, or start MVP measurement.
+
+Object level: production `signal_posts` editorial state was changed only through the supported admin review workflow. No public visibility fields were changed.
+
+## Source Of Truth
+
+Primary source:
+
+- `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+
+Secondary sources:
+
+- `docs/operations/controlled-cycles/2026-04-30-prd-53-second-controlled-cycle-rerun.md`
+- `docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-controlled-draft-only.md`
+- `docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-controlled-draft-only-rerun.md`
+- `docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-schema-apply.md`
+- `docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-migration-history-repair.md`
+- `docs/engineering/change-records/prd-53-minimal-final-slate-composer.md`
+- `docs/engineering/change-records/prd-53-editorial-card-controls.md`
+- `docs/engineering/change-records/prd-53-seven-row-publish-hardening.md`
+- `docs/engineering/change-records/prd-53-minimal-published-slate-audit-history.md`
+
+## Why This Run Was Authorized
+
+PR #171 completed controlled `draft_only` creation and production verification. The admin PRD-53 surface was reachable and schema-ready, showing the current `2026-05-01` candidate set with seven non-live candidates and zero selected final-slate rows.
+
+This run was authorized only for supported admin-review actions and final-slate validation:
+
+- approve valid rows
+- request rewrite for invalid rows
+- hold/reject rows if needed
+- use supported final-slate controls if a valid 5 Core + 2 Context slate was possible
+- run/read final-slate readiness state
+- verify public safety
+- create documentation
+
+It was not authorized to publish, set `is_live=true`, set `published_at`, archive prior live rows, run `draft_only`, run cron, run pipeline write-mode, use direct SQL mutation, change schema, change migrations, change sources, change thresholds, or start MVP measurement.
+
+## Workspace Baseline
+
+| Field | Value |
+| --- | --- |
+| Worktree | `/Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-admin-review-final-slate-validation` |
+| Branch | `codex/prd-53-admin-review-final-slate-validation` |
+| Starting commit | `e2db691` |
+| Commit description | `Merge pull request #171 from brandonma25/codex/prd-53-authorized-controlled-draft-only-rerun` |
+| Production app URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Admin route | `/dashboard/signals/editorial-review` |
+| Current set shown in admin | `2026-05-01` |
+| Current candidate count | `7` |
+| Initial selected final slate count | `0/7` |
+| Published slate audit record | None shown |
+
+The canonical checkout at `/Users/bm/dev/daily-intelligence-aggregator` remained on its existing branch and was not disturbed. This validation used the dedicated worktree above.
+
+## Authorization
+
+Prompt-level authorization present:
+
+- `CONTROLLED_PRODUCTION_ADMIN_REVIEW_APPROVED=true`
+- read-only production/public verification
+- authenticated admin route inspection
+- supported admin review actions
+- final-slate readiness validation through the admin page
+- documentation packet creation
+
+Prompt-level authorization absent:
+
+- `CONTROLLED_PRODUCTION_PUBLISH_APPROVED=true`
+- production publish authorization
+- cron authorization
+- `draft_only` authorization
+- pipeline write-mode authorization
+- migration-history repair authorization
+- schema migration authorization
+- direct SQL mutation authorization
+- MVP measurement authorization
+
+No secrets, database passwords, connection strings, browser cookies, API tokens, or session data were printed into docs or committed.
+
+## Commands Run
+
+Workspace identity and branch ownership checks:
+
+```bash
+pwd
+git branch --show-current
+git status --short --branch
+git worktree list
+```
+
+Required protocol and source-of-truth inspection:
+
+```bash
+sed -n '1,220p' docs/engineering/protocols/engineering-protocol.md
+sed -n '1,220p' docs/engineering/protocols/test-checklist.md
+sed -n '1,220p' docs/engineering/protocols/prd-template.md
+sed -n '1,220p' docs/engineering/protocols/release-machine.md
+sed -n '1,260p' docs/engineering/protocols/release-automation-operating-guide.md
+sed -n '1,220p' docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md
+```
+
+Admin workflow code inspection:
+
+```bash
+rg -n "approveSignalPostAction|requestRewriteAction|rejectSignalPostAction|holdSignalPostAction|assignFinalSlateSlotAction|publishFinalSlateAction" src/app/dashboard/signals/editorial-review src/lib
+sed -n '180,280p' src/app/dashboard/signals/editorial-review/actions.ts
+sed -n '2160,2470p' src/lib/signals-editorial.ts
+sed -n '1,280p' src/lib/final-slate-readiness.ts
+sed -n '1,260p' src/app/dashboard/signals/editorial-review/page.tsx
+sed -n '260,620p' src/app/dashboard/signals/editorial-review/page.tsx
+sed -n '620,820p' src/app/dashboard/signals/editorial-review/page.tsx
+```
+
+Production public and cron safety verification:
+
+```bash
+git rev-parse --short HEAD
+curl -sS -I https://daily-intelligence-aggregator-ybs9.vercel.app/ | sed -n '1,12p'
+curl -sS https://daily-intelligence-aggregator-ybs9.vercel.app/ | rg -n "signal_posts schema preflight failed|final_slate_rank|Today's briefing is being prepared|being prepared|Wednesday, April 29|April 29|Top 5 Core|Next 2 Context"
+curl -sS -I https://daily-intelligence-aggregator-ybs9.vercel.app/signals | sed -n '1,12p'
+curl -sS https://daily-intelligence-aggregator-ybs9.vercel.app/signals | rg -n "Published Signals|7 signals|Top 5 Core Signals|Next 2 Context Signals|signal_posts schema preflight failed|final_slate_rank|final_slate_tier|editorial_decision"
+curl -sS -i https://daily-intelligence-aggregator-ybs9.vercel.app/api/cron/fetch-news | sed -n '1,20p'
+```
+
+Browser actions through authenticated Chrome session:
+
+- Opened `https://daily-intelligence-aggregator-ybs9.vercel.app/dashboard/signals/editorial-review?scope=current`.
+- Confirmed admin route loaded as `newsweb2026@gmail.com`.
+- Confirmed current set `2026-05-01`, seven current candidates, and zero selected final-slate rows.
+- Approved five WITM-passed current candidates through the supported `Approve` buttons.
+- Requested rewrite for the two WITM rewrite-required current candidates through the supported `Request Rewrite` buttons with decision notes.
+- Confirmed `Publish Final Slate` remained disabled.
+- Confirmed no published-slate audit record existed.
+
+## Commands Intentionally Not Run
+
+- production publish
+- supported publish action
+- setting `is_live=true`
+- setting `published_at`
+- archiving previous live rows
+- published-slate audit creation through the publish path
+- cron
+- `draft_only`
+- normal pipeline write-mode
+- direct SQL row surgery
+- direct SQL mutation
+- schema migration apply
+- migration-history repair
+- source changes
+- ranking threshold changes
+- WITM threshold changes
+- MVP measurement
+- final launch-readiness QA
+
+## Baseline Public Status
+
+| Check | Result |
+| --- | --- |
+| Homepage `/` | HTTP 200 |
+| `/signals` | HTTP 200 |
+| Public raw schema-preflight exposure | Not present |
+| Public PRD-53 column-name exposure | Not present |
+| Public last clean briefing date/copy | April 29 briefing with "today's briefing is being prepared" copy |
+| `/signals` markers | `Published Signals`, `7 signals`, `Top 5 Core Signals`, `Next 2 Context Signals` |
+| Cron endpoint without auth | HTTP 401 unauthorized |
+
+Public route output still came from release `e2db691`. No public page showed raw `signal_posts schema preflight failed` text or PRD-53 missing column names.
+
+## Admin Candidate Inventory
+
+| Pipeline rank | Intended tier | Title | Source | WITM status | Initial editorial state | Review action |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | Core | Trump signs DHS legislation, ending record-breaking shutdown | Politico Congress | Passed | Needs Review / Pending Review | Approved |
+| 2 | Core | Economic Letter Countdown: Most Read Topics from 2025 | SF Fed Research and Insights | Rewrite required | Needs Review / Pending Review | Rewrite requested |
+| 3 | Core | A Closer Look at Emerging Market Resilience During Recent Shocks | Liberty Street Economics | Passed | Needs Review / Pending Review | Approved |
+| 4 | Core | The R*-Labor Share Nexus | Liberty Street Economics | Passed | Needs Review / Pending Review | Approved |
+| 5 | Core | The AI Investing Landscape: Insights from Venture Capital | SF Fed Research and Insights | Passed | Needs Review / Pending Review | Approved |
+| 6 | Context | Anthropic, OpenAI back Warner-Budd workforce data bill | Politico Congress | Passed | Needs Review / Pending Review | Approved |
+| 7 | Context | Congress keeps kicking surveillance reform down the road | The Verge | Rewrite required | Needs Review / Pending Review | Rewrite requested |
+
+Quality-gate details for rewrite-requested rows:
+
+- `Economic Letter Countdown: Most Read Topics from 2025`: `unsupported_structural_claim`, because the Core WITM was attached to a retrospective/meta story requiring selection review before publication.
+- `Congress keeps kicking surveillance reform down the road`: `evidence_accessibility_mismatch`, because the Core/Context WITM made a structural claim without enough accessible source evidence.
+
+## Editorial Decisions Taken
+
+Approved through supported admin workflow:
+
+- `Trump signs DHS legislation, ending record-breaking shutdown`
+- `A Closer Look at Emerging Market Resilience During Recent Shocks`
+- `The R*-Labor Share Nexus`
+- `The AI Investing Landscape: Insights from Venture Capital`
+- `Anthropic, OpenAI back Warner-Budd workforce data bill`
+
+Rewrite requested through supported admin workflow:
+
+- `Economic Letter Countdown: Most Read Topics from 2025`
+- `Congress keeps kicking surveillance reform down the road`
+
+No rows were held, rejected, replaced, promoted, demoted, or published. No direct database edits were used.
+
+## Final Slate Validation Result
+
+No final slate was composed.
+
+Reason: the current `2026-05-01` set has only five WITM-passed rows after review. The two remaining current rows require human rewrite and were intentionally left out of final-slate selection. Assigning them to slots would violate PRD-53 readiness requirements.
+
+Observed readiness state:
+
+| Field | Result |
+| --- | --- |
+| Final slate selected count | `0/7` |
+| Core selected count | `0/5` |
+| Context selected count | `0/2` |
+| Readiness badge | `Slate not ready` |
+| Publish button | Disabled |
+| Publish disabled reason | Final slate requires exactly seven selected rows |
+| Published slate audit | No audit record exists yet |
+
+Expected readiness conclusion:
+
+```text
+second_controlled_cycle_blocked_witm_rewrite_required
+```
+
+## Public Safety Verification After Admin Review
+
+| Check | Result |
+| --- | --- |
+| Homepage `/` | HTTP 200 |
+| `/signals` | HTTP 200 |
+| Public schema preflight error exposure | Not present |
+| Public PRD-53 column-name exposure | Not present |
+| Current non-live rows exposed publicly | Not observed |
+| Rewrite-requested rows exposed publicly | Not observed |
+| Held/rejected rows exposed publicly | Not applicable; none created |
+| Public publish occurred | No |
+| Cron endpoint without auth | HTTP 401 unauthorized |
+
+The public surface continued to show the previously published April 29 briefing and `/signals` continued to show the existing published seven-row Boot Up surface.
+
+## What Changed
+
+Production admin editorial state changed only through the supported admin workflow:
+
+- five current non-live review rows were approved
+- two current non-live review rows were marked rewrite requested
+- no final-slate ranks were assigned
+- no public visibility was changed
+
+## What Did Not Change
+
+- no production publish
+- no `is_live=true`
+- no `published_at`
+- no prior live-row archive
+- no published-slate audit creation through publish
+- no cron
+- no `draft_only`
+- no pipeline write-mode
+- no schema migration
+- no migration-history repair
+- no direct SQL mutation
+- no source/ranking/WITM threshold changes
+- no public URL/domain/env/Vercel settings changes
+- no MVP measurement
+- no Phase 2 architecture
+- no personalization
+
+## Validation
+
+```bash
+git diff --check
+python3 scripts/validate-feature-system-csv.py
+python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-admin-review-final-slate-validation --pr-title "PRD-53 admin review final slate validation"
+python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-admin-review-final-slate-validation --pr-title "PRD-53 admin review final slate validation"
+npm run lint
+npm run test
+npm run build
+```
+
+Results:
+
+| Command | Result |
+| --- | --- |
+| `git diff --check` | Passed |
+| `python3 scripts/validate-feature-system-csv.py` | Passed with pre-existing PRD slug warnings |
+| `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-admin-review-final-slate-validation --pr-title "PRD-53 admin review final slate validation"` | Passed |
+| `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-admin-review-final-slate-validation --pr-title "PRD-53 admin review final slate validation"` | Passed |
+| Initial `npm run lint` | Blocked before dependency install: `eslint` unavailable |
+| Initial `npm run test` | Blocked before dependency install: `vitest` unavailable |
+| `npm install` | Completed; reported two npm audit findings |
+| Post-install `npm run lint` | Passed |
+| Post-install `npm run test` | Passed: 73 test files, 575 tests |
+| `npm run build` | Passed |
+
+## Result
+
+```text
+second_controlled_cycle_blocked_witm_rewrite_required
+```
+
+The admin workflow is reachable and can record supported editorial decisions, but the current candidate set cannot become a valid 5 Core + 2 Context slate without rewriting or replacing the two WITM-blocked rows.
+
+## Exact Next Task
+
+Run a follow-up admin rewrite/replacement pass under explicit admin-review authorization:
+
+```text
+CONTROLLED_PRODUCTION_ADMIN_REVIEW_APPROVED=true
+```
+
+The next run should rewrite or replace the two WITM-blocked rows through the supported admin workflow, then rerun final-slate readiness. Do not include `CONTROLLED_PRODUCTION_PUBLISH_APPROVED=true` unless intentionally authorizing public publish after readiness passes.

--- a/docs/operations/tracker-sync/2026-05-01-prd-53-admin-review-final-slate-validation.md
+++ b/docs/operations/tracker-sync/2026-05-01-prd-53-admin-review-final-slate-validation.md
@@ -1,0 +1,84 @@
+# Tracker Sync Fallback - PRD-53 Admin Review Final Slate Validation
+
+Date: 2026-05-01
+Branch: `codex/prd-53-admin-review-final-slate-validation`
+Readiness label: `second_controlled_cycle_blocked_witm_rewrite_required`
+
+## Manual Tracker Update Payload
+
+| Field | Value |
+| --- | --- |
+| Record | PRD-53 Signals admin editorial layer |
+| Status | Blocked |
+| Decision | keep |
+| PRD File | `docs/product/prd/prd-53-signals-admin-editorial-layer.md` |
+| Latest validation packet | `docs/operations/controlled-cycles/2026-05-01-prd-53-admin-review-final-slate-validation.md` |
+| Notes | Admin production route loaded for `newsweb2026@gmail.com` after PR #171. The current `2026-05-01` set had seven candidates and zero selected final-slate rows. Five WITM-passed current rows were approved through the supported admin workflow. Two WITM rewrite-required current rows were marked rewrite requested through the supported admin workflow. No final slate was composed because only five current rows were WITM-passed and approved. Publish remained disabled, no public publish occurred, no cron ran, no `draft_only` ran, no schema or migration command ran, and public `/` plus `/signals` remained safe. |
+| Next task | Run explicit admin-review rewrite or replacement pass for the two WITM-blocked rows, then rerun final-slate readiness. Do not authorize publish until readiness passes. |
+
+## Source Of Truth
+
+- `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+- `docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-controlled-draft-only-rerun.md`
+- `docs/operations/controlled-cycles/2026-05-01-prd-53-admin-review-final-slate-validation.md`
+
+## Commands Run
+
+- Workspace identity and branch ownership checks.
+- Required engineering protocol reads.
+- PRD-53 admin workflow code inspection.
+- Authenticated Chrome admin route inspection.
+- Supported admin approval actions for five WITM-passed current rows.
+- Supported admin rewrite-request actions for two WITM-blocked current rows.
+- Public `/` and `/signals` route checks.
+- Cron endpoint unauthenticated protection check.
+- Repo-standard documentation validation.
+- `npm install`, `npm run lint`, `npm run test`, and `npm run build`.
+
+## Commands Not Run
+
+- production publish
+- supported publish action
+- setting `is_live=true`
+- setting `published_at`
+- archiving previous live rows
+- published-slate audit creation through the publish path
+- cron
+- `draft_only`
+- normal pipeline write-mode
+- direct SQL row surgery
+- direct SQL mutation
+- schema migration apply
+- migration-history repair
+- source changes
+- ranking threshold changes
+- WITM threshold changes
+- MVP measurement
+
+## Result
+
+```text
+second_controlled_cycle_blocked_witm_rewrite_required
+```
+
+## Validation
+
+- `git diff --check`: passed.
+- `python3 scripts/validate-feature-system-csv.py`: passed with pre-existing PRD slug warnings.
+- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-admin-review-final-slate-validation --pr-title "PRD-53 admin review final slate validation"`: passed.
+- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-admin-review-final-slate-validation --pr-title "PRD-53 admin review final slate validation"`: passed.
+- Initial `npm run lint` and `npm run test`: blocked because dependencies were not installed in the worktree.
+- `npm install`: completed; reported two npm audit findings.
+- Post-install `npm run lint`: passed.
+- Post-install `npm run test`: passed, 73 test files and 575 tests.
+- `npm run build`: passed.
+
+## Next Authorization Needed
+
+For the next admin rewrite/replacement pass:
+
+```text
+CONTROLLED_PRODUCTION_ADMIN_REVIEW_APPROVED=true
+```
+
+Do not include `CONTROLLED_PRODUCTION_PUBLISH_APPROVED=true` unless intentionally authorizing the supported production publish after final-slate readiness passes in a later run.


### PR DESCRIPTION
## Summary

Effective change type: operations validation / remediation alignment.

This PR records the supported production admin-review pass for the PRD-53 controlled cycle after PR #171. Five WITM-passed current non-live rows were approved through the admin workflow, and two WITM-blocked current rows were marked request rewrite. No final slate was composed because the current set has only five WITM-passed approved rows.

## Source of truth

- docs/product/prd/prd-53-signals-admin-editorial-layer.md
- docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-controlled-draft-only-rerun.md
- PRD-53 change records for composer, editorial controls, publish hardening, and audit/history

## What was run

- Admin candidate inventory for the 2026-05-01 current set
- Supported admin editorial decision pass
- Final-slate readiness observation
- Public safety verification on / and /signals
- Cron protection check

## What changed

- Admin editorial decision state only:
  - 5 current rows approved
  - 2 current rows request rewrite
- Docs-only operational packet and tracker fallback added

## What did not change

- No publish
- No cron
- No public visibility change
- No schema migration
- No migration repair
- No draft_only
- No pipeline write-mode
- No direct SQL row surgery
- No source/ranking/WITM threshold changes
- No MVP measurement

## Validation

- git diff --check: passed
- python3 scripts/validate-feature-system-csv.py: passed with pre-existing PRD slug warnings
- python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-admin-review-final-slate-validation --pr-title "PRD-53 admin review final slate validation": passed
- python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-admin-review-final-slate-validation --pr-title "PRD-53 admin review final slate validation": passed
- npm install: completed, reported existing npm audit findings
- npm run lint: passed after install
- npm run test: passed, 73 files / 575 tests
- npm run build: passed

## Result

Readiness label: second_controlled_cycle_blocked_witm_rewrite_required.

Exact next task: run an explicitly authorized admin rewrite or replacement pass for the two WITM-blocked rows, then rerun final-slate readiness. Do not authorize publish until readiness passes.