### PR TITLE
PRD-53 authorized second controlled publish

### DIFF
--- a/docs/operations/controlled-cycles/2026-05-01-prd-53-authorized-second-controlled-publish.md
+++ b/docs/operations/controlled-cycles/2026-05-01-prd-53-authorized-second-controlled-publish.md
@@ -1,0 +1,423 @@
+# PRD-53 Authorized Second Controlled Publish
+
+Date: 2026-05-01
+Branch: `codex/prd-53-authorized-second-controlled-publish`
+Readiness label: `ready_for_mvp_measurement_instrumentation`
+
+## Effective Change Type
+
+Operations validation / remediation alignment under the approved PRD-53 Signals admin editorial workflow.
+
+This packet records the supported production publish step for the validated `2026-05-01` 5 Core + 2 Context slate. It does not implement a new feature, create a new PRD, change product scope, run cron, run `draft_only`, run pipeline write-mode, apply schema migrations, run migration repair, use direct SQL row surgery, change source/ranking/WITM thresholds, start MVP measurement, start final launch-readiness QA, start Phase 2 architecture, or start personalization.
+
+Object level: production `signal_posts` public Surface Placement plus published-slate audit/history changed through the supported admin publish workflow. No Article, Story Cluster, source, ranking-threshold, or WITM-threshold changes occurred.
+
+## Source Of Truth
+
+Primary source:
+
+- `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+
+Secondary sources:
+
+- `docs/operations/controlled-cycles/2026-05-01-prd-53-admin-rewrite-replacement-pass.md`
+- `docs/operations/tracker-sync/2026-05-01-prd-53-admin-rewrite-replacement-pass.md`
+- `docs/operations/controlled-cycles/2026-05-01-prd-53-admin-review-final-slate-validation.md`
+- `docs/operations/tracker-sync/2026-05-01-prd-53-admin-review-final-slate-validation.md`
+- `docs/operations/controlled-cycles/2026-04-30-prd-53-second-controlled-cycle-rerun.md`
+- `docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-schema-apply.md`
+- `docs/engineering/change-records/prd-53-minimal-final-slate-composer.md`
+- `docs/engineering/change-records/prd-53-editorial-card-controls.md`
+- `docs/engineering/change-records/prd-53-seven-row-publish-hardening.md`
+- `docs/engineering/change-records/prd-53-minimal-published-slate-audit-history.md`
+
+## Why This Run Was Authorized
+
+PR #173 completed the admin rewrite/replacement pass and left the `2026-05-01` final slate in this state:
+
+- `7/7 selected`
+- `5/5 Core`
+- `2/2 Context`
+- `Slate ready`
+- all selected rows approved
+- all selected rows WITM-passed
+- publish not yet run
+
+This run was authorized only for the supported PRD-53 production publish action and the required post-publish verification.
+
+## Workspace Baseline
+
+| Field | Value |
+| --- | --- |
+| Worktree | `/Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-authorized-second-controlled-publish` |
+| Branch | `codex/prd-53-authorized-second-controlled-publish` |
+| Starting commit | `ae67225` |
+| Commit description | `Merge pull request #173 from brandonma25/codex/prd-53-admin-rewrite-replacement-pass` |
+| Production app URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Admin route | `/dashboard/signals/editorial-review` |
+| Current set shown in admin | `2026-05-01` |
+| Current candidate count before publish | `7` |
+| Selected final slate count before publish | `7/7` |
+| Core count before publish | `5/5` |
+| Context count before publish | `2/2` |
+| Readiness before publish | `Slate ready` |
+| Publish button before publish | Enabled |
+| Production deploy SHA | Not captured; `vercel inspect` did not return deployment metadata in this local shell. |
+
+## Authorization
+
+Prompt-level authorization present:
+
+- `CONTROLLED_PRODUCTION_PUBLISH_APPROVED=true`
+- read-only production/public verification
+- authenticated admin route inspection
+- final-slate readiness revalidation
+- supported PRD-53 publish action for the already validated `2026-05-01` final slate
+- archiving previous live rows through the supported workflow
+- setting selected final-slate rows live/published through the supported workflow
+- creating published-slate audit/history through the supported workflow
+- post-publish public and audit verification
+- documentation packet creation
+
+Prompt-level authorization absent:
+
+- cron authorization
+- `draft_only` authorization
+- pipeline write-mode authorization
+- migration-history repair authorization
+- schema migration authorization
+- direct SQL mutation authorization
+- source/ranking/WITM threshold authorization
+- MVP measurement authorization
+
+Shell environment note:
+
+- `CONTROLLED_PRODUCTION_PUBLISH_APPROVED` was authorized by the user prompt, not exported as a shell variable.
+
+No secrets, database passwords, connection strings, browser cookies, API tokens, service-role credentials, or session data were printed into docs or committed.
+
+## Commands Run
+
+PR #173 merge and baseline sync:
+
+```bash
+gh pr view 173 --json number,state,isDraft,mergeable,headRefName,baseRefName,url,statusCheckRollup
+gh pr merge 173 --merge
+gh pr view 173 --json number,state,mergedAt,mergeCommit,url
+git fetch origin main
+git worktree add /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-authorized-second-controlled-publish -b codex/prd-53-authorized-second-controlled-publish origin/main
+```
+
+Workspace identity and branch ownership checks:
+
+```bash
+pwd
+git branch --show-current
+git status --short --branch
+git worktree list
+git rev-parse --short HEAD
+```
+
+Required protocol and source-of-truth inspection:
+
+```bash
+sed -n '1,220p' AGENTS.md
+sed -n '1,220p' docs/engineering/protocols/engineering-protocol.md
+sed -n '1,220p' docs/engineering/protocols/test-checklist.md
+sed -n '1,220p' docs/engineering/protocols/prd-template.md
+sed -n '1,220p' docs/engineering/protocols/release-machine.md
+sed -n '1,260p' docs/engineering/protocols/release-automation-operating-guide.md
+sed -n '1,220p' docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md
+sed -n '1,260p' docs/product/prd/prd-53-signals-admin-editorial-layer.md
+sed -n '1,430p' docs/operations/controlled-cycles/2026-05-01-prd-53-admin-rewrite-replacement-pass.md
+sed -n '1,180p' docs/operations/tracker-sync/2026-05-01-prd-53-admin-rewrite-replacement-pass.md
+```
+
+Production public, admin, and cron verification:
+
+```bash
+node <<'NODE'
+const base = 'https://daily-intelligence-aggregator-ybs9.vercel.app';
+const titles = [
+  'Trump signs DHS legislation, ending record-breaking shutdown',
+  'Economic Letter Countdown: Most Read Topics from 2025',
+  'A Closer Look at Emerging Market Resilience During Recent Shocks',
+  'The R*-Labor Share Nexus',
+  'The AI Investing Landscape: Insights from Venture Capital',
+  'Anthropic, OpenAI back Warner-Budd workforce data bill',
+  'Congress keeps kicking surveillance reform down the road',
+  'White House plans workshops to bring Anthropic back into federal AI planning',
+  'What homeowners insurance contracts reveal about risk sharing',
+];
+for (const path of ['/', '/signals', '/api/cron/fetch-news']) {
+  const url = base + path + (path.includes('?') ? '&' : '?') + 'qa=' + Date.now();
+  const res = await fetch(url, { redirect: 'manual', headers: { 'cache-control': 'no-cache' } });
+  const text = await res.text();
+  console.log(`${path} status=${res.status}`);
+  for (const marker of [
+    'Friday, May 1',
+    'May 1, 2026',
+    'Published Signals',
+    'Top 5 Core Signals',
+    'Next 2 Context Signals',
+    'signal_posts schema preflight failed',
+    'final_slate_rank',
+    'rewrite required',
+    'WITM rewrite required',
+    'Needs Review',
+    'Slate not ready',
+  ]) console.log(`${path} marker ${JSON.stringify(marker)}=${text.includes(marker)}`);
+  for (const title of titles) console.log(`${path} title ${JSON.stringify(title)}=${text.includes(title)}`);
+}
+NODE
+node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+```
+
+Browser actions through authenticated Chrome session:
+
+- Opened `https://daily-intelligence-aggregator-ybs9.vercel.app/dashboard/signals/editorial-review?scope=current`.
+- Confirmed admin route loaded as `newsweb2026@gmail.com`.
+- Revalidated current set `2026-05-01`, seven current candidates, `7/7 selected`, `5/5 Core`, `2/2 Context`, and `Slate ready`.
+- Confirmed `Publish Final Slate` was enabled.
+- Received action-time confirmation from the user before publishing.
+- Clicked the supported `Publish Final Slate` control.
+- Confirmed success banner: `Published final slate: 5 Core + 2 Context rows are live. Archived 7 previous live rows. Audit record 3156ce1e-d052-4f88-af1b-4630f78e1104.`
+- Confirmed post-publish admin state shows selected rows as `Published`, `Live homepage set`, and `Published warning`.
+- Confirmed publish is now disabled because selected rows are already published.
+
+## Commands Intentionally Not Run
+
+- direct SQL row surgery
+- manual DB publish
+- ad hoc row mutation outside supported admin/server publish workflow
+- schema migration
+- migration repair
+- `draft_only`
+- pipeline write-mode
+- cron
+- source changes
+- ranking threshold changes
+- WITM threshold changes
+- MVP measurement
+- final launch-readiness QA
+- Phase 2 architecture
+- personalization
+
+## Baseline Public Status Before Publish
+
+| Check | Result |
+| --- | --- |
+| Homepage `/` | HTTP 200 |
+| `/signals` | HTTP 200 |
+| Public date/copy | April 29 briefing with "today's briefing is being prepared" copy |
+| `2026-05-01` non-live rows public | Not visible |
+| Public schema preflight error exposure | Not present |
+| Public PRD-53 column-name exposure | Not present |
+| Cron endpoint without auth | HTTP 401 unauthorized |
+
+## Final Slate Readiness Revalidation
+
+Pre-publish admin state:
+
+| Field | Result |
+| --- | --- |
+| Current set | `2026-05-01` |
+| Selected count | `7/7` |
+| Core count | `5/5` |
+| Context count | `2/2` |
+| Readiness badge | `Slate ready` |
+| Publish button | Enabled |
+| Audit before publish | No published slate audit record existed yet |
+
+The selected seven rows were approved and WITM-passed. No selected row was held, rejected, rewrite-requested, unresolved WITM-failed, rank-gap, duplicate-rank, or unpromoted Depth row.
+
+## Final Slate Table
+
+| Final rank | Tier | Title | Source | WITM status | Editorial decision |
+| --- | --- | --- | --- | --- | --- |
+| 1 | Core | Trump signs DHS legislation, ending record-breaking shutdown | Politico Congress | Passed | Approved |
+| 2 | Core | Economic Letter Countdown: Most Read Topics from 2025 | SF Fed Research and Insights | Passed after rewrite | Approved |
+| 3 | Core | A Closer Look at Emerging Market Resilience During Recent Shocks | Liberty Street Economics | Passed | Approved |
+| 4 | Core | The R*-Labor Share Nexus | Liberty Street Economics | Passed | Approved |
+| 5 | Core | The AI Investing Landscape: Insights from Venture Capital | SF Fed Research and Insights | Passed | Approved |
+| 6 | Context | Anthropic, OpenAI back Warner-Budd workforce data bill | Politico Congress | Passed | Approved |
+| 7 | Context | Congress keeps kicking surveillance reform down the road | The Verge | Passed after rewrite | Approved |
+
+## Publish Action Summary
+
+Supported publish action:
+
+- clicked the in-app `Publish Final Slate` control after user confirmation
+- no direct SQL
+- no manual database publish
+- no ad hoc row mutation
+
+Result:
+
+- exactly seven selected rows published
+- five Core rows live
+- two Context rows live
+- previous seven live rows archived through the supported workflow
+- publish audit record created
+
+Published audit record:
+
+```text
+3156ce1e-d052-4f88-af1b-4630f78e1104
+```
+
+Published timestamp shown by admin:
+
+```text
+2026-05-01T07:44:07.384Z
+```
+
+Archived previous live row IDs captured by audit:
+
+```text
+25f9fa0a-d2c0-445f-9f3f-4c47b2c452eb
+ff606539-f435-424f-bdd6-cb6f3833467d
+d3e7afa2-bfe4-4232-8669-ae75b7a6380b
+ee0a7572-caa0-4256-aa32-3b16056b7263
+c402254d-d34b-45a2-a8d7-3ef56c4febd8
+d54873ce-b024-4487-b12f-ab76c5dcc888
+8783ceae-91bc-4341-9895-d56bca0f9800
+```
+
+## Public Verification Result
+
+| Check | Result |
+| --- | --- |
+| Homepage `/` | HTTP 200 |
+| `/signals` | HTTP 200 |
+| Homepage date/copy | `Today - Friday, May 1` |
+| Homepage Core rows | Core ranks 1-5 visible in browser |
+| `/signals` header | `Published Signals` |
+| `/signals` count | `7 signals` |
+| `/signals` Core section | `Top 5 Core Signals` with ranks 1-5 |
+| `/signals` Context section | `Next 2 Context Signals` with ranks 6-7 |
+| Public schema preflight error exposure | Not present |
+| Public PRD-53 column-name exposure | Not present |
+| Rewrite/needs-review markers | Not present on public route probes |
+| Prior April 29 title markers checked | Not present for checked prior titles |
+| Cron endpoint without auth | HTTP 401 unauthorized |
+
+Public title verification:
+
+- Homepage route probe contained all seven published title markers in rendered HTML and browser inspection showed the Top Events surface with Core ranks 1-5.
+- `/signals` route probe and browser inspection showed all seven published title markers under `Top 5 Core Signals` and `Next 2 Context Signals`.
+- Checked prior April 29 title markers `White House plans workshops to bring Anthropic back into federal AI planning` and `What homeowners insurance contracts reveal about risk sharing`; neither appeared in post-publish route probes.
+
+## Audit And History Verification
+
+Admin audit panel verified:
+
+- latest `Published Slate Audit` record exists
+- audit record corresponds to this publish
+- row count: `7`
+- Core count: `5`
+- Context count: `2`
+- ranks 1-5 are Core
+- ranks 6-7 are Context
+- seven item snapshots are displayed with title, source, rank, tier, and decision
+- all decisions are `Approved`
+- previous live row IDs are captured
+- rollback preparation note is present
+- verification checklist exists with status `Not run`
+- no duplicate or missing item ranks were visible in the audit table
+
+Rollback preparation note shown by admin:
+
+```text
+Rollback execution is not implemented in this phase. This audit record identifies the newly published rows to un-live and the archived previous live rows to restore.
+```
+
+## Admin Verification
+
+Authenticated admin route verified after publish:
+
+- `2026-05-01` rows show `Published`
+- selected rows show `Live homepage set`
+- selected rows show `Published warning`
+- publish control is disabled because selected rows are already published
+- audit panel shows the new published-slate audit record
+- no invalid row was included in the final audit table
+
+No additional admin mutations were performed after the supported publish.
+
+## Cron Status
+
+The cron endpoint without auth returned HTTP 401 after publish.
+
+Cron was not run, re-enabled, or used to publish anything.
+
+## What Changed
+
+- exactly seven selected `2026-05-01` rows were published through the supported workflow
+- the previous seven live rows were archived through the supported workflow
+- a published-slate audit record was created with seven item snapshots, previous-live row IDs, rollback preparation copy, and verification checklist metadata
+- homepage and `/signals` now show the current May 1 briefing
+
+## What Did Not Change
+
+- no cron
+- no `draft_only`
+- no pipeline write-mode
+- no schema migration
+- no migration repair
+- no direct SQL
+- no manual DB publish
+- no source changes
+- no source governance changes
+- no ranking threshold changes
+- no WITM threshold changes
+- no public URL/domain/env/Vercel setting changes
+- no removal of `newsweb2026@gmail.com` from Production `ADMIN_EMAILS`
+- no MVP measurement
+- no final launch-readiness QA
+- no Phase 2 architecture
+- no personalization
+
+## Validation
+
+Validation commands for this docs-only PR:
+
+```bash
+git diff --check
+python3 scripts/validate-feature-system-csv.py
+python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-authorized-second-controlled-publish --pr-title "PRD-53 authorized second controlled publish"
+python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-authorized-second-controlled-publish --pr-title "PRD-53 authorized second controlled publish"
+node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+npm run lint
+npm run test
+npm run build
+```
+
+Results:
+
+- `git diff --check`: passed.
+- `python3 scripts/validate-feature-system-csv.py`: passed with pre-existing PRD slug warnings for PRD-32, PRD-37, and PRD-38.
+- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-authorized-second-controlled-publish --pr-title "PRD-53 authorized second controlled publish"`: passed.
+- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-authorized-second-controlled-publish --pr-title "PRD-53 authorized second controlled publish"`: passed.
+- `node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app`: passed; `/` and `/dashboard` returned HTTP 200.
+- Initial `npm run lint`: blocked because dependencies were not installed in the fresh worktree.
+- `npm install`: completed; reported two npm audit findings.
+- Post-install `npm run lint`: passed.
+- `npm run test`: passed, 73 test files and 575 tests.
+- `npm run build`: passed. Next.js emitted the existing workspace-root and module-type warnings, then completed successfully.
+
+## Result
+
+The supported production publish passed.
+
+The second controlled PRD-53 cycle is complete:
+
+```text
+ready_for_mvp_measurement_instrumentation
+```
+
+## Exact Next Task
+
+Review and merge this controlled-publish validation PR after checks pass.
+
+Then begin MVP measurement instrumentation in a separate prompt/branch. Cron remains blocked until separately authorized after the controlled publish is merged and the measurement/QA sequence is ready.

--- a/docs/operations/tracker-sync/2026-05-01-prd-53-authorized-second-controlled-publish.md
+++ b/docs/operations/tracker-sync/2026-05-01-prd-53-authorized-second-controlled-publish.md
@@ -1,0 +1,78 @@
+# Tracker Sync Fallback - PRD-53 Authorized Second Controlled Publish
+
+Date: 2026-05-01
+Branch: `codex/prd-53-authorized-second-controlled-publish`
+Readiness label: `ready_for_mvp_measurement_instrumentation`
+
+## Manual Tracker Update Payload
+
+| Field | Value |
+| --- | --- |
+| Record | PRD-53 Signals admin editorial layer |
+| Status | Built |
+| Decision | keep |
+| PRD File | `docs/product/prd/prd-53-signals-admin-editorial-layer.md` |
+| Latest validation packet | `docs/operations/controlled-cycles/2026-05-01-prd-53-authorized-second-controlled-publish.md` |
+| Notes | After PR #173 merged, the authorized supported PRD-53 production publish ran for the validated `2026-05-01` final slate. Exactly seven selected rows were published as 5 Core + 2 Context, the previous seven live rows were archived through the supported workflow, audit record `3156ce1e-d052-4f88-af1b-4630f78e1104` was created, homepage and `/signals` returned 200 and showed the May 1 slate, public route probes exposed no schema internals or rewrite/needs-review markers, and cron remained protected with 401. No direct SQL, manual DB publish, cron, `draft_only`, pipeline write-mode, schema/migration work, source/ranking/WITM threshold change, or MVP measurement occurred. |
+| Next task | Begin MVP measurement instrumentation in a separate prompt/branch after this validation PR is reviewed and merged. Cron remains separately blocked until explicitly authorized later. |
+
+## Source Of Truth
+
+- `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+- `docs/operations/controlled-cycles/2026-05-01-prd-53-admin-rewrite-replacement-pass.md`
+- `docs/operations/controlled-cycles/2026-05-01-prd-53-authorized-second-controlled-publish.md`
+
+## Commands Run
+
+- Merged PR #173.
+- Created the dedicated `codex/prd-53-authorized-second-controlled-publish` worktree from latest `origin/main`.
+- Ran workspace identity and branch ownership checks.
+- Read required engineering protocol and PRD-53 source-of-truth docs.
+- Revalidated final-slate readiness in authenticated Chrome admin route.
+- Ran the supported `Publish Final Slate` action after user confirmation.
+- Verified public `/`, `/signals`, and cron protection after publish.
+- Verified the admin published-slate audit record and post-publish admin state.
+- Ran repo-standard documentation validation.
+- Ran `npm run lint`, `npm run test`, and `npm run build`.
+
+## Commands Not Run
+
+- direct SQL row surgery
+- manual DB publish
+- ad hoc row mutation outside supported admin/server publish workflow
+- schema migration
+- migration repair
+- `draft_only`
+- pipeline write-mode
+- cron
+- source changes
+- ranking threshold changes
+- WITM threshold changes
+- MVP measurement
+- final launch-readiness QA
+- Phase 2 architecture
+- personalization
+
+## Result
+
+```text
+ready_for_mvp_measurement_instrumentation
+```
+
+## Validation
+
+- `git diff --check`: passed.
+- `python3 scripts/validate-feature-system-csv.py`: passed with pre-existing PRD slug warnings for PRD-32, PRD-37, and PRD-38.
+- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-authorized-second-controlled-publish --pr-title "PRD-53 authorized second controlled publish"`: passed.
+- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-authorized-second-controlled-publish --pr-title "PRD-53 authorized second controlled publish"`: passed.
+- Initial `npm run lint`: blocked because dependencies were not installed in the fresh worktree.
+- `npm install`: completed; reported two npm audit findings.
+- Post-install `npm run lint`: passed.
+- `npm run test`: passed, 73 test files and 575 tests.
+- `npm run build`: passed. Next.js emitted the existing workspace-root and module-type warnings, then completed successfully.
+
+## Next Authorization Needed
+
+MVP measurement instrumentation can begin in a separate prompt/branch after this validation PR is merged.
+
+Cron remains blocked unless separately and explicitly authorized in a later prompt.


### PR DESCRIPTION
## Effective change type

Operations validation / remediation alignment.

## Source of truth

- `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
- `docs/operations/controlled-cycles/2026-05-01-prd-53-admin-rewrite-replacement-pass.md`
- PRD-53 final-slate composer, editorial controls, publish hardening, and audit/history change records

## What was run

- Revalidated the 2026-05-01 final slate in the supported admin workflow.
- Ran the supported `Publish Final Slate` action after explicit authorization.
- Verified public `/` and `/signals` after publish.
- Verified published-slate audit/history in admin.
- Verified cron remained protected with unauthenticated 401.

## What changed

- Exactly seven selected 2026-05-01 rows were published as 5 Core + 2 Context through the supported workflow.
- The previous seven live rows were archived through the supported workflow.
- Published-slate audit record `3156ce1e-d052-4f88-af1b-4630f78e1104` was created.
- Added the controlled-publish validation packet and tracker-sync fallback.

## What did not change

- No cron.
- No schema migration.
- No migration repair.
- No direct SQL or manual DB publish.
- No `draft_only` or pipeline write-mode.
- No source/ranking/WITM threshold changes.
- No MVP measurement, final launch-readiness QA, Phase 2 architecture, or personalization.

## Validation

- `git diff --check` passed.
- `python3 scripts/validate-feature-system-csv.py` passed with pre-existing PRD slug warnings for PRD-32, PRD-37, and PRD-38.
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-authorized-second-controlled-publish --pr-title "PRD-53 authorized second controlled publish"` passed.
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-authorized-second-controlled-publish --pr-title "PRD-53 authorized second controlled publish"` passed.
- `node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app` passed.
- Initial `npm run lint` was blocked before dependencies were installed in the fresh worktree.
- `npm install` passed and reported two npm audit findings.
- Post-install `npm run lint` passed.
- `npm run test` passed: 73 files, 575 tests.
- `npm run build` passed with existing Next workspace-root and module-type warnings.

## Result

`ready_for_mvp_measurement_instrumentation`

Next task: begin MVP measurement instrumentation in a separate branch after this validation PR is reviewed and merged. Cron remains blocked until separately authorized.
