### PR TITLE
MVP measurement instrumentation

### DIFF
--- a/docs/engineering/change-records/mvp-measurement-instrumentation.md
+++ b/docs/engineering/change-records/mvp-measurement-instrumentation.md
@@ -1,0 +1,210 @@
+# MVP Measurement Instrumentation
+
+Date: 2026-05-01
+Branch: `codex/mvp-measurement-instrumentation`
+Readiness label: `ready_for_final_launch_readiness_qa`
+Canonical PRD required: `No`
+
+## Effective Change Type
+
+Remediation / product analytics instrumentation.
+
+This is measurement support for the approved Boot Up MVP success criteria. It does not add a new product surface by default, create a new PRD, alter ranking, change source governance, re-enable cron, publish content, run `draft_only`, start Phase 2 architecture, or start personalization.
+
+Object level changed:
+
+- Signal/Card/Surface Placement measurement only.
+- `public.signal_posts` remains legacy/runtime storage for published Surface Placement plus Card copy. This change does not create canonical Signal identity or use analytics to change product behavior.
+
+## Source Of Truth
+
+Primary:
+
+- Product Position - MVP Success Criteria:
+  - day-7 retention: 40%+ of users return on day 7 without re-engagement prompt
+  - depth engagement: 60%+ of sessions include at least one full signal expansion
+  - comprehension signal: 70%+ of users in a post-session prompt agree they could explain at least one signal
+  - failure threshold: day-7 retention below 25%, or fewer than 40% of users expand at least one signal in first three sessions
+
+Secondary:
+
+- `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+- `docs/operations/controlled-cycles/2026-05-01-prd-53-authorized-second-controlled-publish.md`
+- `docs/operations/tracker-sync/2026-05-01-prd-53-authorized-second-controlled-publish.md`
+- `docs/engineering/change-records/prd-53-minimal-final-slate-composer.md`
+- `docs/engineering/change-records/prd-53-editorial-card-controls.md`
+- `docs/engineering/change-records/prd-53-seven-row-publish-hardening.md`
+- `docs/engineering/change-records/prd-53-minimal-published-slate-audit-history.md`
+
+## Success Criteria Mapping
+
+| MVP question | Implemented signal | Notes |
+| --- | --- | --- |
+| Are users returning by day 7? | anonymous `visitor_id`, `session_id`, event timestamps, `homepage_view`, `signals_page_view` | Summary helper calculates exact day-7 return based on first event date and a return event seven calendar days later. |
+| Are users expanding at least one full signal? | `signal_full_expansion_proxy`, `signal_details_click`, `source_click` | Current UI does not expose a single four-layer per-Signal expansion. The helper reports strict full-expansion events separately from proxy expansion. |
+| Can users report that they could explain at least one signal? | event schema accepts `comprehension_prompt_shown` and `comprehension_prompt_answered` | Visible prompt UI is deferred because there is no existing prompt/survey pattern in the repo. |
+| Are users treating Boot Up like a briefing rather than a headline feed? | page view, details, expansion proxy, and source-click events by route/surface/rank | Measurement can compare passive page views with deeper Signal/Card interactions. |
+
+## Implemented Events
+
+Stored event names:
+
+- `homepage_view`
+- `signals_page_view`
+- `signal_card_expand`
+- `signal_full_expansion`
+- `signal_full_expansion_proxy`
+- `signal_details_click`
+- `source_click`
+- `comprehension_prompt_shown`
+- `comprehension_prompt_answered`
+
+`signal_full_expansion_proxy` is used where the current homepage can expand a Card's `Why it matters` section, but does not yet expose the complete four-layer Signal model as one explicit UI action.
+
+## Storage And API
+
+Added additive schema:
+
+- `supabase/migrations/20260501100000_mvp_measurement_events.sql`
+- `public.mvp_measurement_events`
+
+Captured fields:
+
+- anonymous first-party visitor id
+- anonymous session id
+- event name
+- server event timestamp
+- route/surface
+- legacy `signal_post_id`, where a published Surface Placement/Card row id is available
+- signal slug/title and rank, where available
+- briefing date
+- published slate id, where available
+- bounded metadata JSON
+- authenticated user id only when already safely available from the existing Supabase session
+
+Added event API:
+
+- `POST /api/mvp-measurement/events`
+
+The endpoint validates event names and payload shape, writes through the existing service-role server client, and soft-fails with HTTP 202 if measurement storage is unavailable. Measurement failure must not break reading, ranking, visibility, or navigation.
+
+## Page And Interaction Instrumentation
+
+Homepage `/`:
+
+- emits `homepage_view`
+- records briefing date, visible Top Events count, public ranked signal count, Core count, Context count, and whether the rendered read model contains Core + Context
+- emits `signal_details_click` for the existing Details link
+- emits `signal_full_expansion_proxy` when a user expands homepage `Why it matters`
+- emits `source_click` for supporting coverage links
+
+Signals page `/signals`:
+
+- emits `signals_page_view`
+- records briefing date, visible signal count, Core count, Context count, and published-state kind
+- emits `source_click` for published source links
+
+## Summary Helper
+
+Added:
+
+- `src/lib/mvp-measurement-summary.ts`
+- `scripts/mvp-measurement-summary.ts`
+
+The helper summarizes:
+
+- event count by date
+- event count by route
+- unique visitor count
+- unique session count
+- day-7 return denominator/numerator/rate
+- strict full-expansion session rate
+- proxy expansion session rate
+- first-three-sessions expansion rate
+- comprehension prompt shown/answered/agreement rate, once prompt events exist
+
+## Privacy And Data Minimization
+
+Collected:
+
+- first-party anonymous visitor id in localStorage
+- first-party anonymous session id in sessionStorage
+- route/surface/event metadata needed for MVP success criteria
+- published Signal/Card placement identifiers where available
+- authenticated Supabase user id only when the existing session safely provides it
+
+Not collected:
+
+- email addresses
+- raw IP addresses
+- third-party advertising identifiers
+- cross-site tracking IDs
+- source secrets, service keys, database passwords, browser cookies, auth headers, or connection strings
+
+Behavior guarantees:
+
+- no personalization
+- no behavioral ranking
+- no ranking threshold changes
+- no WITM threshold changes
+- no source changes
+- no public visibility changes
+- no analytics-driven product behavior
+
+## Deferred Or Limited
+
+- Comprehension prompt UI is not implemented in this change because the repo has no existing post-session survey/prompt pattern. The event schema and summary support are ready, but visible prompt UX requires explicit product approval or PRD coverage.
+- Strict "all four layers opened" depth engagement cannot be measured exactly until the UI exposes a discrete four-layer Signal expansion. This PR records the strongest available proxies and reports proxy expansion separately from strict full expansion.
+- Production collection requires the additive `mvp_measurement_events` migration to be applied through the normal authorized schema process. The endpoint soft-fails until the table exists.
+
+## What Did Not Change
+
+- no cron
+- no publish
+- no `draft_only`
+- no pipeline write-mode
+- no source governance change
+- no added sources
+- no ranking threshold change
+- no WITM threshold change
+- no public URL/domain/env/Vercel setting change
+- no Phase 2 architecture
+- no Phase 3 personalization
+- no behavior change based on analytics events
+- no removal of `newsweb2026@gmail.com` from Production `ADMIN_EMAILS`
+
+## Validation
+
+Commands run:
+
+```bash
+npm install
+git diff --check
+npm run lint
+npm run test
+npm run build
+python3 scripts/validate-feature-system-csv.py
+python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/mvp-measurement-instrumentation --pr-title "MVP measurement instrumentation"
+python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/mvp-measurement-instrumentation --pr-title "MVP measurement instrumentation"
+PLAYWRIGHT_MANAGED_WEBSERVER=1 npm run test:e2e:chromium
+PLAYWRIGHT_MANAGED_WEBSERVER=1 npm run test:e2e:webkit
+```
+
+Results:
+
+- `npm install` passed.
+- `git diff --check` passed.
+- `npm run lint` passed.
+- `npm run test` passed: 77 test files, 586 tests.
+- `npm run build` passed.
+- `python3 scripts/validate-feature-system-csv.py` passed with existing PRD slug warnings for PRD-32, PRD-37, and PRD-38.
+- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/mvp-measurement-instrumentation --pr-title "MVP measurement instrumentation"` passed.
+- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/mvp-measurement-instrumentation --pr-title "MVP measurement instrumentation"` passed.
+- `PLAYWRIGHT_MANAGED_WEBSERVER=1 npm run test:e2e:chromium` passed: 33 tests.
+- `PLAYWRIGHT_MANAGED_WEBSERVER=1 npm run test:e2e:webkit` passed: 33 tests.
+
+Generated `.next` caches from old worktrees were cleared after local disk pressure caused earlier build/test artifact writes to fail with `ENOSPC`. Only regenerable Next.js build caches were removed; no source, env, Vercel, or git state was altered.
+
+## Next Task
+
+After this PR is reviewed, deployed, and the additive measurement schema is applied through the normal authorized process, run final launch-readiness QA. Cron remains last and separately authorized.

--- a/docs/operations/tracker-sync/2026-05-01-mvp-measurement-instrumentation.md
+++ b/docs/operations/tracker-sync/2026-05-01-mvp-measurement-instrumentation.md
@@ -1,0 +1,38 @@
+# Tracker Sync Fallback - MVP Measurement Instrumentation
+
+Date: 2026-05-01
+Branch: `codex/mvp-measurement-instrumentation`
+Readiness label: `ready_for_final_launch_readiness_qa`
+
+## Manual Tracker Update Payload
+
+| Field | Value |
+| --- | --- |
+| Record | Product Position - MVP Success Criteria |
+| Status | In Review |
+| Decision | keep |
+| PRD File | Not applicable; instrumentation is remediation/product analytics support for the approved Product Position and PRD-53 controlled publish completion. |
+| Latest validation packet | `docs/engineering/change-records/mvp-measurement-instrumentation.md` |
+| Notes | Adds privacy-conscious MVP measurement instrumentation for day-7 return, page views, Signal/Card depth engagement proxies, source/details clicks, and future comprehension prompt events. Adds additive `mvp_measurement_events` schema, soft-failing event API, page/interaction instrumentation, summary helper, focused tests, and privacy notes. Does not add a visible comprehension prompt UI because no existing prompt pattern exists; that user-facing prompt remains pending explicit product approval or PRD coverage. No cron, publish, `draft_only`, pipeline write-mode, source/ranking/WITM threshold changes, Phase 2 architecture, or personalization. |
+| Next task | Review and merge this PR, apply the additive measurement schema through the authorized schema process, then run final launch-readiness QA. Cron remains last and separately authorized. |
+
+## Source Of Truth
+
+- Product Position - MVP Success Criteria
+- `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+- `docs/operations/controlled-cycles/2026-05-01-prd-53-authorized-second-controlled-publish.md`
+- `docs/engineering/change-records/mvp-measurement-instrumentation.md`
+
+## Validation
+
+Local validation passed:
+
+- `git diff --check`
+- `npm run lint`
+- `npm run test`
+- `npm run build`
+- `python3 scripts/validate-feature-system-csv.py`
+- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/mvp-measurement-instrumentation --pr-title "MVP measurement instrumentation"`
+- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/mvp-measurement-instrumentation --pr-title "MVP measurement instrumentation"`
+- `PLAYWRIGHT_MANAGED_WEBSERVER=1 npm run test:e2e:chromium`
+- `PLAYWRIGHT_MANAGED_WEBSERVER=1 npm run test:e2e:webkit`

--- a/scripts/mvp-measurement-summary.ts
+++ b/scripts/mvp-measurement-summary.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+import { createClient } from "@supabase/supabase-js";
+
+import {
+  summarizeMvpMeasurementEvents,
+  type MvpMeasurementSummaryRow,
+} from "@/lib/mvp-measurement-summary";
+import { env, isSupabaseServerConfigured } from "@/lib/env";
+
+function parseDays() {
+  const flagIndex = process.argv.findIndex((arg) => arg === "--days");
+  const rawValue = flagIndex >= 0 ? process.argv[flagIndex + 1] : "30";
+  const parsed = Number.parseInt(rawValue ?? "30", 10);
+
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 30;
+}
+
+async function main() {
+  if (!isSupabaseServerConfigured) {
+    throw new Error("Supabase server configuration is required to summarize MVP measurement events.");
+  }
+
+  const days = parseDays();
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+  const client = createClient(env.supabaseUrl, env.supabaseServiceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+
+  const result = await client
+    .from("mvp_measurement_events")
+    .select("event_name, visitor_id, session_id, occurred_at, route, metadata")
+    .gte("occurred_at", since)
+    .order("occurred_at", { ascending: true })
+    .limit(10000);
+
+  if (result.error) {
+    throw new Error(result.error.message);
+  }
+
+  const summary = summarizeMvpMeasurementEvents(
+    (result.data ?? []) as unknown as MvpMeasurementSummaryRow[],
+  );
+
+  console.log(JSON.stringify({
+    ok: true,
+    windowDays: days,
+    since,
+    summary,
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/app/api/mvp-measurement/events/route.test.ts
+++ b/src/app/api/mvp-measurement/events/route.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const createSupabaseServiceRoleClient = vi.fn();
+const safeGetUser = vi.fn();
+const logServerEvent = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServiceRoleClient,
+  safeGetUser,
+}));
+
+vi.mock("@/lib/observability", () => ({
+  logServerEvent,
+}));
+
+function buildRequest(body: unknown) {
+  return new Request("http://localhost:3000/api/mvp-measurement/events", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function buildValidBody(overrides: Record<string, unknown> = {}) {
+  return {
+    eventName: "homepage_view",
+    visitorId: "mvp_1234567890abcdef",
+    sessionId: "mvp_session_1234567890abcdef",
+    route: "/",
+    surface: "home",
+    briefingDate: "2026-05-01",
+    metadata: {
+      visibleSignalCount: 5,
+    },
+    ...overrides,
+  };
+}
+
+describe("/api/mvp-measurement/events", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    safeGetUser.mockResolvedValue({
+      user: { id: "user-1" },
+    });
+  });
+
+  it("accepts and stores valid events", async () => {
+    const insert = vi.fn(async () => ({ error: null }));
+    const from = vi.fn(() => ({ insert }));
+    createSupabaseServiceRoleClient.mockReturnValue({ from });
+
+    const { POST } = await import("@/app/api/mvp-measurement/events/route");
+    const response = await POST(buildRequest(buildValidBody()));
+    const body = await response.json();
+
+    expect(response.status).toBe(202);
+    expect(body).toEqual({ ok: true, stored: true });
+    expect(from).toHaveBeenCalledWith("mvp_measurement_events");
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_name: "homepage_view",
+        visitor_id: "mvp_1234567890abcdef",
+        session_id: "mvp_session_1234567890abcdef",
+        user_id: "user-1",
+        route: "/",
+        briefing_date: "2026-05-01",
+      }),
+    );
+  });
+
+  it("rejects invalid event names", async () => {
+    const { POST } = await import("@/app/api/mvp-measurement/events/route");
+    const response = await POST(buildRequest(buildValidBody({ eventName: "rank_for_me" })));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      ok: false,
+      error: "Unsupported event name.",
+    });
+    expect(createSupabaseServiceRoleClient).not.toHaveBeenCalled();
+  });
+
+  it("soft-fails when measurement storage is unavailable", async () => {
+    createSupabaseServiceRoleClient.mockReturnValue(null);
+
+    const { POST } = await import("@/app/api/mvp-measurement/events/route");
+    const response = await POST(buildRequest(buildValidBody()));
+    const body = await response.json();
+
+    expect(response.status).toBe(202);
+    expect(body).toEqual({
+      ok: true,
+      stored: false,
+      reason: "measurement_storage_unavailable",
+    });
+  });
+
+  it("does not expose storage failures to public readers", async () => {
+    const insert = vi.fn(async () => ({ error: { message: "relation missing" } }));
+    createSupabaseServiceRoleClient.mockReturnValue({
+      from: vi.fn(() => ({ insert })),
+    });
+
+    const { POST } = await import("@/app/api/mvp-measurement/events/route");
+    const response = await POST(buildRequest(buildValidBody()));
+    const body = await response.json();
+
+    expect(response.status).toBe(202);
+    expect(body).toEqual({
+      ok: true,
+      stored: false,
+      reason: "measurement_insert_failed",
+    });
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "warn",
+      "MVP measurement event storage failed",
+      expect.objectContaining({
+        eventName: "homepage_view",
+      }),
+    );
+  });
+});

--- a/src/app/api/mvp-measurement/events/route.ts
+++ b/src/app/api/mvp-measurement/events/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+
+import { logServerEvent } from "@/lib/observability";
+import { validateMvpMeasurementEvent } from "@/lib/mvp-measurement";
+import {
+  createSupabaseServiceRoleClient,
+  safeGetUser,
+} from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Invalid JSON body.",
+      },
+      { status: 400 },
+    );
+  }
+
+  const validation = validateMvpMeasurementEvent(body);
+  if (!validation.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: validation.error,
+      },
+      { status: 400 },
+    );
+  }
+
+  const client = createSupabaseServiceRoleClient();
+  if (!client) {
+    return NextResponse.json(
+      {
+        ok: true,
+        stored: false,
+        reason: "measurement_storage_unavailable",
+      },
+      { status: 202 },
+    );
+  }
+
+  let userId: string | null = null;
+  try {
+    const authState = await safeGetUser("/api/mvp-measurement/events");
+    userId = authState.user?.id ?? null;
+  } catch {
+    userId = null;
+  }
+
+  const event = validation.value;
+  const insertResult = await client.from("mvp_measurement_events").insert({
+    event_name: event.eventName,
+    visitor_id: event.visitorId,
+    session_id: event.sessionId,
+    user_id: userId,
+    route: event.route,
+    surface: event.surface,
+    signal_post_id: event.signalPostId,
+    signal_slug: event.signalSlug,
+    signal_rank: event.signalRank,
+    briefing_date: event.briefingDate,
+    published_slate_id: event.publishedSlateId,
+    metadata: event.metadata ?? {},
+  });
+
+  if (insertResult.error) {
+    logServerEvent("warn", "MVP measurement event storage failed", {
+      route: "/api/mvp-measurement/events",
+      eventName: event.eventName,
+      errorMessage: insertResult.error.message,
+    });
+
+    return NextResponse.json(
+      {
+        ok: true,
+        stored: false,
+        reason: "measurement_insert_failed",
+      },
+      { status: 202 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      stored: true,
+    },
+    { status: 202 },
+  );
+}

--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { ExternalLink } from "lucide-react";
 
+import { MvpMeasurementTracker } from "@/components/mvp-measurement/MvpMeasurementTracker";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Panel } from "@/components/ui/panel";
@@ -23,9 +24,25 @@ export default async function PublicSignalsPage() {
   const corePosts = posts.filter((post) => post.rank >= 1 && post.rank <= 5);
   const contextPosts = posts.filter((post) => post.rank >= 6 && post.rank <= 7);
   const hasPublishedPosts = state.kind === "published";
+  const briefingDate = posts[0]?.briefingDate ?? null;
 
   return (
     <main className="mx-auto min-h-screen w-full max-w-6xl px-4 py-6 md:px-6">
+      <MvpMeasurementTracker
+        pageView={{
+          eventName: "signals_page_view",
+          route: "/signals",
+          surface: "signals_index",
+          briefingDate,
+          metadata: {
+            visibleSignalCount: posts.length,
+            coreSignalCount: corePosts.length,
+            contextSignalCount: contextPosts.length,
+            rendersCoreAndContext: corePosts.length === 5 && contextPosts.length === 2,
+            stateKind: state.kind,
+          },
+        }}
+      />
       <div className="space-y-5">
         <header className="space-y-4 border-b border-[var(--border)] pb-5">
           <div className="flex flex-wrap items-center gap-2">
@@ -50,15 +67,17 @@ export default async function PublicSignalsPage() {
         {hasPublishedPosts ? (
           <div className="space-y-7">
             <SignalSection
-              title="Top 5 Core Signals"
-              description="The five highest-priority published Signals for the current briefing."
-              posts={corePosts}
-            />
+                title="Top 5 Core Signals"
+                description="The five highest-priority published Signals for the current briefing."
+                posts={corePosts}
+                briefingDate={briefingDate}
+              />
             {contextPosts.length > 0 ? (
               <SignalSection
                 title="Next 2 Context Signals"
                 description="Published Context Signals that add useful adjacent explanation without displacing the Core slate."
                 posts={contextPosts}
+                briefingDate={briefingDate}
               />
             ) : null}
           </div>
@@ -90,10 +109,12 @@ function SignalSection({
   title,
   description,
   posts,
+  briefingDate,
 }: {
   title: string;
   description: string;
   posts: EditorialSignalPost[];
+  briefingDate: string | null;
 }) {
   if (posts.length === 0) {
     return null;
@@ -132,6 +153,14 @@ function SignalSection({
                           target="_blank"
                           rel="noreferrer"
                           className="inline-flex items-center gap-1 text-[var(--accent)] hover:underline"
+                          data-mvp-measurement-event="source_click"
+                          data-mvp-route="/signals"
+                          data-mvp-surface="signals_published_slate"
+                          data-mvp-signal-post-id={post.id}
+                          data-mvp-signal-slug={post.title}
+                          data-mvp-signal-rank={post.rank}
+                          data-mvp-briefing-date={briefingDate ?? undefined}
+                          data-mvp-source-name={post.sourceName || "Unknown source"}
                         >
                           Source
                           <ExternalLink className="h-3.5 w-3.5" />

--- a/src/components/landing/homepage.tsx
+++ b/src/components/landing/homepage.tsx
@@ -9,6 +9,7 @@ import { BriefingCardCategory } from "@/components/home/BriefingCardCategory";
 import { CategoryPreviewGrid } from "@/components/home/CategoryPreviewGrid";
 import { CategoryTabStrip } from "@/components/home/CategoryTabStrip";
 import { DevelopingNow } from "@/components/home/DevelopingNow";
+import { MvpMeasurementTracker } from "@/components/mvp-measurement/MvpMeasurementTracker";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Panel } from "@/components/ui/panel";
@@ -21,6 +22,7 @@ import {
   buildIntentionalEditorialPreview,
   type EditorialWhyItMattersContent,
 } from "@/lib/editorial-content";
+import { trackMvpMeasurementEvent } from "@/lib/mvp-measurement-client";
 import type { DashboardData, ViewerAccount } from "@/lib/types";
 import { cn, getBriefingDateKey, minutesToLabel } from "@/lib/utils";
 
@@ -55,6 +57,21 @@ export default function LandingHomepage({
 
   return (
     <AppShell currentPath="/" mode={data.mode} account={viewer}>
+      <MvpMeasurementTracker
+        pageView={{
+          eventName: "homepage_view",
+          route: "/",
+          surface: "home",
+          briefingDate: briefingDateKey,
+          metadata: {
+            visibleSignalCount: topEvents.length,
+            publicRankedSignalCount: data.publicRankedItems?.length ?? topEvents.length,
+            coreSignalCount: homepageViewModel.debug.coreSignalCount,
+            contextSignalCount: homepageViewModel.debug.contextSignalCount,
+            rendersCoreAndContext: homepageViewModel.debug.coreSignalCount >= 5 && homepageViewModel.debug.contextSignalCount >= 2,
+          },
+        }}
+      />
       <div className="space-y-5 py-2">
         {authMessage ? (
           <Panel className="p-4" role="alert">
@@ -187,6 +204,13 @@ function HomeTopEventCard({
           <Link
             href={detailHref}
             className="text-sm font-semibold text-[var(--accent)] underline-offset-4 hover:underline"
+            data-mvp-measurement-event="signal_details_click"
+            data-mvp-route="/"
+            data-mvp-surface="home_top_event"
+            data-mvp-signal-post-id={event.id}
+            data-mvp-signal-slug={event.title}
+            data-mvp-signal-rank={rank}
+            data-mvp-briefing-date={detailHref.replace("/briefing/", "")}
           >
             Details
           </Link>
@@ -213,7 +237,18 @@ function HomeTopEventCard({
             <p className="text-[0.7rem] font-semibold uppercase tracking-[0.08em] text-[var(--text-secondary)]">
               Why it matters
             </p>
-            <WhyItMattersPreview text={whyItMatters} structuredContent={event.editorialWhyItMatters} />
+            <WhyItMattersPreview
+              text={whyItMatters}
+              structuredContent={event.editorialWhyItMatters}
+              measurement={{
+                route: "/",
+                surface: "home_top_event",
+                signalPostId: event.id,
+                signalSlug: event.title,
+                signalRank: rank,
+                briefingDate: detailHref.replace("/briefing/", ""),
+              }}
+            />
           </div>
         ) : null}
 
@@ -247,6 +282,14 @@ function HomeTopEventCard({
                   target="_blank"
                   rel="noreferrer"
                   className="flex items-start justify-between gap-3 rounded-card border border-[var(--border)] bg-[var(--card)] px-3 py-3 text-sm text-[var(--text-primary)] transition-colors hover:border-[var(--text-secondary)]"
+                  data-mvp-measurement-event="source_click"
+                  data-mvp-route="/"
+                  data-mvp-surface="home_top_event_supporting_coverage"
+                  data-mvp-signal-post-id={event.id}
+                  data-mvp-signal-slug={event.title}
+                  data-mvp-signal-rank={rank}
+                  data-mvp-briefing-date={detailHref.replace("/briefing/", "")}
+                  data-mvp-source-name={article.sourceName}
                 >
                   <span className="min-w-0">
                     <span className="font-semibold">{article.sourceName}</span>
@@ -268,9 +311,18 @@ const WHY_IT_MATTERS_PREVIEW_THRESHOLD = 220;
 function WhyItMattersPreview({
   text,
   structuredContent,
+  measurement,
 }: {
   text: string;
   structuredContent?: EditorialWhyItMattersContent | null;
+  measurement: {
+    route: string;
+    surface: string;
+    signalPostId: string;
+    signalSlug: string;
+    signalRank: number;
+    briefingDate: string;
+  };
 }) {
   const [expanded, setExpanded] = useState(false);
   const normalizedText = text.trim();
@@ -310,7 +362,19 @@ function WhyItMattersPreview({
           type="button"
           aria-expanded={expanded}
           className="mt-3 inline-flex text-sm font-semibold text-[var(--accent)] underline-offset-4 hover:underline"
-          onClick={() => setExpanded((current) => !current)}
+          onClick={() => {
+            if (!expanded) {
+              void trackMvpMeasurementEvent({
+                eventName: "signal_full_expansion_proxy",
+                ...measurement,
+                metadata: {
+                  proxyReason: "homepage_why_it_matters_read_more",
+                  hasStructuredWhyItMatters: Boolean(structuredExpandedContent),
+                },
+              });
+            }
+            setExpanded((current) => !current);
+          }}
         >
           {expanded ? "Show less" : "Read more"}
         </button>

--- a/src/components/mvp-measurement/MvpMeasurementTracker.test.tsx
+++ b/src/components/mvp-measurement/MvpMeasurementTracker.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MvpMeasurementTracker } from "@/components/mvp-measurement/MvpMeasurementTracker";
+
+function installStorage(name: "localStorage" | "sessionStorage") {
+  const storage = new Map<string, string>();
+  Object.defineProperty(window, name, {
+    configurable: true,
+    value: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+      clear: () => storage.clear(),
+    },
+  });
+}
+
+describe("MvpMeasurementTracker", () => {
+  beforeEach(() => {
+    installStorage("localStorage");
+    installStorage("sessionStorage");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ ok: true, stored: true }), { status: 202 })),
+    );
+  });
+
+  it("emits a homepage view event with anonymous visitor and session identifiers", async () => {
+    render(
+      <MvpMeasurementTracker
+        pageView={{
+          eventName: "homepage_view",
+          route: "/",
+          surface: "home",
+          briefingDate: "2026-05-01",
+          metadata: {
+            visibleSignalCount: 5,
+          },
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const payload = JSON.parse(String(init?.body));
+
+    expect(payload).toMatchObject({
+      eventName: "homepage_view",
+      route: "/",
+      surface: "home",
+      briefingDate: "2026-05-01",
+      metadata: {
+        visibleSignalCount: 5,
+      },
+    });
+    expect(payload.visitorId).toMatch(/^mvp_/);
+    expect(payload.sessionId).toMatch(/^mvp_session_/);
+  });
+
+  it("emits source click events from instrumented links", async () => {
+    render(
+      <>
+        <MvpMeasurementTracker
+          pageView={{
+            eventName: "signals_page_view",
+            route: "/signals",
+            surface: "signals_index",
+            briefingDate: "2026-05-01",
+          }}
+        />
+        <a
+          href="https://example.com"
+          data-mvp-measurement-event="source_click"
+          data-mvp-route="/signals"
+          data-mvp-surface="signals_published_slate"
+          data-mvp-signal-post-id="3156ce1e-d052-4f88-af1b-4630f78e1104"
+          data-mvp-signal-rank="7"
+          data-mvp-source-name="Example"
+        >
+          Source
+        </a>
+      </>,
+    );
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole("link", { name: "Source" }));
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[1]!;
+    const payload = JSON.parse(String(init?.body));
+
+    expect(payload).toMatchObject({
+      eventName: "source_click",
+      route: "/signals",
+      surface: "signals_published_slate",
+      signalPostId: "3156ce1e-d052-4f88-af1b-4630f78e1104",
+      signalRank: 7,
+      briefingDate: "2026-05-01",
+      metadata: {
+        sourceName: "Example",
+        linkText: "Source",
+      },
+    });
+  });
+});

--- a/src/components/mvp-measurement/MvpMeasurementTracker.tsx
+++ b/src/components/mvp-measurement/MvpMeasurementTracker.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import type { MvpMeasurementEventInput } from "@/lib/mvp-measurement";
+import {
+  readMvpMeasurementDataset,
+  trackMvpMeasurementEvent,
+} from "@/lib/mvp-measurement-client";
+
+type PageViewEvent = Omit<MvpMeasurementEventInput, "visitorId" | "sessionId">;
+
+export function MvpMeasurementTracker({
+  pageView,
+}: {
+  pageView: PageViewEvent;
+}) {
+  const trackedPageView = useRef(false);
+
+  useEffect(() => {
+    if (!trackedPageView.current) {
+      trackedPageView.current = true;
+      void trackMvpMeasurementEvent(pageView);
+    }
+  }, [pageView]);
+
+  useEffect(() => {
+    function handleClick(event: MouseEvent) {
+      const target = event.target instanceof Element ? event.target : null;
+      const element = target?.closest("[data-mvp-measurement-event]");
+
+      if (!(element instanceof HTMLElement)) {
+        return;
+      }
+
+      const measurementEvent = readMvpMeasurementDataset(element);
+      if (!measurementEvent) {
+        return;
+      }
+
+      void trackMvpMeasurementEvent({
+        ...measurementEvent,
+        route: measurementEvent.route ?? pageView.route,
+        briefingDate: measurementEvent.briefingDate ?? pageView.briefingDate,
+        publishedSlateId: measurementEvent.publishedSlateId ?? pageView.publishedSlateId,
+      });
+    }
+
+    document.addEventListener("click", handleClick);
+    return () => document.removeEventListener("click", handleClick);
+  }, [pageView]);
+
+  return null;
+}

--- a/src/lib/mvp-measurement-client.ts
+++ b/src/lib/mvp-measurement-client.ts
@@ -1,0 +1,135 @@
+"use client";
+
+import {
+  isMvpMeasurementEventName,
+  isUuid,
+  type MvpMeasurementEventInput,
+  type MvpMeasurementEventName,
+} from "@/lib/mvp-measurement";
+
+const VISITOR_STORAGE_KEY = "bootup:mvp-measurement:visitor-id";
+const SESSION_STORAGE_KEY = "bootup:mvp-measurement:session-id";
+
+function createId(prefix: string) {
+  const randomId =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+
+  return `${prefix}_${randomId.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
+}
+
+function readStorage(storage: Storage | undefined, key: string) {
+  try {
+    return storage?.getItem(key) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStorage(storage: Storage | undefined, key: string, value: string) {
+  try {
+    storage?.setItem(key, value);
+  } catch {
+    // Measurement must never block reading. If storage is unavailable, the
+    // caller still receives an ephemeral identifier for this event.
+  }
+}
+
+export function getOrCreateMvpVisitorId() {
+  const existing = readStorage(
+    typeof window !== "undefined" ? window.localStorage : undefined,
+    VISITOR_STORAGE_KEY,
+  );
+
+  if (existing?.startsWith("mvp_")) {
+    return existing;
+  }
+
+  const visitorId = createId("mvp");
+  writeStorage(
+    typeof window !== "undefined" ? window.localStorage : undefined,
+    VISITOR_STORAGE_KEY,
+    visitorId,
+  );
+  return visitorId;
+}
+
+export function getOrCreateMvpSessionId() {
+  const existing = readStorage(
+    typeof window !== "undefined" ? window.sessionStorage : undefined,
+    SESSION_STORAGE_KEY,
+  );
+
+  if (existing?.startsWith("mvp_session_")) {
+    return existing;
+  }
+
+  const sessionId = createId("mvp_session");
+  writeStorage(
+    typeof window !== "undefined" ? window.sessionStorage : undefined,
+    SESSION_STORAGE_KEY,
+    sessionId,
+  );
+  return sessionId;
+}
+
+export function getSignalPostIdFromLegacyId(value: string | null | undefined) {
+  return isUuid(value) ? value : null;
+}
+
+export async function trackMvpMeasurementEvent(
+  input: Omit<MvpMeasurementEventInput, "visitorId" | "sessionId"> & {
+    eventName: MvpMeasurementEventName;
+  },
+) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const payload: MvpMeasurementEventInput = {
+    ...input,
+    visitorId: getOrCreateMvpVisitorId(),
+    sessionId: getOrCreateMvpSessionId(),
+  };
+
+  try {
+    await fetch("/api/mvp-measurement/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(payload),
+      keepalive: true,
+    });
+  } catch {
+    // Best-effort instrumentation only. Measurement failures must not affect
+    // public reading, ranking, visibility, or navigation.
+  }
+}
+
+export function readMvpMeasurementDataset(element: HTMLElement) {
+  const eventName = element.dataset.mvpMeasurementEvent;
+  if (!isMvpMeasurementEventName(eventName)) {
+    return null;
+  }
+
+  const signalRank = element.dataset.mvpSignalRank
+    ? Number.parseInt(element.dataset.mvpSignalRank, 10)
+    : null;
+
+  return {
+    eventName,
+    route: element.dataset.mvpRoute ?? null,
+    surface: element.dataset.mvpSurface ?? null,
+    signalPostId: getSignalPostIdFromLegacyId(element.dataset.mvpSignalPostId),
+    signalSlug: element.dataset.mvpSignalSlug ?? null,
+    signalRank: Number.isFinite(signalRank) ? signalRank : null,
+    briefingDate: element.dataset.mvpBriefingDate ?? null,
+    publishedSlateId: element.dataset.mvpPublishedSlateId ?? null,
+    metadata: {
+      sourceName: element.dataset.mvpSourceName,
+      linkText: element.textContent?.trim().slice(0, 160),
+    },
+  };
+}

--- a/src/lib/mvp-measurement-summary.test.ts
+++ b/src/lib/mvp-measurement-summary.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { summarizeMvpMeasurementEvents } from "@/lib/mvp-measurement-summary";
+
+describe("MVP measurement summary", () => {
+  it("summarizes retention, expansion proxies, comprehension, dates, and routes", () => {
+    const summary = summarizeMvpMeasurementEvents([
+      {
+        event_name: "homepage_view",
+        visitor_id: "mvp_visitor_a",
+        session_id: "mvp_session_a1",
+        occurred_at: "2026-05-01T12:00:00.000Z",
+        route: "/",
+      },
+      {
+        event_name: "signal_details_click",
+        visitor_id: "mvp_visitor_a",
+        session_id: "mvp_session_a1",
+        occurred_at: "2026-05-01T12:01:00.000Z",
+        route: "/",
+      },
+      {
+        event_name: "homepage_view",
+        visitor_id: "mvp_visitor_a",
+        session_id: "mvp_session_a2",
+        occurred_at: "2026-05-08T12:00:00.000Z",
+        route: "/",
+      },
+      {
+        event_name: "signals_page_view",
+        visitor_id: "mvp_visitor_b",
+        session_id: "mvp_session_b1",
+        occurred_at: "2026-05-02T12:00:00.000Z",
+        route: "/signals",
+      },
+      {
+        event_name: "comprehension_prompt_answered",
+        visitor_id: "mvp_visitor_b",
+        session_id: "mvp_session_b1",
+        occurred_at: "2026-05-02T12:02:00.000Z",
+        route: "/signals",
+        metadata: { response: "agree" },
+      },
+    ]);
+
+    expect(summary.eventCount).toBe(5);
+    expect(summary.uniqueVisitorCount).toBe(2);
+    expect(summary.uniqueSessionCount).toBe(3);
+    expect(summary.eventCountByDate).toMatchObject({
+      "2026-05-01": 2,
+      "2026-05-02": 2,
+      "2026-05-08": 1,
+    });
+    expect(summary.eventCountByRoute).toMatchObject({
+      "/": 3,
+      "/signals": 2,
+    });
+    expect(summary.day7Return).toEqual({
+      denominator: 2,
+      numerator: 1,
+      rate: 0.5,
+    });
+    expect(summary.depthEngagement.proxyExpansionSessions).toBe(1);
+    expect(summary.depthEngagement.proxyRate).toBe(1 / 3);
+    expect(summary.comprehension.agreeCount).toBe(1);
+    expect(summary.comprehension.agreementRate).toBe(1);
+    expect(summary.firstThreeSessionsExpansion).toEqual({
+      denominator: 2,
+      numerator: 1,
+      rate: 0.5,
+    });
+  });
+});

--- a/src/lib/mvp-measurement-summary.ts
+++ b/src/lib/mvp-measurement-summary.ts
@@ -1,0 +1,204 @@
+import type { MvpMeasurementEventName } from "@/lib/mvp-measurement";
+
+export type MvpMeasurementSummaryRow = {
+  event_name: MvpMeasurementEventName;
+  visitor_id: string;
+  session_id: string;
+  occurred_at: string;
+  route: string | null;
+  metadata?: unknown;
+};
+
+export type MvpMeasurementSummary = {
+  eventCount: number;
+  uniqueVisitorCount: number;
+  uniqueSessionCount: number;
+  eventCountByDate: Record<string, number>;
+  eventCountByRoute: Record<string, number>;
+  day7Return: {
+    denominator: number;
+    numerator: number;
+    rate: number | null;
+  };
+  depthEngagement: {
+    strictFullExpansionSessions: number;
+    proxyExpansionSessions: number;
+    denominator: number;
+    strictRate: number | null;
+    proxyRate: number | null;
+  };
+  comprehension: {
+    promptShownCount: number;
+    answeredCount: number;
+    agreeCount: number;
+    agreementRate: number | null;
+  };
+  firstThreeSessionsExpansion: {
+    denominator: number;
+    numerator: number;
+    rate: number | null;
+  };
+};
+
+const DEPTH_PROXY_EVENTS = new Set<MvpMeasurementEventName>([
+  "signal_full_expansion",
+  "signal_full_expansion_proxy",
+  "signal_details_click",
+]);
+
+function dateKey(value: string) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString().slice(0, 10);
+}
+
+function addDays(date: string, days: number) {
+  const parsed = new Date(`${date}T00:00:00.000Z`);
+  parsed.setUTCDate(parsed.getUTCDate() + days);
+  return parsed.toISOString().slice(0, 10);
+}
+
+function rate(numerator: number, denominator: number) {
+  return denominator > 0 ? numerator / denominator : null;
+}
+
+function metadataResponse(row: MvpMeasurementSummaryRow) {
+  if (!row.metadata || typeof row.metadata !== "object" || Array.isArray(row.metadata)) {
+    return null;
+  }
+
+  const response = (row.metadata as Record<string, unknown>).response;
+  return typeof response === "string" ? response.trim().toLowerCase() : null;
+}
+
+export function summarizeMvpMeasurementEvents(rows: MvpMeasurementSummaryRow[]): MvpMeasurementSummary {
+  const eventCountByDate: Record<string, number> = {};
+  const eventCountByRoute: Record<string, number> = {};
+  const visitorDates = new Map<string, Set<string>>();
+  const sessionEvents = new Map<string, Set<MvpMeasurementEventName>>();
+  const visitorSessions = new Map<string, Map<string, string>>();
+  const visitors = new Set<string>();
+
+  let promptShownCount = 0;
+  let answeredCount = 0;
+  let agreeCount = 0;
+
+  rows.forEach((row) => {
+    visitors.add(row.visitor_id);
+    const rowDate = dateKey(row.occurred_at);
+    if (rowDate) {
+      eventCountByDate[rowDate] = (eventCountByDate[rowDate] ?? 0) + 1;
+      if (!visitorDates.has(row.visitor_id)) {
+        visitorDates.set(row.visitor_id, new Set());
+      }
+      visitorDates.get(row.visitor_id)?.add(rowDate);
+
+      if (!visitorSessions.has(row.visitor_id)) {
+        visitorSessions.set(row.visitor_id, new Map());
+      }
+      const sessionMap = visitorSessions.get(row.visitor_id);
+      const existingSessionDate = sessionMap?.get(row.session_id);
+      if (!existingSessionDate || rowDate < existingSessionDate) {
+        sessionMap?.set(row.session_id, rowDate);
+      }
+    }
+
+    const route = row.route ?? "unknown";
+    eventCountByRoute[route] = (eventCountByRoute[route] ?? 0) + 1;
+
+    if (!sessionEvents.has(row.session_id)) {
+      sessionEvents.set(row.session_id, new Set());
+    }
+    sessionEvents.get(row.session_id)?.add(row.event_name);
+
+    if (row.event_name === "comprehension_prompt_shown") {
+      promptShownCount += 1;
+    }
+
+    if (row.event_name === "comprehension_prompt_answered") {
+      answeredCount += 1;
+      if (metadataResponse(row) === "agree") {
+        agreeCount += 1;
+      }
+    }
+  });
+
+  let day7Denominator = 0;
+  let day7Numerator = 0;
+  visitorDates.forEach((dates) => {
+    const orderedDates = [...dates].sort();
+    const firstDate = orderedDates[0];
+    if (!firstDate) {
+      return;
+    }
+
+    day7Denominator += 1;
+    if (dates.has(addDays(firstDate, 7))) {
+      day7Numerator += 1;
+    }
+  });
+
+  let strictFullExpansionSessions = 0;
+  let proxyExpansionSessions = 0;
+  sessionEvents.forEach((events) => {
+    if (events.has("signal_full_expansion")) {
+      strictFullExpansionSessions += 1;
+    }
+
+    if ([...events].some((eventName) => DEPTH_PROXY_EVENTS.has(eventName))) {
+      proxyExpansionSessions += 1;
+    }
+  });
+
+  let firstThreeDenominator = 0;
+  let firstThreeNumerator = 0;
+  visitorSessions.forEach((sessionMap) => {
+    const firstThreeSessionIds = [...sessionMap.entries()]
+      .sort((left, right) => left[1].localeCompare(right[1]))
+      .slice(0, 3)
+      .map(([sessionId]) => sessionId);
+
+    if (firstThreeSessionIds.length === 0) {
+      return;
+    }
+
+    firstThreeDenominator += 1;
+    if (
+      firstThreeSessionIds.some((sessionId) =>
+        [...(sessionEvents.get(sessionId) ?? [])].some((eventName) => DEPTH_PROXY_EVENTS.has(eventName)),
+      )
+    ) {
+      firstThreeNumerator += 1;
+    }
+  });
+
+  return {
+    eventCount: rows.length,
+    uniqueVisitorCount: visitors.size,
+    uniqueSessionCount: sessionEvents.size,
+    eventCountByDate,
+    eventCountByRoute,
+    day7Return: {
+      denominator: day7Denominator,
+      numerator: day7Numerator,
+      rate: rate(day7Numerator, day7Denominator),
+    },
+    depthEngagement: {
+      strictFullExpansionSessions,
+      proxyExpansionSessions,
+      denominator: sessionEvents.size,
+      strictRate: rate(strictFullExpansionSessions, sessionEvents.size),
+      proxyRate: rate(proxyExpansionSessions, sessionEvents.size),
+    },
+    comprehension: {
+      promptShownCount,
+      answeredCount,
+      agreeCount,
+      agreementRate: rate(agreeCount, answeredCount),
+    },
+    firstThreeSessionsExpansion: {
+      denominator: firstThreeDenominator,
+      numerator: firstThreeNumerator,
+      rate: rate(firstThreeNumerator, firstThreeDenominator),
+    },
+  };
+}

--- a/src/lib/mvp-measurement.test.ts
+++ b/src/lib/mvp-measurement.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  sanitizeMetadata,
+  validateMvpMeasurementEvent,
+} from "@/lib/mvp-measurement";
+
+const validPayload = {
+  eventName: "signal_full_expansion_proxy",
+  visitorId: "mvp_1234567890abcdef",
+  sessionId: "mvp_session_1234567890abcdef",
+  route: "/",
+  surface: "home_top_event",
+  signalPostId: "3156ce1e-d052-4f88-af1b-4630f78e1104",
+  signalRank: 1,
+  briefingDate: "2026-05-01T12:00:00.000Z",
+  metadata: {
+    sourceName: "Example Source",
+  },
+};
+
+describe("MVP measurement event validation", () => {
+  it("accepts a valid privacy-scoped event payload", () => {
+    const result = validateMvpMeasurementEvent(validPayload);
+
+    expect(result).toEqual({
+      ok: true,
+      value: expect.objectContaining({
+        eventName: "signal_full_expansion_proxy",
+        visitorId: "mvp_1234567890abcdef",
+        sessionId: "mvp_session_1234567890abcdef",
+        briefingDate: "2026-05-01",
+        signalRank: 1,
+      }),
+    });
+  });
+
+  it("rejects unsupported event names", () => {
+    const result = validateMvpMeasurementEvent({
+      ...validPayload,
+      eventName: "personalize_rankings",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Unsupported event name.",
+    });
+  });
+
+  it("rejects malformed anonymous identifiers", () => {
+    const result = validateMvpMeasurementEvent({
+      ...validPayload,
+      visitorId: "user@example.com",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Invalid visitor id.",
+    });
+  });
+
+  it("bounds metadata keys and string values", () => {
+    const metadata = sanitizeMetadata(
+      Object.fromEntries(
+        Array.from({ length: 30 }, (_, index) => [
+          `key ${index}`,
+          "a".repeat(400),
+        ]),
+      ),
+    );
+
+    expect(Object.keys(metadata)).toHaveLength(24);
+    expect(Object.keys(metadata)[0]).toBe("key_0");
+    expect(String(Object.values(metadata)[0])).toHaveLength(300);
+  });
+});

--- a/src/lib/mvp-measurement.ts
+++ b/src/lib/mvp-measurement.ts
@@ -1,0 +1,193 @@
+export const MVP_MEASUREMENT_EVENT_NAMES = [
+  "homepage_view",
+  "signals_page_view",
+  "signal_card_expand",
+  "signal_full_expansion",
+  "signal_full_expansion_proxy",
+  "signal_details_click",
+  "source_click",
+  "comprehension_prompt_shown",
+  "comprehension_prompt_answered",
+] as const;
+
+export type MvpMeasurementEventName = (typeof MVP_MEASUREMENT_EVENT_NAMES)[number];
+
+export type MvpMeasurementEventInput = {
+  eventName: MvpMeasurementEventName;
+  visitorId: string;
+  sessionId: string;
+  route?: string | null;
+  surface?: string | null;
+  signalPostId?: string | null;
+  signalSlug?: string | null;
+  signalRank?: number | null;
+  briefingDate?: string | null;
+  publishedSlateId?: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+export type ValidatedMvpMeasurementEvent = Required<
+  Pick<MvpMeasurementEventInput, "eventName" | "visitorId" | "sessionId">
+> &
+  Pick<
+    MvpMeasurementEventInput,
+    | "route"
+    | "surface"
+    | "signalPostId"
+    | "signalSlug"
+    | "signalRank"
+    | "briefingDate"
+    | "publishedSlateId"
+    | "metadata"
+  >;
+
+type ValidationResult =
+  | {
+      ok: true;
+      value: ValidatedMvpMeasurementEvent;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const VISITOR_ID_PATTERN = /^mvp_[a-z0-9_-]{12,80}$/i;
+const SESSION_ID_PATTERN = /^mvp_session_[a-z0-9_-]{12,80}$/i;
+const MAX_METADATA_KEYS = 24;
+const MAX_METADATA_STRING_LENGTH = 300;
+const MAX_METADATA_ARRAY_LENGTH = 24;
+
+export function isMvpMeasurementEventName(value: unknown): value is MvpMeasurementEventName {
+  return typeof value === "string" && MVP_MEASUREMENT_EVENT_NAMES.includes(value as MvpMeasurementEventName);
+}
+
+export function isUuid(value: unknown): value is string {
+  return typeof value === "string" && UUID_PATTERN.test(value);
+}
+
+export function normalizeBriefingDate(value: unknown) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (DATE_KEY_PATTERN.test(trimmed)) {
+    return trimmed;
+  }
+
+  const isoDatePrefix = trimmed.slice(0, 10);
+  return DATE_KEY_PATTERN.test(isoDatePrefix) ? isoDatePrefix : null;
+}
+
+function normalizeOptionalString(value: unknown, maxLength: number) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, maxLength) : null;
+}
+
+function sanitizeMetadataValue(value: unknown, depth = 0): unknown {
+  if (value === null || typeof value === "boolean" || typeof value === "number") {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    return value.slice(0, MAX_METADATA_STRING_LENGTH);
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .slice(0, MAX_METADATA_ARRAY_LENGTH)
+      .map((entry) => sanitizeMetadataValue(entry, depth + 1))
+      .filter((entry) => entry !== undefined);
+  }
+
+  if (typeof value === "object" && depth < 2) {
+    return sanitizeMetadata(value as Record<string, unknown>, depth + 1);
+  }
+
+  return undefined;
+}
+
+export function sanitizeMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+  depth = 0,
+): Record<string, unknown> {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(metadata)
+      .slice(0, MAX_METADATA_KEYS)
+      .map(([key, value]) => [
+        key.replace(/[^a-zA-Z0-9_.-]/g, "_").slice(0, 64),
+        sanitizeMetadataValue(value, depth),
+      ])
+      .filter(([key, value]) => Boolean(key) && value !== undefined),
+  );
+}
+
+export function validateMvpMeasurementEvent(input: unknown): ValidationResult {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return { ok: false, error: "Expected event object." };
+  }
+
+  const event = input as Record<string, unknown>;
+
+  if (!isMvpMeasurementEventName(event.eventName)) {
+    return { ok: false, error: "Unsupported event name." };
+  }
+
+  const visitorId = normalizeOptionalString(event.visitorId, 96);
+  if (!visitorId || !VISITOR_ID_PATTERN.test(visitorId)) {
+    return { ok: false, error: "Invalid visitor id." };
+  }
+
+  const sessionId = normalizeOptionalString(event.sessionId, 104);
+  if (!sessionId || !SESSION_ID_PATTERN.test(sessionId)) {
+    return { ok: false, error: "Invalid session id." };
+  }
+
+  const signalRank =
+    typeof event.signalRank === "number" && Number.isInteger(event.signalRank)
+      ? event.signalRank
+      : typeof event.signalRank === "string" && /^\d+$/.test(event.signalRank)
+        ? Number.parseInt(event.signalRank, 10)
+        : null;
+
+  if (signalRank !== null && (signalRank < 1 || signalRank > 20)) {
+    return { ok: false, error: "Invalid signal rank." };
+  }
+
+  const signalPostId = normalizeOptionalString(event.signalPostId, 64);
+  if (signalPostId && !isUuid(signalPostId)) {
+    return { ok: false, error: "Invalid signal post id." };
+  }
+
+  const publishedSlateId = normalizeOptionalString(event.publishedSlateId, 64);
+  if (publishedSlateId && !isUuid(publishedSlateId)) {
+    return { ok: false, error: "Invalid published slate id." };
+  }
+
+  return {
+    ok: true,
+    value: {
+      eventName: event.eventName,
+      visitorId,
+      sessionId,
+      route: normalizeOptionalString(event.route, 120),
+      surface: normalizeOptionalString(event.surface, 120),
+      signalPostId,
+      signalSlug: normalizeOptionalString(event.signalSlug, 160),
+      signalRank,
+      briefingDate: normalizeBriefingDate(event.briefingDate),
+      publishedSlateId,
+      metadata: sanitizeMetadata(event.metadata as Record<string, unknown> | null | undefined),
+    },
+  };
+}

--- a/supabase/migrations/20260501100000_mvp_measurement_events.sql
+++ b/supabase/migrations/20260501100000_mvp_measurement_events.sql
@@ -1,0 +1,61 @@
+create table if not exists public.mvp_measurement_events (
+  id uuid primary key default gen_random_uuid(),
+  event_name text not null
+    check (
+      event_name in (
+        'homepage_view',
+        'signals_page_view',
+        'signal_card_expand',
+        'signal_full_expansion',
+        'signal_full_expansion_proxy',
+        'signal_details_click',
+        'source_click',
+        'comprehension_prompt_shown',
+        'comprehension_prompt_answered'
+      )
+    ),
+  occurred_at timestamptz not null default now(),
+  visitor_id text not null check (length(visitor_id) between 16 and 96),
+  session_id text not null check (length(session_id) between 20 and 104),
+  user_id uuid,
+  route text,
+  surface text,
+  signal_post_id uuid references public.signal_posts(id) on delete set null,
+  signal_slug text,
+  signal_rank integer check (signal_rank is null or signal_rank between 1 and 20),
+  briefing_date date,
+  published_slate_id uuid references public.published_slates(id) on delete set null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists mvp_measurement_events_occurred_at_idx
+on public.mvp_measurement_events (occurred_at desc);
+
+create index if not exists mvp_measurement_events_visitor_occurred_at_idx
+on public.mvp_measurement_events (visitor_id, occurred_at);
+
+create index if not exists mvp_measurement_events_session_idx
+on public.mvp_measurement_events (session_id);
+
+create index if not exists mvp_measurement_events_event_name_occurred_at_idx
+on public.mvp_measurement_events (event_name, occurred_at desc);
+
+create index if not exists mvp_measurement_events_briefing_date_idx
+on public.mvp_measurement_events (briefing_date);
+
+alter table public.mvp_measurement_events enable row level security;
+
+drop policy if exists "Service role reads MVP measurement events" on public.mvp_measurement_events;
+create policy "Service role reads MVP measurement events"
+on public.mvp_measurement_events
+for select
+to service_role
+using (true);
+
+drop policy if exists "Service role writes MVP measurement events" on public.mvp_measurement_events;
+create policy "Service role writes MVP measurement events"
+on public.mvp_measurement_events
+for insert
+to service_role
+with check (true);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -236,6 +236,52 @@ on public.published_slate_items (signal_post_id);
 create index if not exists published_slates_published_at_idx
 on public.published_slates (published_at desc);
 
+create table if not exists public.mvp_measurement_events (
+  id uuid primary key default gen_random_uuid(),
+  event_name text not null
+    check (
+      event_name in (
+        'homepage_view',
+        'signals_page_view',
+        'signal_card_expand',
+        'signal_full_expansion',
+        'signal_full_expansion_proxy',
+        'signal_details_click',
+        'source_click',
+        'comprehension_prompt_shown',
+        'comprehension_prompt_answered'
+      )
+    ),
+  occurred_at timestamptz not null default now(),
+  visitor_id text not null check (length(visitor_id) between 16 and 96),
+  session_id text not null check (length(session_id) between 20 and 104),
+  user_id uuid,
+  route text,
+  surface text,
+  signal_post_id uuid references public.signal_posts(id) on delete set null,
+  signal_slug text,
+  signal_rank integer check (signal_rank is null or signal_rank between 1 and 20),
+  briefing_date date,
+  published_slate_id uuid references public.published_slates(id) on delete set null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists mvp_measurement_events_occurred_at_idx
+on public.mvp_measurement_events (occurred_at desc);
+
+create index if not exists mvp_measurement_events_visitor_occurred_at_idx
+on public.mvp_measurement_events (visitor_id, occurred_at);
+
+create index if not exists mvp_measurement_events_session_idx
+on public.mvp_measurement_events (session_id);
+
+create index if not exists mvp_measurement_events_event_name_occurred_at_idx
+on public.mvp_measurement_events (event_name, occurred_at desc);
+
+create index if not exists mvp_measurement_events_briefing_date_idx
+on public.mvp_measurement_events (briefing_date);
+
 create table if not exists public.pipeline_article_candidates (
   id uuid primary key default gen_random_uuid(),
   run_id text not null,
@@ -302,6 +348,7 @@ alter table public.user_event_state enable row level security;
 alter table public.signal_posts enable row level security;
 alter table public.published_slates enable row level security;
 alter table public.published_slate_items enable row level security;
+alter table public.mvp_measurement_events enable row level security;
 alter table public.pipeline_article_candidates enable row level security;
 
 create policy "Users manage their own profile" on public.user_profiles
@@ -384,6 +431,12 @@ create policy "Service role writes published slate items" on public.published_sl
 
 create policy "Service role deletes published slate items" on public.published_slate_items
   for delete to service_role using (true);
+
+create policy "Service role reads MVP measurement events" on public.mvp_measurement_events
+  for select to service_role using (true);
+
+create policy "Service role writes MVP measurement events" on public.mvp_measurement_events
+  for insert to service_role with check (true);
 
 drop trigger if exists set_signal_posts_updated_at on public.signal_posts;
 create trigger set_signal_posts_updated_at


### PR DESCRIPTION
## Effective change type

remediation / product analytics instrumentation

## Source of truth

- Product Position MVP success criteria
- PRD-53 controlled publish completion, including `docs/operations/controlled-cycles/2026-05-01-prd-53-authorized-second-controlled-publish.md`

## What changed

- Added privacy-conscious `mvp_measurement_events` storage with RLS and service-role-only access.
- Added a soft-failing measurement event API at `/api/mvp-measurement/events` so public reading is never blocked by analytics storage.
- Added first-party anonymous visitor/session IDs using localStorage/sessionStorage only.
- Instrumented `/` and `/signals` page views with briefing/surface context.
- Instrumented details/source/depth proxy clicks without changing ranking, visibility, or publish gates.
- Added summary helper/script for day-7 return, depth engagement, first-three-session expansion, route/date counts, and future comprehension prompt agreement.
- Added focused unit/API/component tests and a change record plus tracker-sync fallback.

## Deferred / limitations

- No visible comprehension prompt UI was added because no existing prompt/survey pattern exists; the event schema supports it, but user-facing prompt behavior remains a separately approved product/governance step.
- The current UI does not expose a true four-layer full Signal expansion, so this PR records strict `signal_full_expansion` separately from the current `signal_full_expansion_proxy`.
- Production collection requires the additive migration to be applied through the normal authorized schema path.

## What did not change

- no cron
- no publish
- no `draft_only`
- no pipeline write-mode
- no source governance or added sources
- no ranking or WITM threshold changes
- no public URL/domain/env/Vercel changes
- no Phase 2 architecture
- no personalization or behavior-based ranking

## Validation

- `git diff --check` passed
- `npm run lint` passed
- `npm run test` passed: 77 files, 586 tests
- `npm run build` passed
- `python3 scripts/validate-feature-system-csv.py` passed with existing PRD slug warnings for PRD-32, PRD-37, and PRD-38
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/mvp-measurement-instrumentation --pr-title "MVP measurement instrumentation"` passed
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/mvp-measurement-instrumentation --pr-title "MVP measurement instrumentation"` passed
- `PLAYWRIGHT_MANAGED_WEBSERVER=1 npm run test:e2e:chromium` passed: 33 tests
- `PLAYWRIGHT_MANAGED_WEBSERVER=1 npm run test:e2e:webkit` passed: 33 tests

## Risks / follow-up

- Apply the additive measurement schema through the authorized migration process before relying on production collection.
- Calibrate metric definitions after the first real usage window.
- Final launch-readiness QA remains next; cron remains last and separately authorized.

Readiness label: `ready_for_final_launch_readiness_qa`
