### PR TITLE
Final launch-readiness QA rerun

### DIFF
--- a/docs/operations/controlled-cycles/2026-05-01-final-launch-readiness-qa-rerun.md
+++ b/docs/operations/controlled-cycles/2026-05-01-final-launch-readiness-qa-rerun.md
@@ -1,0 +1,413 @@
+# Final Launch-Readiness QA Rerun
+
+Date checked: 2026-05-02
+Slate date: 2026-05-01
+Branch: `codex/final-launch-readiness-qa-rerun`
+Readiness label: `launch_readiness_partial_measurement_summary_limited`
+
+## Effective Change Type
+
+Operations validation / launch-readiness QA.
+
+This packet records the final Boot Up MVP launch-readiness QA rerun after PR #177 aligned production storage for MVP measurement events. It does not implement a new feature, create a new PRD, alter product scope, run cron, run `draft_only`, run pipeline write-mode, publish, run direct SQL row surgery, change source/ranking/WITM thresholds, start Phase 2 architecture, start personalization, or add a visible comprehension prompt.
+
+Object levels validated:
+
+- public Surface Placement rendering for the May 1, 2026 published slate
+- public Card details/depth proxy affordances
+- first-party MVP measurement event writes
+- admin route protection
+- cron protection
+- published-slate audit/history status, limited by unavailable direct production database readback in this worktree
+
+Object levels not changed:
+
+- Article
+- Story Cluster
+- conceptual Signal identity
+- public Card copy
+- public Surface Placement / visibility
+
+## Source Of Truth
+
+Primary:
+
+- Product Position - MVP product experience and success criteria
+- `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+
+Secondary:
+
+- `docs/operations/controlled-cycles/2026-05-01-final-launch-readiness-qa.md`
+- `docs/operations/tracker-sync/2026-05-01-final-launch-readiness-qa.md`
+- `docs/operations/controlled-cycles/2026-05-01-mvp-measurement-storage-alignment.md`
+- `docs/operations/tracker-sync/2026-05-01-mvp-measurement-storage-alignment.md`
+- `docs/engineering/change-records/mvp-measurement-instrumentation.md`
+- `docs/operations/controlled-cycles/2026-05-01-prd-53-authorized-second-controlled-publish.md`
+- `docs/operations/tracker-sync/2026-05-01-prd-53-authorized-second-controlled-publish.md`
+
+## Production Deploy Checked
+
+| Field | Result |
+| --- | --- |
+| Production URL checked | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Starting commit | `a212dd552daea72e2416bb64ce8b1b2e4b700880` |
+| Starting commit summary | `Merge pull request #177 from brandonma25/codex/mvp-measurement-storage-alignment` |
+| Vercel deployment ID | `dpl_6GEaxxLVp4DZpLMHqEdzDTiYYFVU` |
+| Vercel deployment URL | `https://bootup-nat13xkgz-brandonma25s-projects.vercel.app` |
+| Vercel target | Production |
+| Vercel status | Ready |
+| GitHub production verification | Passed for PR #177 merge commit `a212dd5` |
+
+## Commands Run
+
+Workspace and protocol checks:
+
+```bash
+pwd
+git branch --show-current
+git status --short --branch
+git worktree list
+git fetch origin main --prune
+git worktree add "/Users/bm/dev/worktrees/daily-intelligence-aggregator-final-launch-readiness-qa-rerun" -b codex/final-launch-readiness-qa-rerun origin/main
+sed -n '1,220p' AGENTS.md
+sed -n '1,220p' docs/engineering/protocols/engineering-protocol.md
+sed -n '1,220p' docs/engineering/protocols/test-checklist.md
+sed -n '1,220p' docs/engineering/protocols/prd-template.md
+sed -n '1,260p' docs/engineering/protocols/release-machine.md
+sed -n '1,260p' docs/engineering/protocols/release-automation-operating-guide.md
+sed -n '1,220p' docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md
+```
+
+Source-of-truth inspection:
+
+```bash
+sed -n '1,260p' docs/product/prd/prd-53-signals-admin-editorial-layer.md
+sed -n '1,300p' docs/operations/controlled-cycles/2026-05-01-final-launch-readiness-qa.md
+sed -n '1,320p' docs/operations/controlled-cycles/2026-05-01-mvp-measurement-storage-alignment.md
+sed -n '1,260p' docs/operations/controlled-cycles/2026-05-01-prd-53-authorized-second-controlled-publish.md
+sed -n '1,240p' src/lib/mvp-measurement.ts
+sed -n '1,180p' src/app/api/mvp-measurement/events/route.ts
+sed -n '1,160p' scripts/mvp-measurement-summary.ts
+```
+
+Production deployment and route checks:
+
+```bash
+vercel inspect https://daily-intelligence-aggregator-ybs9.vercel.app --no-color
+gh run list --branch main --limit 5 --json databaseId,displayTitle,headSha,status,conclusion,createdAt,url
+node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+node <production route and content marker probe>
+node <production Playwright browser QA probe>
+```
+
+Measurement checks:
+
+```bash
+npm install
+node <synthetic MVP measurement event API probe>
+npx tsx scripts/mvp-measurement-summary.ts --days 1
+```
+
+Notes:
+
+- Synthetic measurement probes used QA-only anonymous visitor/session identifiers.
+- Measurement event metadata included a QA marker and no PII.
+- No secrets, database passwords, connection strings, service-role keys, browser cookies, auth headers, or production credentials were printed or committed.
+
+## Baseline Production Capture
+
+| Check | Result |
+| --- | --- |
+| Homepage `/` | HTTP 200 |
+| `/signals` | HTTP 200 |
+| `/briefing/2026-05-01` | HTTP 200 |
+| `/dashboard/signals/editorial-review` unauthenticated | HTTP 200 with admin sign-in gate |
+| `/api/cron/fetch-news` unauthenticated | HTTP 401 unauthorized |
+| Latest public briefing date | Friday, May 1, 2026 |
+| Visible public signal count | 7 on `/signals` |
+| `mvp_measurement_events` production schema | Verified at the application layer by `stored:true` event API responses; direct catalog read was not available in this worktree |
+| Cron | Protected; not run |
+
+## Homepage QA Result
+
+Result: Pass.
+
+Homepage `/` returned HTTP 200 and rendered the May 1 public briefing. Browser QA confirmed:
+
+- page title `Daily Intelligence Briefing`
+- `Friday, May 1, 2026`
+- `Last updated Friday, May 1`
+- tabs render safely: Top Events, Tech News, Economics, Politics
+- five `Read more` controls
+- five Details links
+- no raw schema-preflight text
+- no missing PRD-53 column names
+- no measurement-storage errors visible to users
+- no rewrite-requested, held/rejected, rank-8, or non-live candidate markers visible in inspected public content
+
+Visible Core titles:
+
+| Rank | Title |
+| --- | --- |
+| 1 | Trump signs DHS legislation, ending record-breaking shutdown |
+| 2 | Economic Letter Countdown: Most Read Topics from 2025 |
+| 3 | A Closer Look at Emerging Market Resilience During Recent Shocks |
+| 4 | The R*-Labor Share Nexus |
+| 5 | The AI Investing Landscape: Insights from Venture Capital |
+
+Every visible Core Card includes explicit `Why it matters` / importance reasoning. The page uses honest May 1 dated copy and does not present a false newer briefing date.
+
+## `/signals` QA Result
+
+Result: Pass.
+
+`/signals` returned HTTP 200 and rendered:
+
+- `Published Signals`
+- `7 signals`
+- `Top 5 Core Signals`
+- `Next 2 Context Signals`
+- all five Core rows
+- both Context rows
+- seven source links
+- `Why it matters` reasoning for the published rows
+
+Visible Context titles:
+
+| Rank | Title |
+| --- | --- |
+| 6 | Anthropic, OpenAI back Warner-Budd workforce data bill |
+| 7 | Congress keeps kicking surveillance reform down the road |
+
+Public safety observations:
+
+- no raw schema-preflight errors
+- no missing-column names
+- no misleading `0 signals` state
+- no measurement-storage errors visible to users
+- no rewrite-requested, held/rejected, rank-8, Depth, unpublished, or non-live candidate markers visible in inspected public content
+
+The public read contract remains tied to live published rows. This QA did not change public read gates:
+
+- `is_live=true`
+- `editorial_status='published'`
+- `published_at IS NOT NULL`
+
+## `/briefing/2026-05-01` QA Result
+
+Result: Pass.
+
+The briefing detail route returned HTTP 200. Browser QA confirmed:
+
+- page title `Briefing Detail - Daily Intelligence`
+- May 1 slate content is present
+- `Trump signs DHS legislation, ending record-breaking shutdown` is visible
+- `Why it matters` content is present
+- no raw schema/preflight/measurement errors
+- no missing-column names
+- no inspected non-live/candidate row markers
+
+## Details And Expansion QA Result
+
+Result: Pass with documented MVP measurement limitation.
+
+The homepage details/depth path works:
+
+- five Details links are available
+- five `Read more` controls are available
+- clicking the first `Read more` control expanded the Card/depth proxy state
+- the expanded state preserved the expected reasoning text
+- source links are present and render as normal outbound links
+
+The current UI still uses Details/source/depth-proxy affordances rather than one explicit four-layer Signal expansion control. This matches the PR #175 limitation: strict "all four layers opened" depth engagement is not exactly measurable until the UI exposes that interaction, so the measurement layer records `signal_full_expansion_proxy`, `signal_details_click`, and `source_click` separately.
+
+## Measurement Instrumentation QA Result
+
+Result: Pass at production write layer.
+
+Browser QA confirmed anonymous first-party identifiers were created/read safely:
+
+- visitor id prefix: `mvp_`
+- session id prefix: `mvp_session_`
+
+Synthetic QA events sent through `POST /api/mvp-measurement/events`:
+
+| Event | HTTP status | Result |
+| --- | ---: | --- |
+| `homepage_view` | 202 | `{"ok":true,"stored":true}` |
+| `signals_page_view` | 202 | `{"ok":true,"stored":true}` |
+| `signal_details_click` | 202 | `{"ok":true,"stored":true}` |
+| `signal_full_expansion_proxy` | 202 | `{"ok":true,"stored":true}` |
+| `source_click` | 202 | `{"ok":true,"stored":true}` |
+
+Measurement safety observations:
+
+- no PII was required for anonymous users
+- event payloads used synthetic QA visitor/session IDs
+- event payload metadata was bounded and marked as QA/test
+- event API did not expose secrets
+- public UX was not blocked by instrumentation
+- event storage does not expose unpublished/non-live Signal row data through public pages
+
+## Measurement Summary Helper QA Result
+
+Result: Limited.
+
+The helper is installed and runnable after `npm install`, but this worktree has no Supabase server configuration exposed. The command:
+
+```bash
+npx tsx scripts/mvp-measurement-summary.ts --days 1
+```
+
+returned:
+
+```text
+Supabase server configuration is required to summarize MVP measurement events.
+```
+
+This is not an event-write blocker. Production event writes now return `stored:true`, so measurement storage is aligned at the application write layer. However, this QA environment cannot yet produce a live production summary through the local helper.
+
+Expected helper capabilities once run in a configured environment:
+
+- total events by date
+- homepage views
+- `/signals` views
+- signal expansion/detail events
+- source clicks
+- visitor/session counts
+- day-7 retention feasibility
+- first-three-session expansion feasibility
+- comprehension prompt status / deferral
+
+Known measurement limitations remain:
+
+- day-7 retention requires elapsed time and returning users
+- visible comprehension prompt UI remains deferred because no existing prompt/survey pattern exists
+- full four-layer expansion remains proxied until the UI exposes a discrete four-layer expansion interaction
+
+## Admin Protection And Workflow QA Result
+
+Result: Admin protection pass; authenticated workflow readback limited.
+
+Unauthenticated `/dashboard/signals/editorial-review` returned HTTP 200 with the admin sign-in gate:
+
+- `Admin sign-in required`
+
+No admin actions were run. No publish, `draft_only`, review mutation, final-slate mutation, or candidate mutation occurred.
+
+An existing Chrome profile was opened to the authenticated admin route for read-only inspection, but the page remained in the loading shell during this QA attempt. Because the prompt did not authorize admin mutations and public/measurement checks passed, no additional admin action was attempted. The prior PR #174 and PR #177 packets remain the durable sources for completed publish and storage-alignment evidence.
+
+## Audit And History QA Result
+
+Result: Limited by unavailable direct production database readback in this worktree.
+
+The PR #174 controlled-publish packet remains the durable source confirming:
+
+- the May 1 slate was published through the supported PRD-53 workflow
+- seven rows were published
+- ranks 1-5 were Core
+- ranks 6-7 were Context
+- previous live rows were archived through the supported workflow
+- a published-slate audit record was created
+- rollback preparation copy was present
+
+This rerun did not directly query `published_slates` or `published_slate_items` from production because this worktree has no Supabase server configuration or safe production database readback path exposed. No ad hoc database access, direct SQL, migration repair, or schema migration was attempted.
+
+## Cron And Automation QA Result
+
+Result: Pass.
+
+Unauthenticated cron check:
+
+```text
+GET /api/cron/fetch-news -> HTTP 401
+```
+
+Cron remains protected. This QA did not run cron, re-enable cron, schedule automatic publishing, or trigger any automated public publish path.
+
+## Safety And Scope Confirmation
+
+Confirmed not changed or not run in this QA:
+
+- no new feature
+- no new PRD
+- no product scope change
+- no added sources
+- no source governance change
+- no ranking threshold change
+- no WITM threshold change
+- no URL/domain/env/Vercel setting change
+- no secret exposure
+- no removal of `newsweb2026@gmail.com` from Production `ADMIN_EMAILS`
+- no cron run or cron re-enable
+- no migration-history repair
+- no schema migration beyond already-merged PR #177 measurement storage alignment
+- no direct SQL row surgery
+- no Signal row mutation
+- no `draft_only`
+- no pipeline write-mode
+- no production publish
+- no controlled user exposure
+- no Phase 2 architecture
+- no personalization
+- no visible comprehension prompt UI
+
+## Validation
+
+Commands run:
+
+```bash
+npm install
+git diff --check
+python3 scripts/validate-feature-system-csv.py
+python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/final-launch-readiness-qa-rerun --pr-title "Final launch-readiness QA rerun"
+python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/final-launch-readiness-qa-rerun --pr-title "Final launch-readiness QA rerun"
+npm run lint
+npm run test
+npx vitest run src/app/dashboard/signals/editorial-review/page.test.tsx
+npm run build
+```
+
+Results:
+
+- `npm install` passed; npm reported two audit findings.
+- `git diff --check` passed.
+- `python3 scripts/validate-feature-system-csv.py` passed with existing PRD slug warnings for PRD-32, PRD-37, and PRD-38.
+- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/final-launch-readiness-qa-rerun --pr-title "Final launch-readiness QA rerun"` passed.
+- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/final-launch-readiness-qa-rerun --pr-title "Final launch-readiness QA rerun"` passed.
+- `npm run lint` passed.
+- First `npm run test` attempt hit one timeout while lint/build/test were running concurrently.
+- `npx vitest run src/app/dashboard/signals/editorial-review/page.test.tsx` passed: 19 tests.
+- Final sequential `npm run test` passed: 77 test files, 586 tests.
+- `npm run build` passed. Next.js emitted an existing workspace-root lockfile warning and a module-type warning for `tailwind.config.ts`; neither blocked build output.
+
+Commands not run:
+
+- Chromium/WebKit PR suites were not run because this PR is docs-only and browser QA was covered by a production Playwright script against the live routes.
+
+## Blockers Or Limitations
+
+Blocking product/public-safety issues found: none.
+
+Remaining limitations:
+
+- local measurement summary helper cannot read production rows in this worktree because Supabase server configuration is not exposed
+- direct production audit/history table readback is unavailable from this worktree
+- authenticated admin workflow readback through Chrome was limited by the page staying in the loading shell; unauthenticated admin protection still passed
+- comprehension prompt UI remains deferred
+- strict four-layer expansion remains proxied
+- day-7 retention requires elapsed time and user data
+
+## Result
+
+Public launch-readiness QA passed and measurement event writes are production-ready. The only remaining readiness limitation is measurement summary readback from this local worktree.
+
+Readiness label:
+
+```text
+launch_readiness_partial_measurement_summary_limited
+```
+
+## Exact Next Task
+
+Run the MVP measurement summary helper in a configured server environment, or expose a safe internal read-only summary path for production measurement events. If the summary readback is verified, proceed to controlled user exposure. Cron remains a later staged operations task and is not part of this next step.

--- a/docs/operations/tracker-sync/2026-05-01-final-launch-readiness-qa-rerun.md
+++ b/docs/operations/tracker-sync/2026-05-01-final-launch-readiness-qa-rerun.md
@@ -1,0 +1,89 @@
+# Tracker Sync Fallback - Final Launch-Readiness QA Rerun
+
+Date checked: 2026-05-02
+Branch: `codex/final-launch-readiness-qa-rerun`
+Readiness label: `launch_readiness_partial_measurement_summary_limited`
+
+## Manual Tracker Update Payload
+
+| Field | Value |
+| --- | --- |
+| Record | Product Position - MVP Success Criteria / PRD-53 controlled publish follow-up |
+| Status | In Review |
+| Decision | keep |
+| PRD File | `docs/product/prd/prd-53-signals-admin-editorial-layer.md` |
+| Latest validation packet | `docs/operations/controlled-cycles/2026-05-01-final-launch-readiness-qa-rerun.md` |
+| Result | Final launch-readiness QA rerun passed for public homepage, `/signals`, `/briefing/2026-05-01`, details/depth proxy, production measurement event writes, admin protection, and cron protection. Production measurement events now return `stored:true` for `homepage_view`, `signals_page_view`, `signal_details_click`, `signal_full_expansion_proxy`, and `source_click`. |
+| Limitation | Local measurement summary helper remains unable to read production events because this worktree has no Supabase server configuration exposed. Direct production audit/history table readback is also unavailable from this worktree. |
+| Readiness label | `launch_readiness_partial_measurement_summary_limited` |
+| Next task | Run the MVP measurement summary helper in a configured server environment, or expose a safe internal read-only production measurement summary path. If summary readback is verified, proceed to controlled user exposure. Cron remains a later staged operations task. |
+
+## Source Of Truth
+
+- Product Position - MVP product experience and success criteria
+- `docs/product/prd/prd-53-signals-admin-editorial-layer.md`
+- `docs/operations/controlled-cycles/2026-05-01-final-launch-readiness-qa.md`
+- `docs/operations/controlled-cycles/2026-05-01-mvp-measurement-storage-alignment.md`
+- `docs/engineering/change-records/mvp-measurement-instrumentation.md`
+- `docs/operations/controlled-cycles/2026-05-01-prd-53-authorized-second-controlled-publish.md`
+
+## QA Summary
+
+Passed:
+
+- production deployment `dpl_6GEaxxLVp4DZpLMHqEdzDTiYYFVU` was Ready
+- GitHub production verification passed for PR #177 merge commit `a212dd5`
+- homepage `/` returned HTTP 200 and rendered the May 1 briefing with five Core Cards and explicit `Why it matters` reasoning
+- `/signals` returned HTTP 200 and rendered `Published Signals`, `7 signals`, `Top 5 Core Signals`, and `Next 2 Context Signals`
+- `/briefing/2026-05-01` returned HTTP 200 and rendered the May 1 detail/depth content safely
+- browser QA confirmed Details links, `Read more` controls, depth-proxy expansion, source links, and anonymous first-party measurement identifiers
+- production event API returned `stored:true` for synthetic QA events:
+  - `homepage_view`
+  - `signals_page_view`
+  - `signal_details_click`
+  - `signal_full_expansion_proxy`
+  - `source_click`
+- unauthenticated admin route remained protected by the admin sign-in gate
+- cron endpoint without auth returned HTTP 401
+- no public schema/preflight/measurement errors or missing column names were visible
+- no publish, cron, `draft_only`, Signal row mutation, direct SQL, source/ranking/WITM threshold change, Phase 2 architecture, or personalization occurred
+
+Limited:
+
+- `npx tsx scripts/mvp-measurement-summary.ts --days 1` could not read production rows because Supabase server configuration is not exposed in this worktree
+- direct production `published_slates` / `published_slate_items` readback was unavailable from this worktree
+- authenticated Chrome admin readback remained on the loading shell during this QA attempt, so no admin state was mutated
+
+## Validation
+
+```bash
+git diff --check
+python3 scripts/validate-feature-system-csv.py
+python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/final-launch-readiness-qa-rerun --pr-title "Final launch-readiness QA rerun"
+python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/final-launch-readiness-qa-rerun --pr-title "Final launch-readiness QA rerun"
+npm run lint
+npm run test
+npm run build
+```
+
+Results:
+
+- `git diff --check` passed.
+- `python3 scripts/validate-feature-system-csv.py` passed with existing PRD slug warnings for PRD-32, PRD-37, and PRD-38.
+- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/final-launch-readiness-qa-rerun --pr-title "Final launch-readiness QA rerun"` passed.
+- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/final-launch-readiness-qa-rerun --pr-title "Final launch-readiness QA rerun"` passed.
+- `npm run lint` passed.
+- Final sequential `npm run test` passed: 77 test files, 586 tests.
+- `npm run build` passed.
+
+Validation command block for manual rerun:
+
+```bash
+git diff --check
+python3 scripts/validate-feature-system-csv.py
+python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/final-launch-readiness-qa-rerun --pr-title "Final launch-readiness QA rerun"
+python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/final-launch-readiness-qa-rerun --pr-title "Final launch-readiness QA rerun"
+npm run lint
+npm run test
+npm run build
+```


### PR DESCRIPTION
## Effective change type

operations validation / launch-readiness QA

## Source of truth

- Product Position MVP criteria
- PR #174 controlled publish completion
- PR #175 measurement instrumentation
- PR #176 launch-readiness blocker
- PR #177 measurement storage alignment
- `docs/product/prd/prd-53-signals-admin-editorial-layer.md`

## What was validated

- homepage `/`
- `/signals`
- `/briefing/2026-05-01`
- details/depth proxy flow
- production measurement instrumentation writes
- measurement summary helper behavior
- admin protection
- audit/history status where safely accessible
- cron protection
- scope/safety boundaries

## Result

Public launch-readiness QA passed and production measurement event writes return `stored:true` for:

- `homepage_view`
- `signals_page_view`
- `signal_details_click`
- `signal_full_expansion_proxy`
- `source_click`

Readiness label:

```text
launch_readiness_partial_measurement_summary_limited
```

The remaining limitation is local measurement summary readback: this worktree has no Supabase server configuration exposed, so `npx tsx scripts/mvp-measurement-summary.ts --days 1` cannot read production rows from here. Direct production audit/history table readback is also unavailable from this worktree.

## What did not change

- no publish
- no cron
- no `draft_only`
- no Signal row mutation
- no direct SQL
- no schema migration
- no source/ranking/WITM threshold changes
- no Phase 2 architecture
- no personalization
- no visible comprehension prompt UI

## Validation

- `npm install` passed; npm reported two audit findings.
- `git diff --check` passed.
- `python3 scripts/validate-feature-system-csv.py` passed with existing PRD slug warnings for PRD-32, PRD-37, and PRD-38.
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/final-launch-readiness-qa-rerun --pr-title "Final launch-readiness QA rerun"` passed.
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/final-launch-readiness-qa-rerun --pr-title "Final launch-readiness QA rerun"` passed.
- `npm run lint` passed.
- Final sequential `npm run test` passed: 77 test files, 586 tests.
- `npm run build` passed.

## Next task

Run the MVP measurement summary helper in a configured server environment, or expose a safe internal read-only production measurement summary path. If summary readback is verified, proceed to controlled user exposure. Cron remains a later staged operations task.
