### PR TITLE
MVP measurement summary readiness

### DIFF
--- a/docs/engineering/change-records/mvp-measurement-summary-readiness.md
+++ b/docs/engineering/change-records/mvp-measurement-summary-readiness.md
@@ -1,0 +1,165 @@
+# MVP Measurement Summary Readiness
+
+Date: 2026-05-01
+Branch: `codex/mvp-measurement-summary-readiness`
+Readiness label: `measurement_summary_ready_via_configured_environment_only`
+Canonical PRD required: `No`
+
+## Effective Change Type
+
+Remediation / alignment.
+
+This change aligns summary readback for the already-approved MVP measurement instrumentation. It does not create a public analytics product, create a new PRD, change product scope, mutate Signal rows, run cron, publish, change ranking/source/WITM thresholds, start Phase 2 architecture, start personalization, or add a visible comprehension prompt UI.
+
+Object level changed:
+
+- Signal/Card/Surface Placement measurement summary only.
+
+Object levels not changed:
+
+- Article
+- Story Cluster
+- conceptual Signal identity
+- public Card copy
+- public Surface Placement / visibility
+
+## Source Of Truth
+
+Primary:
+
+- Product Position - MVP Success Criteria:
+  - day-7 retention
+  - depth engagement / Signal expansion
+  - comprehension confidence
+
+Secondary:
+
+- PR #175 MVP measurement instrumentation
+- PR #177 measurement storage alignment
+- PR #178 final launch-readiness QA rerun blocker
+- `docs/engineering/change-records/mvp-measurement-instrumentation.md`
+- `docs/operations/controlled-cycles/2026-05-01-final-launch-readiness-qa-rerun.md`
+- `docs/operations/controlled-cycles/2026-05-01-mvp-measurement-storage-alignment.md`
+
+## What Changed
+
+- Added aggregate event counts by event name to `summarizeMvpMeasurementEvents`.
+- Moved the existing script query into a shared read helper:
+  - `readMvpMeasurementSummary`
+  - `normalizeMvpMeasurementSummaryWindowDays`
+- Updated `scripts/mvp-measurement-summary.ts` to use the shared helper.
+- Added an internal read-only JSON endpoint:
+  - `GET /api/internal/mvp-measurement/summary?days=30`
+
+## Internal Summary Path
+
+The internal endpoint is not a public analytics dashboard and has no UI. It is intended for controlled launch-readiness readback in a configured server environment.
+
+Protection:
+
+- requires an authenticated Supabase session via `safeGetUser`
+- requires an authorized admin email via `ADMIN_EMAILS`
+- reads through the existing service-role server client
+- returns aggregate counts only
+- sets `Cache-Control: no-store`
+- returns generic errors to callers
+- does not return raw visitor IDs, session IDs, service credentials, cookies, auth headers, or connection strings
+
+Returned summary fields include:
+
+- total event count
+- unique anonymous visitor count
+- unique session count
+- event counts by date
+- event counts by event name
+- event counts by route
+- day-7 return denominator/numerator/rate
+- strict full-expansion session rate
+- proxy expansion session rate
+- first-three-sessions expansion rate
+- comprehension prompt shown/answered/agreement rate
+- explicit limitations for elapsed day-7 data, deferred comprehension prompt UI, and strict full-expansion proxy status
+
+## Existing Helper Status
+
+The existing local helper remains server-configured only:
+
+```bash
+npx tsx scripts/mvp-measurement-summary.ts --days 1
+```
+
+In this worktree it returned:
+
+```text
+Supabase server configuration is required to summarize MVP measurement events.
+```
+
+The local shell had no `SUPABASE`, `DATABASE`, `POSTGRES`, `VERCEL`, or `ADMIN_EMAILS` variables exposed. Secrets were not printed, pulled into local files, persisted, or committed.
+
+## What Did Not Change
+
+- no public analytics dashboard
+- no public/user-facing measurement UI
+- no visible comprehension prompt UI
+- no event schema change
+- no signal-row mutation
+- no direct SQL row surgery
+- no ad hoc DDL or DML
+- no publish
+- no `draft_only`
+- no pipeline write-mode
+- no cron
+- no source governance change
+- no ranking threshold change
+- no WITM threshold change
+- no Phase 2 architecture
+- no personalization
+- no analytics-driven ranking or product behavior
+
+## Validation
+
+Commands run:
+
+```bash
+npm install
+npx vitest run src/lib/mvp-measurement-summary.test.ts src/app/api/internal/mvp-measurement/summary/route.test.ts
+npx tsx scripts/mvp-measurement-summary.ts --days 1
+git diff --check
+python3 scripts/validate-feature-system-csv.py
+python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/mvp-measurement-summary-readiness --pr-title "MVP measurement summary readiness"
+python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/mvp-measurement-summary-readiness --pr-title "MVP measurement summary readiness"
+npm run lint
+npm run test
+npm run build
+PLAYWRIGHT_MANAGED_WEBSERVER=1 npm run test:e2e:chromium
+PLAYWRIGHT_MANAGED_WEBSERVER=1 npx playwright test tests/routes/core-routes.spec.ts tests/audit/route-traversal.spec.ts --project=chromium --workers=1
+PLAYWRIGHT_MANAGED_WEBSERVER=1 npx playwright test --project=chromium --workers=1
+PLAYWRIGHT_MANAGED_WEBSERVER=1 npx playwright test --project=webkit --workers=1
+```
+
+Results:
+
+- `npm install` passed; npm reported two audit findings.
+- Focused Vitest passed: 2 files, 6 tests.
+- Local summary helper remained blocked by missing Supabase server configuration, as expected.
+- `git diff --check` passed.
+- Governance validation passed.
+- `npm run lint` passed.
+- `npm run test` passed: 78 files, 591 tests.
+- Final `npm run build` passed after correcting the helper query-builder type.
+- Full serial Chromium passed: 33 tests.
+- Full serial WebKit passed: 33 tests.
+
+The first full Chromium run with default parallel workers hit two navigation timeouts around the legacy `/sources` redirect path. The exact failing specs passed serially, and the full Chromium suite then passed serially.
+
+## Result
+
+The previous limitation is now bounded with a safe configured-environment path:
+
+```text
+measurement_summary_ready_via_configured_environment_only
+```
+
+## Next Task
+
+After this PR is merged and deployed, rerun final launch-readiness QA and verify the internal summary endpoint with an authenticated admin session in production or preview. If summary readback succeeds and public/cron safety still passes, proceed to controlled user exposure. Cron remains a later staged operations task.

--- a/docs/operations/controlled-cycles/2026-05-01-mvp-measurement-summary-readiness.md
+++ b/docs/operations/controlled-cycles/2026-05-01-mvp-measurement-summary-readiness.md
@@ -1,0 +1,357 @@
+# MVP Measurement Summary Readiness
+
+Date checked: 2026-05-02
+Branch: `codex/mvp-measurement-summary-readiness`
+Readiness label: `measurement_summary_ready_via_configured_environment_only`
+
+## Effective Change Type
+
+Remediation / alignment.
+
+This packet records the measurement-summary readiness pass after PR #178 found final launch-readiness partially limited by unavailable local production summary readback. It does not create a public analytics product, create a new PRD, change product scope, run cron, run `draft_only`, run pipeline write-mode, publish, mutate Signal rows, run direct SQL row surgery, change source/ranking/WITM thresholds, start Phase 2 architecture, start personalization, or implement visible comprehension prompt UI.
+
+Object levels affected:
+
+- Signal/Card/Surface Placement measurement summary only
+
+Object levels not changed:
+
+- Article
+- Story Cluster
+- conceptual Signal identity
+- public Card copy
+- public Surface Placement / visibility
+
+## Source Of Truth
+
+Primary:
+
+- Product Position - MVP Success Criteria:
+  - day-7 retention
+  - depth engagement / Signal expansion
+  - comprehension confidence
+
+Secondary:
+
+- `docs/operations/controlled-cycles/2026-05-01-final-launch-readiness-qa-rerun.md`
+- `docs/operations/tracker-sync/2026-05-01-final-launch-readiness-qa-rerun.md`
+- `docs/operations/controlled-cycles/2026-05-01-mvp-measurement-storage-alignment.md`
+- `docs/operations/tracker-sync/2026-05-01-mvp-measurement-storage-alignment.md`
+- `docs/engineering/change-records/mvp-measurement-instrumentation.md`
+- `docs/operations/controlled-cycles/2026-05-01-final-launch-readiness-qa.md`
+- `docs/operations/tracker-sync/2026-05-01-final-launch-readiness-qa.md`
+
+## PR #178 Blocker Summary
+
+PR #178 confirmed:
+
+- public homepage `/` passed
+- `/signals` passed
+- `/briefing/2026-05-01` passed
+- production measurement event writes returned `stored:true`
+- cron remained protected with HTTP 401
+- no publish, cron, `draft_only`, Signal row mutation, direct SQL row surgery, ranking/WITM/source change, Phase 2 architecture, or personalization occurred
+
+Remaining limitation:
+
+```text
+local measurement summary helper cannot read production rows because the worktree has no Supabase server config exposed
+```
+
+PR #178 readiness:
+
+```text
+launch_readiness_partial_measurement_summary_limited
+```
+
+## Authorization
+
+Prompt-level authorization present:
+
+- `CONTROLLED_PRODUCTION_MEASUREMENT_SUMMARY_READ_APPROVED=true`
+- `CONTROLLED_PRODUCTION_SCHEMA_READONLY_INSPECTION_APPROVED=true`
+
+Prompt-level authorization absent:
+
+- controlled user exposure authorization
+- public/user-facing analytics dashboard authorization
+- visible comprehension prompt UI authorization
+- event schema change authorization
+- signal-row mutation authorization
+- direct SQL row-surgery authorization
+- ad hoc DDL authorization
+- ad hoc DML authorization
+- publish authorization
+- `draft_only` authorization
+- pipeline write-mode authorization
+- cron authorization
+- source/ranking/WITM threshold authorization
+- Phase 2 architecture authorization
+- personalization authorization
+
+Shell environment note:
+
+- The authorization variables were present in the user prompt, not exported as shell variables.
+- No `SUPABASE`, `DATABASE`, `POSTGRES`, `VERCEL`, or `ADMIN_EMAILS` environment variables were exposed to this worktree during the local check.
+- No secrets, database passwords, connection strings, service-role keys, browser cookies, auth headers, or production credentials were printed or persisted.
+
+## Baseline Inspection
+
+Files and conventions inspected:
+
+- `scripts/mvp-measurement-summary.ts`
+- `src/lib/mvp-measurement-summary.ts`
+- `src/lib/mvp-measurement.ts`
+- `src/app/api/mvp-measurement/events/route.ts`
+- `src/lib/supabase/server.ts`
+- `src/lib/admin-auth.ts`
+- `supabase/migrations/20260501100000_mvp_measurement_events.sql`
+- `docs/engineering/change-records/mvp-measurement-instrumentation.md`
+- `docs/operations/controlled-cycles/2026-05-01-final-launch-readiness-qa-rerun.md`
+- `docs/operations/controlled-cycles/2026-05-01-mvp-measurement-storage-alignment.md`
+
+Findings:
+
+- The existing summary helper requires server-only Supabase configuration.
+- The helper reads `mvp_measurement_events` through service-role access and does not mutate data.
+- The production schema includes service-role read/write policies for `mvp_measurement_events`.
+- The existing event API writes only validated measurement events and soft-fails without blocking public UX.
+- Admin authorization convention exists through `safeGetUser` plus `ADMIN_EMAILS`.
+- The existing helper did not report event counts by event name, which made event-specific readback less direct.
+
+## Existing Helper Attempt
+
+Command:
+
+```bash
+npx tsx scripts/mvp-measurement-summary.ts --days 1
+```
+
+Result:
+
+```text
+Supabase server configuration is required to summarize MVP measurement events.
+```
+
+Interpretation:
+
+- The helper is present and runnable after dependencies are installed.
+- This local worktree intentionally does not have server-only production credentials exposed.
+- No unsafe workaround was attempted.
+- Secrets were not pulled from Vercel or Supabase into local files.
+
+## Minimal Read-Only Summary Path Added
+
+Added:
+
+- `GET /api/internal/mvp-measurement/summary?days=30`
+
+Supporting changes:
+
+- `summarizeMvpMeasurementEvents` now includes `eventCountByEventName`.
+- `readMvpMeasurementSummary` centralizes the service-role read query for both the script and internal route.
+- `scripts/mvp-measurement-summary.ts` now uses the shared summary read helper.
+
+Protection:
+
+- requires an authenticated Supabase session
+- requires `ADMIN_EMAILS` authorization through `isAdminUser`
+- uses the existing server-side service-role client
+- returns aggregate-only JSON
+- never returns raw visitor IDs or session IDs
+- does not return secrets, cookies, auth headers, connection strings, or database details
+- returns generic errors to callers if the service read fails
+- uses `Cache-Control: no-store`
+
+Data read:
+
+- `event_name`
+- `visitor_id`
+- `session_id`
+- `occurred_at`
+- `route`
+- `metadata`
+
+Data returned:
+
+- total event count
+- event counts by date
+- event counts by event name
+- event counts by route
+- unique visitor count
+- unique session count
+- day-7 return denominator/numerator/rate
+- strict full-expansion session count/rate
+- proxy expansion session count/rate
+- first-three-sessions expansion denominator/numerator/rate
+- comprehension prompt shown/answered/agreement counts/rate
+- explicit limitations
+
+No mutation occurs.
+
+## Summary Verification Result
+
+Local focused tests passed:
+
+```bash
+npx vitest run src/lib/mvp-measurement-summary.test.ts src/app/api/internal/mvp-measurement/summary/route.test.ts
+```
+
+Result:
+
+```text
+2 files passed
+6 tests passed
+```
+
+Verified by tests:
+
+- unauthenticated requests cannot read summaries
+- non-admin users cannot read summaries
+- missing server config returns an unavailable status
+- authorized admin requests receive aggregate-only summaries
+- event counts by event name are grouped correctly
+- `homepage_view`, `signal_details_click`, and `source_click` appear in aggregate output when rows are present
+- raw anonymous visitor/session IDs are not returned
+- query errors return generic caller-facing errors and are logged server-side
+
+Production summary readback was not run in this branch because the internal path must be deployed first and requires authenticated admin access in a configured server environment. This is the intended safe operational boundary.
+
+## Public Safety Verification
+
+Production URL:
+
+```text
+https://daily-intelligence-aggregator-ybs9.vercel.app
+```
+
+Read-only checks run before code changes:
+
+| Route | Result |
+| --- | --- |
+| `/` | HTTP 200 |
+| `/signals` | HTTP 200 |
+| `/briefing/2026-05-01` | HTTP 200 |
+| `/api/cron/fetch-news` without auth | HTTP 401 |
+
+Additional observations:
+
+- `/` showed May 1 markers
+- `/signals` showed `Published Signals`
+- no schema-preflight error text was visible
+- no missing-column text was visible
+- no measurement-storage error text was visible
+- cron remained protected
+
+The repo production route probe also passed:
+
+```text
+PASS production route probe
+/ -> HTTP 200; /dashboard -> HTTP 200
+```
+
+## Cron Status
+
+Cron remained protected:
+
+```text
+GET /api/cron/fetch-news -> HTTP 401
+```
+
+No cron run was triggered. Cron was not re-enabled.
+
+## What Did Not Change
+
+- no public analytics product
+- no new PRD
+- no product scope change
+- no public/user-facing dashboard
+- no visible comprehension prompt UI
+- no event schema change
+- no signal-row mutation
+- no direct SQL row surgery
+- no ad hoc DDL
+- no ad hoc DML
+- no publish
+- no `draft_only`
+- no pipeline write-mode
+- no cron
+- no source governance change
+- no ranking threshold change
+- no WITM threshold change
+- no public URL/domain/env/Vercel setting change
+- no removal of `newsweb2026@gmail.com` from Production `ADMIN_EMAILS`
+- no Phase 2 architecture
+- no personalization
+- no analytics-driven ranking or product behavior
+
+## Validation
+
+Commands run:
+
+```bash
+npm install
+npx vitest run src/lib/mvp-measurement-summary.test.ts src/app/api/internal/mvp-measurement/summary/route.test.ts
+npx tsx scripts/mvp-measurement-summary.ts --days 1
+node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+node <read-only public route and cron probe>
+git diff --check
+python3 scripts/validate-feature-system-csv.py
+python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/mvp-measurement-summary-readiness --pr-title "MVP measurement summary readiness"
+python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/mvp-measurement-summary-readiness --pr-title "MVP measurement summary readiness"
+npm run lint
+npm run test
+npm run build
+PLAYWRIGHT_MANAGED_WEBSERVER=1 npm run test:e2e:chromium
+PLAYWRIGHT_MANAGED_WEBSERVER=1 npx playwright test tests/routes/core-routes.spec.ts tests/audit/route-traversal.spec.ts --project=chromium --workers=1
+PLAYWRIGHT_MANAGED_WEBSERVER=1 npx playwright test --project=chromium --workers=1
+PLAYWRIGHT_MANAGED_WEBSERVER=1 npx playwright test --project=webkit --workers=1
+```
+
+Results:
+
+- `npm install` passed; npm reported two audit findings.
+- Focused Vitest passed: 2 files, 6 tests.
+- The local helper remained blocked by missing Supabase server configuration.
+- Production route probe passed.
+- Public route and cron checks passed.
+- `git diff --check` passed.
+- `python3 scripts/validate-feature-system-csv.py` passed with existing PRD slug warnings for PRD-32, PRD-37, and PRD-38.
+- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/mvp-measurement-summary-readiness --pr-title "MVP measurement summary readiness"` passed.
+- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/mvp-measurement-summary-readiness --pr-title "MVP measurement summary readiness"` passed.
+- `npm run lint` passed.
+- `npm run test` passed: 78 files, 591 tests.
+- First `npm run build` attempt found a Supabase query-builder typing mismatch in the shared helper; the helper type was corrected to accept Supabase's thenable query builder.
+- Final `npm run build` passed. Next.js emitted existing workspace-root and Tailwind module-type warnings.
+- Initial full Chromium run with default parallel workers hit two navigation timeouts around the legacy `/sources` redirect path.
+- Targeted serial rerun of the failing Chromium specs passed: 8 tests.
+- Full serial Chromium rerun passed: 33 tests.
+- Full serial WebKit rerun passed: 33 tests.
+
+## Blockers Remaining
+
+No public-safety blocker was found.
+
+Remaining operational limitation:
+
+- production summary readback must be verified after this internal route is merged and deployed, or the existing CLI helper must be run in a separately configured server environment
+
+This limitation is now bounded by a concrete safe path.
+
+## Result
+
+Summary readiness is bounded by a configured-environment path:
+
+```text
+measurement_summary_ready_via_configured_environment_only
+```
+
+## Exact Next Task
+
+After this PR is merged and deployed, rerun final launch-readiness QA and verify the internal summary route with authenticated admin access:
+
+```text
+GET /api/internal/mvp-measurement/summary?days=7
+```
+
+If that summary readback succeeds and public/cron safety still passes, move to controlled user exposure. Cron remains a later staged operations task.

--- a/docs/operations/tracker-sync/2026-05-01-mvp-measurement-summary-readiness.md
+++ b/docs/operations/tracker-sync/2026-05-01-mvp-measurement-summary-readiness.md
@@ -1,0 +1,25 @@
+# Tracker Sync Fallback - MVP Measurement Summary Readiness
+
+Date: 2026-05-01
+Branch: `codex/mvp-measurement-summary-readiness`
+Readiness label: `measurement_summary_ready_via_configured_environment_only`
+
+Direct live tracker writeback was not performed from this worktree. Use this fallback payload for manual tracker sync if needed.
+
+| Field | Value |
+| --- | --- |
+| Change type | Remediation / alignment |
+| Source of truth | Product Position MVP Success Criteria; PR #175 measurement instrumentation; PR #177 measurement storage alignment; PR #178 final launch-readiness QA rerun blocker |
+| Status | In Review |
+| Readiness | `measurement_summary_ready_via_configured_environment_only` |
+| Summary | Added a safe internal read-only MVP measurement summary path for configured server environments. Existing local CLI helper remains server-configured only and cannot read production rows from unconfigured local worktrees. |
+| What changed | `summarizeMvpMeasurementEvents` now reports event counts by event name; the CLI summary script uses a shared read helper; `GET /api/internal/mvp-measurement/summary` returns aggregate-only measurement summaries for authenticated admins. |
+| Protection | Authenticated Supabase session plus `ADMIN_EMAILS`; service-role read path; aggregate-only JSON; no raw visitor/session IDs returned; no secrets returned; `Cache-Control: no-store`. |
+| Public safety | `/`, `/signals`, and `/briefing/2026-05-01` returned HTTP 200; unauthenticated cron returned HTTP 401; no schema or measurement errors were visible publicly. |
+| What did not change | No public analytics dashboard, no visible comprehension prompt UI, no event schema change, no signal row mutation, no direct SQL, no publish, no `draft_only`, no cron, no source/ranking/WITM threshold change, no Phase 2 architecture, no personalization. |
+| Validation | Focused Vitest passed for summary helper and internal route. Full repo validation recorded in the PR. |
+| Next task | After merge and deploy, rerun final launch-readiness QA and verify `GET /api/internal/mvp-measurement/summary?days=7` with authenticated admin access. If summary readback succeeds and public/cron safety still passes, proceed to controlled user exposure. Cron remains later. |
+
+## Manual Tracker Note
+
+This is not net-new feature scope. It is a bounded remediation/alignment path for reading already-stored MVP measurement events before controlled user exposure.

--- a/scripts/mvp-measurement-summary.ts
+++ b/scripts/mvp-measurement-summary.ts
@@ -3,17 +3,16 @@
 import { createClient } from "@supabase/supabase-js";
 
 import {
-  summarizeMvpMeasurementEvents,
-  type MvpMeasurementSummaryRow,
+  normalizeMvpMeasurementSummaryWindowDays,
+  readMvpMeasurementSummary,
 } from "@/lib/mvp-measurement-summary";
 import { env, isSupabaseServerConfigured } from "@/lib/env";
 
 function parseDays() {
   const flagIndex = process.argv.findIndex((arg) => arg === "--days");
   const rawValue = flagIndex >= 0 ? process.argv[flagIndex + 1] : "30";
-  const parsed = Number.parseInt(rawValue ?? "30", 10);
 
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 30;
+  return normalizeMvpMeasurementSummaryWindowDays(rawValue);
 }
 
 async function main() {
@@ -22,35 +21,15 @@ async function main() {
   }
 
   const days = parseDays();
-  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
   const client = createClient(env.supabaseUrl, env.supabaseServiceRoleKey, {
     auth: {
       autoRefreshToken: false,
       persistSession: false,
     },
   });
+  const summary = await readMvpMeasurementSummary(client, days);
 
-  const result = await client
-    .from("mvp_measurement_events")
-    .select("event_name, visitor_id, session_id, occurred_at, route, metadata")
-    .gte("occurred_at", since)
-    .order("occurred_at", { ascending: true })
-    .limit(10000);
-
-  if (result.error) {
-    throw new Error(result.error.message);
-  }
-
-  const summary = summarizeMvpMeasurementEvents(
-    (result.data ?? []) as unknown as MvpMeasurementSummaryRow[],
-  );
-
-  console.log(JSON.stringify({
-    ok: true,
-    windowDays: days,
-    since,
-    summary,
-  }, null, 2));
+  console.log(JSON.stringify(summary, null, 2));
 }
 
 main().catch((error) => {

--- a/src/app/api/internal/mvp-measurement/summary/route.test.ts
+++ b/src/app/api/internal/mvp-measurement/summary/route.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const createSupabaseServiceRoleClient = vi.fn();
+const safeGetUser = vi.fn();
+const isAdminUser = vi.fn();
+const logServerEvent = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServiceRoleClient,
+  safeGetUser,
+}));
+
+vi.mock("@/lib/admin-auth", () => ({
+  isAdminUser,
+}));
+
+vi.mock("@/lib/observability", () => ({
+  logServerEvent,
+}));
+
+function buildRequest(days = "30") {
+  return new Request(`http://localhost:3000/api/internal/mvp-measurement/summary?days=${days}`);
+}
+
+function buildSummaryClient(rows: Array<Record<string, unknown>>) {
+  const limit = vi.fn(async () => ({
+    data: rows,
+    error: null,
+  }));
+  const order = vi.fn(() => ({ limit }));
+  const gte = vi.fn(() => ({ order }));
+  const select = vi.fn(() => ({ gte }));
+  const from = vi.fn(() => ({ select }));
+
+  return {
+    client: { from },
+    calls: {
+      from,
+      select,
+      gte,
+      order,
+      limit,
+    },
+  };
+}
+
+describe("/api/internal/mvp-measurement/summary", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    safeGetUser.mockResolvedValue({
+      user: { id: "user-1", email: "admin@example.com" },
+    });
+    isAdminUser.mockReturnValue(true);
+  });
+
+  it("requires authentication before reading measurement events", async () => {
+    safeGetUser.mockResolvedValue({
+      user: null,
+    });
+
+    const { GET } = await import("@/app/api/internal/mvp-measurement/summary/route");
+    const response = await GET(buildRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body).toEqual({
+      ok: false,
+      error: "admin_auth_required",
+    });
+    expect(createSupabaseServiceRoleClient).not.toHaveBeenCalled();
+  });
+
+  it("requires an admin email before reading measurement events", async () => {
+    isAdminUser.mockReturnValue(false);
+
+    const { GET } = await import("@/app/api/internal/mvp-measurement/summary/route");
+    const response = await GET(buildRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toEqual({
+      ok: false,
+      error: "admin_access_required",
+    });
+    expect(createSupabaseServiceRoleClient).not.toHaveBeenCalled();
+  });
+
+  it("returns an unavailable status when server measurement config is missing", async () => {
+    createSupabaseServiceRoleClient.mockReturnValue(null);
+
+    const { GET } = await import("@/app/api/internal/mvp-measurement/summary/route");
+    const response = await GET(buildRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toEqual({
+      ok: false,
+      error: "measurement_summary_unavailable",
+    });
+  });
+
+  it("returns aggregate-only measurement summary for authorized admins", async () => {
+    const { client, calls } = buildSummaryClient([
+      {
+        event_name: "homepage_view",
+        visitor_id: "mvp_visitor_a",
+        session_id: "mvp_session_a1",
+        occurred_at: "2026-05-01T12:00:00.000Z",
+        route: "/",
+      },
+      {
+        event_name: "signal_details_click",
+        visitor_id: "mvp_visitor_a",
+        session_id: "mvp_session_a1",
+        occurred_at: "2026-05-01T12:05:00.000Z",
+        route: "/",
+      },
+      {
+        event_name: "source_click",
+        visitor_id: "mvp_visitor_b",
+        session_id: "mvp_session_b1",
+        occurred_at: "2026-05-02T12:00:00.000Z",
+        route: "/signals",
+      },
+    ]);
+    createSupabaseServiceRoleClient.mockReturnValue(client);
+
+    const { GET } = await import("@/app/api/internal/mvp-measurement/summary/route");
+    const response = await GET(buildRequest("7"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(calls.from).toHaveBeenCalledWith("mvp_measurement_events");
+    expect(calls.select).toHaveBeenCalledWith("event_name, visitor_id, session_id, occurred_at, route, metadata");
+    expect(calls.limit).toHaveBeenCalledWith(10000);
+    expect(body).toMatchObject({
+      ok: true,
+      windowDays: 7,
+      summary: {
+        eventCount: 3,
+        uniqueVisitorCount: 2,
+        uniqueSessionCount: 2,
+        eventCountByEventName: {
+          homepage_view: 1,
+          signal_details_click: 1,
+          source_click: 1,
+        },
+        eventCountByRoute: {
+          "/": 2,
+          "/signals": 1,
+        },
+      },
+    });
+    expect(JSON.stringify(body)).not.toContain("mvp_visitor_a");
+    expect(JSON.stringify(body)).not.toContain("mvp_session_a1");
+  });
+
+  it("does not expose query errors to callers", async () => {
+    const limit = vi.fn(async () => ({
+      data: null,
+      error: { message: "relation missing" },
+    }));
+    createSupabaseServiceRoleClient.mockReturnValue({
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          gte: vi.fn(() => ({
+            order: vi.fn(() => ({ limit })),
+          })),
+        })),
+      })),
+    });
+
+    const { GET } = await import("@/app/api/internal/mvp-measurement/summary/route");
+    const response = await GET(buildRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body).toEqual({
+      ok: false,
+      error: "measurement_summary_query_failed",
+    });
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "warn",
+      "MVP measurement summary read failed",
+      expect.objectContaining({
+        route: "/api/internal/mvp-measurement/summary",
+      }),
+    );
+  });
+});

--- a/src/app/api/internal/mvp-measurement/summary/route.ts
+++ b/src/app/api/internal/mvp-measurement/summary/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+
+import { isAdminUser } from "@/lib/admin-auth";
+import { logServerEvent } from "@/lib/observability";
+import { readMvpMeasurementSummary } from "@/lib/mvp-measurement-summary";
+import {
+  createSupabaseServiceRoleClient,
+  safeGetUser,
+} from "@/lib/supabase/server";
+
+const ROUTE = "/api/internal/mvp-measurement/summary";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function json(body: Record<string, unknown>, status: number) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export async function GET(request: Request) {
+  const { user } = await safeGetUser(ROUTE);
+
+  if (!user) {
+    return json(
+      {
+        ok: false,
+        error: "admin_auth_required",
+      },
+      401,
+    );
+  }
+
+  if (!isAdminUser(user)) {
+    return json(
+      {
+        ok: false,
+        error: "admin_access_required",
+      },
+      403,
+    );
+  }
+
+  const client = createSupabaseServiceRoleClient();
+  if (!client) {
+    return json(
+      {
+        ok: false,
+        error: "measurement_summary_unavailable",
+      },
+      503,
+    );
+  }
+
+  const days = new URL(request.url).searchParams.get("days");
+
+  try {
+    return json(await readMvpMeasurementSummary(client, days), 200);
+  } catch (error) {
+    logServerEvent("warn", "MVP measurement summary read failed", {
+      route: ROUTE,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
+
+    return json(
+      {
+        ok: false,
+        error: "measurement_summary_query_failed",
+      },
+      502,
+    );
+  }
+}

--- a/src/lib/mvp-measurement-summary.test.ts
+++ b/src/lib/mvp-measurement-summary.test.ts
@@ -51,6 +51,12 @@ describe("MVP measurement summary", () => {
       "2026-05-02": 2,
       "2026-05-08": 1,
     });
+    expect(summary.eventCountByEventName).toMatchObject({
+      homepage_view: 2,
+      signals_page_view: 1,
+      signal_details_click: 1,
+      comprehension_prompt_answered: 1,
+    });
     expect(summary.eventCountByRoute).toMatchObject({
       "/": 3,
       "/signals": 2,

--- a/src/lib/mvp-measurement-summary.ts
+++ b/src/lib/mvp-measurement-summary.ts
@@ -14,6 +14,7 @@ export type MvpMeasurementSummary = {
   uniqueVisitorCount: number;
   uniqueSessionCount: number;
   eventCountByDate: Record<string, number>;
+  eventCountByEventName: Partial<Record<MvpMeasurementEventName, number>>;
   eventCountByRoute: Record<string, number>;
   day7Return: {
     denominator: number;
@@ -40,11 +41,64 @@ export type MvpMeasurementSummary = {
   };
 };
 
+export type MvpMeasurementSummaryResult = {
+  ok: true;
+  windowDays: number;
+  since: string;
+  summary: MvpMeasurementSummary;
+  limitations: {
+    day7Retention: string;
+    comprehensionPrompt: string;
+    strictFullExpansion: string;
+  };
+};
+
+type MvpMeasurementSummaryQueryResult = {
+  data?: unknown[] | null;
+  error?: {
+    message: string;
+  } | null;
+};
+
+type MvpMeasurementSummaryQueryClient = {
+  from(table: "mvp_measurement_events"): {
+    select(columns: string): {
+      gte(column: "occurred_at", value: string): {
+        order(
+          column: "occurred_at",
+          options: { ascending: boolean },
+        ): {
+          limit(count: number): PromiseLike<MvpMeasurementSummaryQueryResult>;
+        };
+      };
+    };
+  };
+};
+
 const DEPTH_PROXY_EVENTS = new Set<MvpMeasurementEventName>([
   "signal_full_expansion",
   "signal_full_expansion_proxy",
   "signal_details_click",
 ]);
+
+const DEFAULT_SUMMARY_WINDOW_DAYS = 30;
+const MAX_SUMMARY_WINDOW_DAYS = 90;
+const SUMMARY_ROW_LIMIT = 10000;
+
+export function normalizeMvpMeasurementSummaryWindowDays(value: unknown) {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number.parseInt(value, 10)
+        : DEFAULT_SUMMARY_WINDOW_DAYS;
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_SUMMARY_WINDOW_DAYS;
+  }
+
+  return Math.min(Math.floor(parsed), MAX_SUMMARY_WINDOW_DAYS);
+}
 
 function dateKey(value: string) {
   const date = new Date(value);
@@ -72,6 +126,7 @@ function metadataResponse(row: MvpMeasurementSummaryRow) {
 
 export function summarizeMvpMeasurementEvents(rows: MvpMeasurementSummaryRow[]): MvpMeasurementSummary {
   const eventCountByDate: Record<string, number> = {};
+  const eventCountByEventName: Partial<Record<MvpMeasurementEventName, number>> = {};
   const eventCountByRoute: Record<string, number> = {};
   const visitorDates = new Map<string, Set<string>>();
   const sessionEvents = new Map<string, Set<MvpMeasurementEventName>>();
@@ -84,6 +139,8 @@ export function summarizeMvpMeasurementEvents(rows: MvpMeasurementSummaryRow[]):
 
   rows.forEach((row) => {
     visitors.add(row.visitor_id);
+    eventCountByEventName[row.event_name] = (eventCountByEventName[row.event_name] ?? 0) + 1;
+
     const rowDate = dateKey(row.occurred_at);
     if (rowDate) {
       eventCountByDate[rowDate] = (eventCountByDate[rowDate] ?? 0) + 1;
@@ -176,6 +233,7 @@ export function summarizeMvpMeasurementEvents(rows: MvpMeasurementSummaryRow[]):
     uniqueVisitorCount: visitors.size,
     uniqueSessionCount: sessionEvents.size,
     eventCountByDate,
+    eventCountByEventName,
     eventCountByRoute,
     day7Return: {
       denominator: day7Denominator,
@@ -199,6 +257,38 @@ export function summarizeMvpMeasurementEvents(rows: MvpMeasurementSummaryRow[]):
       denominator: firstThreeDenominator,
       numerator: firstThreeNumerator,
       rate: rate(firstThreeNumerator, firstThreeDenominator),
+    },
+  };
+}
+
+export async function readMvpMeasurementSummary(
+  client: MvpMeasurementSummaryQueryClient,
+  inputDays?: unknown,
+): Promise<MvpMeasurementSummaryResult> {
+  const windowDays = normalizeMvpMeasurementSummaryWindowDays(inputDays);
+  const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000).toISOString();
+  const result = await client
+    .from("mvp_measurement_events")
+    .select("event_name, visitor_id, session_id, occurred_at, route, metadata")
+    .gte("occurred_at", since)
+    .order("occurred_at", { ascending: true })
+    .limit(SUMMARY_ROW_LIMIT);
+
+  if (result.error) {
+    throw new Error(result.error.message);
+  }
+
+  return {
+    ok: true,
+    windowDays,
+    since,
+    summary: summarizeMvpMeasurementEvents(
+      (result.data ?? []) as unknown as MvpMeasurementSummaryRow[],
+    ),
+    limitations: {
+      day7Retention: "Requires seven elapsed calendar days and returning visitor events; absence of data is not a failure.",
+      comprehensionPrompt: "Visible comprehension prompt UI remains deferred; prompt events summarize when explicitly captured.",
+      strictFullExpansion: "Current UI can report strict full-expansion events when present and depth proxies separately.",
     },
   };
 }


### PR DESCRIPTION
## Effective change type

Remediation / alignment.

## Source of truth

- Product Position MVP success criteria: day-7 retention, depth engagement / Signal expansion, comprehension confidence
- PR #175 measurement instrumentation
- PR #177 measurement storage alignment
- PR #178 final launch-readiness QA rerun blocker

## What changed

- Added `eventCountByEventName` to MVP measurement summaries.
- Centralized the summary read query in `readMvpMeasurementSummary` and reused it from the CLI helper.
- Added `GET /api/internal/mvp-measurement/summary?days=30`, an aggregate-only internal summary path for configured server environments.
- Gated the internal path behind authenticated Supabase user state plus `ADMIN_EMAILS` admin authorization.
- Added tests and durable documentation packets.

## What did not change

- No public analytics dashboard.
- No visible comprehension prompt UI.
- No event schema change.
- No Signal row mutation.
- No direct SQL, ad hoc DDL, or ad hoc DML.
- No publish, `draft_only`, pipeline write-mode, cron, controlled user exposure, Phase 2 architecture, or personalization.
- No source/ranking/WITM threshold changes.

## Validation

- `npm install` passed; npm reported two audit findings.
- `npx vitest run src/lib/mvp-measurement-summary.test.ts src/app/api/internal/mvp-measurement/summary/route.test.ts` passed: 2 files, 6 tests.
- `npx tsx scripts/mvp-measurement-summary.ts --days 1` remained blocked by missing Supabase server config, as expected.
- `node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app` passed.
- Read-only public route probe passed: `/`, `/signals`, `/briefing/2026-05-01` returned 200; unauthenticated cron returned 401.
- `git diff --check` passed.
- `python3 scripts/validate-feature-system-csv.py` passed with existing PRD slug warnings for PRD-32, PRD-37, and PRD-38.
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/mvp-measurement-summary-readiness --pr-title "MVP measurement summary readiness"` passed.
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/mvp-measurement-summary-readiness --pr-title "MVP measurement summary readiness"` passed.
- `npm run lint` passed.
- `npm run test` passed: 78 files, 591 tests.
- First `npm run build` found a Supabase query-builder typing mismatch in the shared helper; corrected, then final `npm run build` passed.
- Initial full Chromium run with default parallel workers hit two navigation timeouts around the legacy `/sources` redirect path; targeted serial rerun passed: 8 tests.
- Full serial Chromium passed: 33 tests.
- Full serial WebKit passed: 33 tests.

## Result

`measurement_summary_ready_via_configured_environment_only`

The local helper still cannot read production rows from an unconfigured worktree, but the branch adds a safe configured-environment path for authenticated admins. After this PR is merged and deployed, rerun final launch-readiness QA and verify `GET /api/internal/mvp-measurement/summary?days=7` with authenticated admin access. If that passes, proceed to controlled user exposure. Cron remains later.
