### PR TITLE
Public card cleanup — phase 1

### DIFF
--- a/docs/engineering/change-records/2026-05-02-public-card-cleanup-phase-1.md
+++ b/docs/engineering/change-records/2026-05-02-public-card-cleanup-phase-1.md
@@ -1,0 +1,64 @@
+# Public Card Cleanup — Phase 1
+
+Date: 2026-05-02
+Branch: `feature/public-card-cleanup-phase-1`
+Change type: remediation / display-layer cleanup
+Source of truth: live production audit of `daily-intelligence-aggregator-ybs9.vercel.app` on 2026-05-02
+
+## Problem
+
+The public homepage and `/signals` surface were leaking internal diagnostics and rendering duplicated content per signal card. A live audit on 2026-05-02 found:
+
+- The story headline appeared three times per Top Event card: as the `<h2>` title, as the gray subtitle, and as the third bullet in the key-points list. When `event.summary === event.title` and the third key point fell back to the same string, the same headline was rendered three times.
+- Supporting-coverage rows rendered as `Source: Title` even when the supplied source name and article title were identical, producing strings like `Politico Congress: Politico Congress` and `Liberty Street Economics: Liberty Street Economics`.
+- `Lead coverage is anchored by [source].` and `Previously published at rank #N for the homepage briefing.` were rendered as user-facing bullets despite being internal versioning artifacts.
+- The Top Event chip strip rendered `1 source` and `Developing` chips that carried no reader signal because every event has the same values.
+- Below the card body, `Meaningful impact` and `current briefing cycle` MetaPills exposed internal ranking labels with no reader meaning.
+- The `/signals` page rendered a `Score N` badge with the raw integer importance score.
+- The By Category section subhead read `Fresh coverage across the core lenses the homepage already uses.` — internal phrasing leaked into the public surface.
+
+## Root cause
+
+The public homepage card was built on top of `mapHomepageSignalPostToBriefingItem` in `src/lib/data.ts`, which generated three deterministic key-point bullets for every signal post regardless of whether the underlying values were informative or duplicate. The chip and MetaPill rows in `src/components/landing/homepage.tsx` rendered every label provided by the event-intelligence layer instead of selecting only labels that carry user-visible signal. The `/signals` route in `src/app/signals/page.tsx` rendered the raw importance score as a badge alongside the editorial tags. The By Category subhead in `src/components/home/CategoryPreviewGrid.tsx` was authored as internal-team copy and never rewritten for public reading.
+
+## Change made
+
+- Reduced `buildHomepageSignalKeyPoints` to surface at most one bullet (the post summary or selection reason) and only when it does not duplicate the title; the rank and lead-coverage bullets are no longer emitted.
+- Added title-deduplication filtering to the homepage Top Event card so any incoming key point that equals the title is dropped before render.
+- Hid the gray subtitle paragraph when `event.summary` equals `event.title`.
+- Removed the `sourceLabel` and `confidenceLabel` chips (`1 source`, `Developing`) from the Top Event chip strip, keeping only the topic badge.
+- Removed the `impactLabel` and `recencyLabel` MetaPills (`Meaningful impact`, `current briefing cycle`) from the Top Event meta row, keeping only the read-time pill.
+- Hid the `: {title}` suffix in supporting-coverage rows when the article title equals the source name.
+- Removed the `Score N` badge from `/signals` published-slate cards.
+- Rewrote the By Category subhead to `More from today's briefing, by category.`
+
+## Files modified
+
+- `src/lib/data.ts`
+- `src/components/landing/homepage.tsx`
+- `src/components/home/CategoryPreviewGrid.tsx`
+- `src/app/signals/page.tsx`
+- `docs/engineering/change-records/2026-05-02-public-card-cleanup-phase-1.md` (this file)
+
+## Validation
+
+- `npm run lint` passed
+- `npm run test` passed: 77 test files, 586 tests
+- `npm run build` passed
+- `python3 scripts/validate-feature-system-csv.py` passed with the existing PRD slug warnings for PRD-32, PRD-37, PRD-38
+
+## Safety / scope boundaries
+
+- No schema migration.
+- No source manifest changes.
+- No ranking, classification, or WITM template changes.
+- No auth, session, or routing changes.
+- No publish, cron, or pipeline write-mode changes.
+- No editorial copy authored or published.
+- No production data writes.
+
+## Remaining work / next phases
+
+- Phase 2: Replace the homepage `Last updated [date] — Today's briefing is being prepared.` banner with a date-anchored "Last published" label so day-old content is no longer presented as today's briefing while cron remains disabled.
+- Phase 3: Add visible auth entry points from the homepage and verify `/briefing/[date]` deep links resolve for the date currently advertised on the homepage.
+- Phase 4: Diagnose why the By Category > Tech section renders an empty state despite five active tech sources in the manifest.

--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -140,7 +140,6 @@ function SignalSection({
                       {post.tags.map((tag) => (
                         <Badge key={tag}>{tag}</Badge>
                       ))}
-                      {post.signalScore !== null ? <Badge>Score {Math.round(post.signalScore)}</Badge> : null}
                     </div>
                     <h3 className="mt-3 text-xl font-semibold leading-7 text-[var(--text-primary)]">
                       {post.title}

--- a/src/components/home/CategoryPreviewGrid.tsx
+++ b/src/components/home/CategoryPreviewGrid.tsx
@@ -19,7 +19,7 @@ export function CategoryPreviewGrid({ categoryPreviews }: CategoryPreviewGridPro
             By Category
           </h2>
           <p className="text-sm text-[var(--text-secondary)]">
-            Fresh coverage across the core lenses the homepage already uses.
+            More from today&apos;s briefing, by category.
           </p>
         </div>
       </div>

--- a/src/components/landing/homepage.tsx
+++ b/src/components/landing/homepage.tsx
@@ -170,8 +170,11 @@ function HomeTopEventCard({
   detailHref: string;
   featured: boolean;
 }) {
+  const titleNormalized = event.title.trim();
   const keyPoints = Array.isArray(event.keyPoints)
-    ? event.keyPoints.map((point) => point.trim()).filter(Boolean)
+    ? event.keyPoints
+        .map((point) => point.trim())
+        .filter((point) => Boolean(point) && point !== titleNormalized)
     : [];
   const sourceNames = event.relatedArticles
     .map((article) => article.sourceName.trim())
@@ -196,8 +199,6 @@ function HomeTopEventCard({
               <p className="section-label">Top Event</p>
               <div className="flex flex-wrap gap-2">
                 <Badge>{event.topicName}</Badge>
-                <Badge>{event.intelligence.sourceLabel}</Badge>
-                <Badge>{event.intelligence.confidenceLabel}</Badge>
               </div>
             </div>
           </div>
@@ -218,7 +219,9 @@ function HomeTopEventCard({
 
         <div>
           <h2 className="briefing-title text-[var(--text-primary)]">{event.title}</h2>
-          <p className="mt-3 text-base text-[var(--text-secondary)]">{event.summary}</p>
+          {event.summary && event.summary.trim() !== titleNormalized ? (
+            <p className="mt-3 text-base text-[var(--text-secondary)]">{event.summary}</p>
+          ) : null}
         </div>
 
         {keyPoints.length ? (
@@ -267,8 +270,6 @@ function HomeTopEventCard({
 
         <div className="flex flex-wrap gap-2 text-xs font-medium text-[var(--text-secondary)]">
           <MetaPill>{minutesToLabel(event.estimatedMinutes)} read</MetaPill>
-          <MetaPill>{event.intelligence.impactLabel}</MetaPill>
-          <MetaPill>{event.intelligence.recencyLabel}</MetaPill>
         </div>
 
         {event.relatedArticles.length ? (
@@ -293,7 +294,9 @@ function HomeTopEventCard({
                 >
                   <span className="min-w-0">
                     <span className="font-semibold">{article.sourceName}</span>
-                    <span className="text-[var(--text-secondary)]">: {article.title}</span>
+                    {article.title && article.title.trim() !== article.sourceName.trim() ? (
+                      <span className="text-[var(--text-secondary)]">: {article.title}</span>
+                    ) : null}
                   </span>
                   <ExternalLink className="mt-1 h-3.5 w-3.5 shrink-0 text-[var(--text-secondary)]" />
                 </a>

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -401,18 +401,12 @@ function buildHomepageSignalKeyPoints(
   post: HomepageSignalPost,
   source: HomepageSignalSnapshotSource,
 ): [string, string, string] {
-  const sourcePoint = post.sourceName
-    ? `Lead coverage is anchored by ${post.sourceName}.`
-    : source === "published_live"
-      ? "Lead coverage is anchored by the published signal set."
-      : "Lead coverage is anchored by the previously published signal set.";
-  const rankPoint =
-    source === "published_live"
-      ? `Published as live signal #${post.rank} for the homepage briefing.`
-      : `Previously published at rank #${post.rank} for the homepage briefing.`;
   const summaryPoint = post.summary || post.selectionReason || selectHomepageSignalWhyItMatters(post, source);
+  const titleNormalized = post.title.trim();
+  const summaryTrimmed = summaryPoint.trim();
+  const dedupedSummary = summaryTrimmed && summaryTrimmed !== titleNormalized ? summaryTrimmed : "";
 
-  return [sourcePoint, rankPoint, summaryPoint];
+  return [dedupedSummary, "", ""];
 }
 
 function mapHomepageSignalPostToBriefingItem(


### PR DESCRIPTION
## Effective change type

remediation / display-layer cleanup

## Source of truth

- Live production audit of `daily-intelligence-aggregator-ybs9.vercel.app` on 2026-05-02
- `docs/engineering/change-records/2026-05-02-public-card-cleanup-phase-1.md`

## What changed

Strips duplicated headlines, internal versioning artifacts, and diagnostic chips that were leaking into public surfaces.

**Homepage Top Event card (`src/components/landing/homepage.tsx`)**
- Drops the gray subtitle paragraph when `event.summary === event.title` (was rendering the headline twice)
- Drops the `sourceLabel` and `confidenceLabel` chips (`1 source`, `Developing`) from the chip strip; keeps the topic badge
- Drops the `impactLabel` and `recencyLabel` MetaPills (`Meaningful impact`, `current briefing cycle`); keeps the read-time pill
- Hides the `: {title}` suffix in supporting-coverage rows when source name equals article title (fixes `Politico Congress: Politico Congress`)
- Filters incoming key-point strings that match the title before render

**Signal-post key points (`src/lib/data.ts`)**
- Removes `Lead coverage is anchored by [source].` and `Previously published at rank #N for the homepage briefing.` bullets
- Returns at most one informative bullet (post summary), and only when it does not duplicate the title

**Signals page (`src/app/signals/page.tsx`)**
- Removes the `Score N` badge that exposed the raw integer importance score

**By Category section (`src/components/home/CategoryPreviewGrid.tsx`)**
- Rewrites the subhead from `Fresh coverage across the core lenses the homepage already uses.` to `More from today's briefing, by category.`

## Out of scope (deliberately deferred)

- WITM editorial copy and the deterministic template are unchanged in this PR per request
- No cron, publish, schema, source manifest, ranking, classification, auth, or routing changes
- No editorial copy authored or published

## Validation

- `git diff --check` passed
- `npm run lint` passed
- `npm run test` passed: 77 test files, 586 tests
- `npm run build` passed
- `python3 scripts/validate-feature-system-csv.py` passed with existing PRD slug warnings for PRD-32, PRD-37, PRD-38
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name feature/public-card-cleanup-phase-1 --pr-title "Public card cleanup phase 1"` passed
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name feature/public-card-cleanup-phase-1 --pr-title "Public card cleanup phase 1"` passed

## Risks / follow-up

- This is a presentation-layer cleanup with no data writes. Visual verification on the Vercel preview is the relevant gate.
- Tests assert the homepage shell via testid, not rendered diagnostic strings, so removing labels does not regress coverage.
- Phases 2-4 will follow as separate PRs: stale-date banner copy, briefing-detail/auth-entry verification, and category volume-layer selection diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)