### PR TITLE
Public card cleanup — phase 2 (stale-state copy)

### DIFF
--- a/src/components/landing/homepage.test.tsx
+++ b/src/components/landing/homepage.test.tsx
@@ -449,7 +449,7 @@ describe("LandingHomepage", () => {
       {
         homepageFreshnessNotice: {
           kind: "stale",
-          text: "Last updated Sunday, April 26 — Today's briefing is being prepared.",
+          text: "Showing the latest published briefing from Sunday, April 26.",
           briefingDate: "2026-04-26",
         },
       },
@@ -465,7 +465,7 @@ describe("LandingHomepage", () => {
     );
 
     expect(screen.getByTestId("home-freshness-notice")).toHaveTextContent(
-      "Last updated Sunday, April 26 — Today's briefing is being prepared.",
+      "Showing the latest published briefing from Sunday, April 26.",
     );
     expect(screen.getByText("Previously published signal")).toBeInTheDocument();
   });
@@ -474,7 +474,7 @@ describe("LandingHomepage", () => {
     const data = createData([], {
       homepageFreshnessNotice: {
         kind: "empty",
-        text: "Today's briefing is being prepared.",
+        text: "The latest briefing is not yet available. Please check back soon.",
         briefingDate: null,
       },
     });
@@ -489,9 +489,9 @@ describe("LandingHomepage", () => {
     );
 
     expect(screen.getByTestId("home-freshness-notice")).toHaveTextContent(
-      "Today's briefing is being prepared.",
+      "The latest briefing is not yet available. Please check back soon.",
     );
-    expect(screen.getAllByText("Today's briefing is being prepared.").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("The latest briefing is not yet available. Please check back soon.").length).toBeGreaterThan(0);
     expect(screen.queryByText(/placeholder|stored public signal snapshot|rail readable|sample slot/i)).not.toBeInTheDocument();
   });
 

--- a/src/lib/data.test.ts
+++ b/src/lib/data.test.ts
@@ -228,11 +228,11 @@ describe("homepage read model", () => {
     const state = await getHomepagePageState("/");
 
     expect(state.data.briefing.intro).toBe(
-      "Today's briefing is being prepared. Showing the most recently published signal set with its original date.",
+      "Showing the most recently published briefing.",
     );
     expect(state.data.homepageFreshnessNotice).toEqual({
       kind: "stale",
-      text: "Last updated Saturday, April 25 — Today's briefing is being prepared.",
+      text: "Showing the latest published briefing from Saturday, April 25.",
       briefingDate: "2026-04-25",
     });
     expect(state.data.briefing.items.map((item) => item.title)).toEqual([
@@ -264,12 +264,12 @@ describe("homepage read model", () => {
     const viewModel = buildHomepageViewModel(state.data);
     const serializedOutput = JSON.stringify(state.data);
 
-    expect(state.data.briefing.intro).toBe("Today's briefing is being prepared.");
+    expect(state.data.briefing.intro).toBe("The latest briefing is not yet available. Please check back soon.");
     expect(state.data.briefing.items).toEqual([]);
     expect(state.data.publicRankedItems).toEqual([]);
     expect(state.data.homepageFreshnessNotice).toEqual({
       kind: "empty",
-      text: "Today's briefing is being prepared.",
+      text: "The latest briefing is not yet available. Please check back soon.",
       briefingDate: null,
     });
     expect(viewModel.featured).toBeNull();

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -480,7 +480,7 @@ function formatHomepageFreshnessDate(dateKey: string) {
   }).format(date);
 }
 
-function buildEmptyPublicHomepageData(message = "Today's briefing is being prepared."): DashboardData {
+function buildEmptyPublicHomepageData(message = "The latest briefing is not yet available. Please check back soon."): DashboardData {
   const sources = getSourcesForPublicSurface("public.home");
   const briefingDate = normalizeCalendarSafeBriefingDate(getBriefingDateKey(formatISO(new Date())));
 
@@ -532,12 +532,12 @@ async function buildPublicHomepageData(): Promise<DashboardData> {
   const intro =
     homepageSignalSnapshot.source === "published_live"
       ? "The homepage renders from today's published signal set instead of triggering feed ingestion during SSR."
-      : "Today's briefing is being prepared. Showing the most recently published signal set with its original date.";
+      : "Showing the most recently published briefing.";
   const homepageFreshnessNotice =
     homepageSignalSnapshot.source === "recent_published" && homepageSignalSnapshot.briefingDate
       ? {
           kind: "stale" as const,
-          text: `Last updated ${formatHomepageFreshnessDate(homepageSignalSnapshot.briefingDate)} — Today's briefing is being prepared.`,
+          text: `Showing the latest published briefing from ${formatHomepageFreshnessDate(homepageSignalSnapshot.briefingDate)}.`,
           briefingDate: homepageSignalSnapshot.briefingDate,
         }
       : undefined;

--- a/tests/dashboard.spec.ts
+++ b/tests/dashboard.spec.ts
@@ -7,6 +7,9 @@ function isAccountAuthGateUrl(url: URL) {
   );
 }
 
+const fallbackBriefingCopy =
+  /Showing the most recently published briefing\.|The latest briefing is not yet available\. Please check back soon\./;
+
 test.describe("V1 shell and routing", () => {
   test.describe.configure({ mode: "serial" });
 
@@ -52,7 +55,7 @@ test.describe("V1 shell and routing", () => {
 
     const detailLink = page.getByRole("link", { name: "Details" }).first();
     if (!(await detailLink.isVisible())) {
-      await expect(page.getByText("Today's briefing is being prepared.").first()).toBeVisible();
+      await expect(page.getByText(fallbackBriefingCopy).first()).toBeVisible();
       await expect(page.getByText(/stored public signal snapshot|placeholder:|sample slot|fallback rail/i)).toHaveCount(0);
       return;
     }

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -8,6 +8,16 @@ async function expectNoStaticHomepagePlaceholder(page: Page) {
   ).toHaveCount(0);
 }
 
+async function expectFallbackBriefingCopy(page: Page) {
+  await expect(
+    page
+      .getByText(
+        /Showing the most recently published briefing\.|The latest briefing is not yet available\. Please check back soon\./,
+      )
+      .first(),
+  ).toBeVisible();
+}
+
 test.describe("homepage", () => {
   test("renders the public V1 briefing flow", async ({ page, diagnostics }) => {
     await page.goto("/");
@@ -17,7 +27,7 @@ test.describe("homepage", () => {
     if (await page.getByRole("link", { name: "Details" }).first().isVisible()) {
       await expect(page.getByRole("link", { name: "Details" }).first()).toBeVisible();
     } else {
-      await expect(page.getByText("Today's briefing is being prepared.").first()).toBeVisible();
+      await expectFallbackBriefingCopy(page);
     }
     await expectNoStaticHomepagePlaceholder(page);
     await expect(page.getByText("Daily Intelligence Aggregator")).toHaveCount(0);
@@ -45,7 +55,7 @@ test.describe("homepage", () => {
 
     const topEventCount = await topEventCards.count();
     if (topEventCount === 0) {
-      await expect(page.getByText("Today's briefing is being prepared.").first()).toBeVisible();
+      await expectFallbackBriefingCopy(page);
       await expect(page.getByRole("link", { name: "Details" })).toHaveCount(0);
       await expectNoStaticHomepagePlaceholder(page);
       expect(diagnostics.entries).toEqual([]);
@@ -135,7 +145,7 @@ test.describe("homepage", () => {
     const topEventCount = await topEventCards.count();
 
     if (topEventCount === 0) {
-      await expect(page.getByText("Today's briefing is being prepared.").first()).toBeVisible();
+      await expectFallbackBriefingCopy(page);
       await expect(page.getByText(gateCopy)).toHaveCount(0);
       await expectNoStaticHomepagePlaceholder(page);
       expect(diagnostics.entries).toEqual([]);

--- a/tests/smoke/homepage.spec.ts
+++ b/tests/smoke/homepage.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "../utils/audit-fixture";
 
+const fallbackBriefingCopy =
+  /Showing the most recently published briefing\.|The latest briefing is not yet available\. Please check back soon\./;
+
 test.describe("homepage smoke", () => {
   test("loads the public V1 homepage and respects the current fallback state", async ({ page }) => {
     await page.goto("/");
@@ -8,7 +11,7 @@ test.describe("homepage smoke", () => {
 
     const detailLink = page.getByRole("link", { name: "Details" }).first();
     if (!(await detailLink.isVisible())) {
-      await expect(page.getByText("Today's briefing is being prepared.").first()).toBeVisible();
+      await expect(page.getByText(fallbackBriefingCopy).first()).toBeVisible();
       await expect(page.getByText(/stored public signal snapshot|placeholder:|sample slot|fallback rail/i)).toHaveCount(0);
       return;
     }


### PR DESCRIPTION
## Effective change type

remediation / display-layer copy (trivial)

## Source of truth

- Live production audit of `daily-intelligence-aggregator-ybs9.vercel.app` on 2026-05-02
- Phase 1 PR #180

## What changed

The homepage banner read `Last updated [date] — Today's briefing is being prepared.` while serving day-old content. With cron disabled, the "being prepared" framing implied imminent fresh content that was not coming, and the framing degraded as the date drifted further from today.

This PR replaces the user-facing stale-state strings with date-anchored honest copy.

**Stale freshness notice (`src/lib/data.ts`)**
- Old: `Last updated [date] — Today's briefing is being prepared.`
- New: `Showing the latest published briefing from [date].`

**Stale briefing intro (`src/lib/data.ts`)**
- Old: `Today's briefing is being prepared. Showing the most recently published signal set with its original date.`
- New: `Showing the most recently published briefing.`

**Empty fallback (`src/lib/data.ts`)**
- Old: `Today's briefing is being prepared.`
- New: `The latest briefing is not yet available. Please check back soon.`

Test fixtures in `src/components/landing/homepage.test.tsx` and `src/lib/data.test.ts` updated to match.

## Out of scope

- No cron change. Cron remains separately authorized.
- No schema, source manifest, ranking, classification, WITM, auth, or pipeline-write changes.

## Validation

- `git diff --check` passed
- `npm run lint` passed
- `npm run test` passed: 78 test files, 591 tests
- `npm run build` passed
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name feature/public-card-cleanup-phase-2 --pr-title "Public card cleanup phase 2"` passed (trivial-code-change classification)

## Risks / follow-up

- Visual verification on Vercel preview is the relevant gate.
- This is the natural complement to Phase 1: Phase 1 cleaned up card-level diagnostic leaks; Phase 2 fixes the page-level stale-state framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)