### PR TITLE
Public card cleanup — phase 4 (hide empty By Category grid)

### DIFF
--- a/src/components/home/CategoryPreviewGrid.test.tsx
+++ b/src/components/home/CategoryPreviewGrid.test.tsx
@@ -82,12 +82,29 @@ function createEvent(
 }
 
 describe("CategoryPreviewGrid", () => {
-  it("renders three category subsections with the correct labels", () => {
-    render(
+  it("hides the entire By Category grid when every category preview is empty", () => {
+    const { container } = render(
       <CategoryPreviewGrid
         categoryPreviews={{
           tech: [],
           finance: [],
+          politics: [],
+        }}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByRole("heading", { name: "Tech" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Finance" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Politics" })).not.toBeInTheDocument();
+  });
+
+  it("renders three category subsections with the correct labels when at least one category has events", () => {
+    render(
+      <CategoryPreviewGrid
+        categoryPreviews={{
+          tech: [],
+          finance: [createEvent("finance-1", "Finance event", "finance")],
           politics: [],
         }}
       />,
@@ -131,14 +148,17 @@ describe("CategoryPreviewGrid", () => {
     render(
       <CategoryPreviewGrid
         categoryPreviews={{
-          tech: [],
-          finance: [],
-          politics: [],
+          tech: [createEvent("tech-1", "Tech event", "tech")],
+          finance: [createEvent("finance-1", "Finance event", "finance")],
+          politics: [createEvent("politics-1", "Politics event", "politics")],
         }}
       />,
     );
 
-    const headings = screen.getAllByRole("heading", { level: 3 }).map((heading) => heading.textContent);
+    const headings = screen
+      .getAllByRole("heading", { level: 3 })
+      .filter((heading) => heading.id.startsWith("category-preview-"))
+      .map((heading) => heading.textContent);
 
     expect(headings).toEqual(["Tech", "Finance", "Politics"]);
   });

--- a/src/components/home/CategoryPreviewGrid.tsx
+++ b/src/components/home/CategoryPreviewGrid.tsx
@@ -10,6 +10,15 @@ type CategoryPreviewGridProps = {
 };
 
 export function CategoryPreviewGrid({ categoryPreviews }: CategoryPreviewGridProps) {
+  const totalEvents = HOMEPAGE_CATEGORY_CONFIG.reduce(
+    (sum, category) => sum + (categoryPreviews[category.key]?.length ?? 0),
+    0,
+  );
+
+  if (totalEvents === 0) {
+    return null;
+  }
+
   return (
     <section aria-labelledby="by-category-heading" className="space-y-4">
       <div className="space-y-2">


### PR DESCRIPTION
## Effective change type

remediation / display-layer (trivial)

## Source of truth

- Live production audit of `daily-intelligence-aggregator-ybs9.vercel.app` on 2026-05-02
- Phases 1 (PR #180) and 2 (PR #181)

## What changed

The live homepage was rendering three "No X stories in today's briefing." empty-state cards in a 3-column grid because the snapshot-only public path (cron-disabled) has no depth pool to populate the By Category volume layer beyond the already-surfaced Top Signals.

Mirrors the existing `DevelopingNow` behavior: when the total event count across all categories is zero, return null and suppress the entire By Category section. Per-category empty-state cards are still rendered when at least one category has events, so partial sparseness still communicates honest selection state.

## Files changed

- `src/components/home/CategoryPreviewGrid.tsx` — added `totalEvents === 0` short-circuit
- `src/components/home/CategoryPreviewGrid.test.tsx` — replaced "renders headings when all empty" assertion with the new "hide entire grid when all empty" assertion; updated ordering test to use a non-empty preview map; tightened the heading query so it matches only the section headings, not the inner card titles

## Out of scope

- No category selection or classification logic changes.
- No source manifest, ranking, WITM, auth, or pipeline changes.

## Validation

- `git diff --check` passed
- `npm run lint` passed
- `npm run test` passed: 78 test files, 592 tests
- `npm run build` passed
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name feature/public-card-cleanup-phase-4 --pr-title "Public card cleanup phase 4"` passed (trivial-code-change classification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)