### PR TITLE
Public card cleanup — phase 3 (briefing detail public access)

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1167,7 +1167,19 @@ export async function getBriefingDetailPageState(dateKey: string, route = `/brie
 
   if (authState.supabase && authState.user) {
     const history = await loadStoredBriefings(authState.supabase, authState.user.id, 14, route);
-    briefing = history.find((candidate) => getBriefingDateKey(candidate.briefingDate) === dateKey) ?? null;
+    const historicalMatch = history.find(
+      (candidate) => getBriefingDateKey(candidate.briefingDate) === dateKey,
+    );
+    if (historicalMatch) {
+      briefing = historicalMatch;
+    }
+  }
+
+  if (!briefing) {
+    const publicData = authState.user ? await buildPublicHomepageData() : data;
+    if (getBriefingDateKey(publicData.briefing.briefingDate) === dateKey) {
+      briefing = publicData.briefing;
+    }
   }
 
   return {


### PR DESCRIPTION
## Effective change type

remediation / public-route accessibility (trivial)

## Source of truth

- Live production audit of `daily-intelligence-aggregator-ybs9.vercel.app` on 2026-05-02
- Phases 1 (PR #180), 2 (PR #181), 4 (PR #187)

## What changed

`/briefing/[date]` rendered "This briefing is not available" for the date currently surfaced on the homepage in some sessions. The "Details" links on each Top Event card pointed at this route, so the deep-link was broken whenever it triggered.

Root cause: in `getBriefingDetailPageState`, the user-history lookup unconditionally overwrote the briefing match, so a signed-in user with no history match would lose access to the public Top Events briefing even when the requested date matched the public snapshot's date.

**Fix:**
- Only overwrite the briefing match when user history actually has an entry for the requested date.
- Add a final public-homepage fallback so signed-in users without a matching history entry still see the public briefing when its date matches the requested URL parameter.

## Out of scope (deliberately)

- No new auth UI work — desktop sidebar already exposes a Sign in CTA, and mobile bottom-tab Account/History routes already redirect to `/login?redirectTo=...`. The auth entry points already exist; no homepage header CTA added in this PR.
- No source manifest, ranking, WITM, classification, or pipeline changes.

## Validation

- `git diff --check` passed
- `npm run lint` passed
- `npm run test` passed: 78 test files, 592 tests
- `npm run build` passed
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name feature/public-card-cleanup-phase-3 --pr-title "Public card cleanup phase 3"` passed (trivial-code-change classification)

## Risks / follow-up

- This adds at most one extra `buildPublicHomepageData` call on the briefing-detail SSR path for signed-in users without a history match, which reads a cached snapshot rather than triggering ingestion.
- Auth/session validation on the Vercel preview is the relevant gate before merge — the fix is meant to expand access for signed-in users only when the date matches a public briefing they would already be entitled to see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)