### PR TITLE
docs: remove deprecated duplicate doc folders

### DIFF
--- a/docs/bugs/2026-04-26-regression-static-stories-editorial-page.md
+++ b/docs/bugs/2026-04-26-regression-static-stories-editorial-page.md
@@ -1,5 +1,0 @@
-# Deprecated Legacy Bug Report
-
-Canonical record moved to `docs/engineering/bug-fixes/2026-04-26-static-stories-editorial-page-regression.md`.
-
-This folder is non-canonical. Do not add new bug reports under `docs/bugs/`.

--- a/docs/bugs/editorial-history-ordering.md
+++ b/docs/bugs/editorial-history-ordering.md
@@ -1,5 +1,0 @@
-# Deprecated Legacy Bug Report
-
-Canonical record moved to `docs/engineering/bug-fixes/editorial-history-ordering.md`.
-
-This folder is non-canonical. Do not add new bug reports under `docs/bugs/`.

--- a/docs/bugs/homepage-tabs-signal-regression-politics-tldr.md
+++ b/docs/bugs/homepage-tabs-signal-regression-politics-tldr.md
@@ -1,5 +1,0 @@
-# Deprecated Legacy Bug Report
-
-Canonical record moved to `docs/engineering/bug-fixes/homepage-tabs-signal-regression-politics-tldr.md`.
-
-This folder is non-canonical. Do not add new bug reports under `docs/bugs/`.

--- a/docs/changes/001-public-source-manifest-pr.md
+++ b/docs/changes/001-public-source-manifest-pr.md
@@ -1,8 +1,0 @@
-# Deprecated Change Note
-
-Canonical records:
-- `docs/product/prd/prd-54-public-source-manifest.md`
-- `docs/adr/001-public-source-manifest.md`
-- `docs/engineering/change-records/public-source-manifest-governance.md`
-
-This folder is non-canonical. Do not add new records under `docs/changes/`.

--- a/docs/changes/002-manifest-ingestion-unblock-pr.md
+++ b/docs/changes/002-manifest-ingestion-unblock-pr.md
@@ -1,5 +1,0 @@
-# Deprecated Change Note
-
-Canonical record moved to `docs/engineering/change-records/manifest-ingestion-unblock.md`.
-
-This folder is non-canonical. Do not add new records under `docs/changes/`.

--- a/docs/changes/003-reuters-verification-blocker.md
+++ b/docs/changes/003-reuters-verification-blocker.md
@@ -1,5 +1,0 @@
-# Deprecated Change Note
-
-Canonical record moved to `docs/engineering/testing/2026-04-23-reuters-world-preview-verification-blocker.md`.
-
-This folder is non-canonical. Do not add new records under `docs/changes/`.

--- a/docs/changes/004-bbc-world-verification-success.md
+++ b/docs/changes/004-bbc-world-verification-success.md
@@ -1,5 +1,0 @@
-# Deprecated Change Note
-
-Canonical record moved to `docs/engineering/testing/2026-04-23-bbc-world-preview-verification-success.md`.
-
-This folder is non-canonical. Do not add new records under `docs/changes/`.

--- a/docs/changes/005-category-1-supply-expansion-pr.md
+++ b/docs/changes/005-category-1-supply-expansion-pr.md
@@ -1,8 +1,0 @@
-# Deprecated Change Note
-
-Canonical records:
-- `docs/engineering/change-records/category-1-public-source-supply-expansion.md`
-- `docs/engineering/testing/2026-04-23-bbc-world-preview-verification-success.md`
-- `docs/product/prd/prd-54-public-source-manifest.md`
-
-This folder is non-canonical. Do not add new records under `docs/changes/`.

--- a/docs/changes/006-homepage-volume-layers-pr.md
+++ b/docs/changes/006-homepage-volume-layers-pr.md
@@ -1,7 +1,0 @@
-# Deprecated Change Note
-
-Canonical records:
-- `docs/product/prd/prd-57-homepage-volume-layers.md`
-- `docs/engineering/change-records/homepage-volume-layers-governance-coverage.md`
-
-This folder is non-canonical. Do not add new records under `docs/changes/`.

--- a/docs/engineering/bug-fixes/2026-04-26-static-stories-editorial-page-regression.md
+++ b/docs/engineering/bug-fixes/2026-04-26-static-stories-editorial-page-regression.md
@@ -12,7 +12,7 @@
 - Branch: `bugfix/static-stories-editorial-page-regression`
 - Head SHA: `a45fdb6d93d4ea4f220b641dfe194964218b0528`
 - Merge SHA: `ab4536b7a6b05ac9642dc5b4053f0778096cd5b8`
-- GitHub source-of-truth status: canonical record consolidated here on 2026-05-04; legacy `docs/bugs/2026-04-26-regression-static-stories-editorial-page.md` now redirects here.
+- GitHub source-of-truth status: canonical record consolidated here on 2026-05-04; deprecated legacy redirect was removed on 2026-05-04.
 - External references reviewed, if any: PR #109 metadata and the legacy bug report.
 - Google Sheet / Work Log reference, if historically relevant: historical tracker-sync reference only, `docs/operations/tracker-sync/2026-04-26-static-stories-editorial-page-regression.md`.
 - Branch cleanup status: branch deletion state not independently recoverable in this cleanup; PR metadata preserves branch and SHA.

--- a/docs/engineering/bug-fixes/editorial-history-ordering.md
+++ b/docs/engineering/bug-fixes/editorial-history-ordering.md
@@ -6,7 +6,7 @@
 - PR: #111, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/111`
 - Head SHA: `d2d399acf28e209130e035e978b03ff8feceb5be`
 - Merge SHA: `bdefaedec1bfb8f2eab8c9ff32ecbb73766fe93c`
-- GitHub source-of-truth status: canonical record consolidated here on 2026-05-04; legacy `docs/bugs/editorial-history-ordering.md` now redirects here.
+- GitHub source-of-truth status: canonical record consolidated here on 2026-05-04; deprecated legacy redirect was removed on 2026-05-04.
 - Area: `/dashboard/signals/editorial-review`
 - Data source: `signal_posts`
 - Affected object level: Surface Placement.

--- a/docs/engineering/bug-fixes/editorial-panel-default-collapse.md
+++ b/docs/engineering/bug-fixes/editorial-panel-default-collapse.md
@@ -17,7 +17,7 @@ Added a client-side `SignalPostEditor` card with per-article collapsed state. Ca
 - `src/app/dashboard/signals/editorial-review/StructuredEditorialFields.tsx`
 - `src/app/dashboard/signals/editorial-review/page.tsx`
 - `src/app/dashboard/signals/editorial-review/page.test.tsx`
-- `docs/bugs/editorial-panel-default-collapse.md`
+- `docs/engineering/bug-fixes/editorial-panel-default-collapse.md`
 
 ## Testing Performed
 

--- a/docs/engineering/bug-fixes/homepage-tabs-signal-regression-politics-tldr.md
+++ b/docs/engineering/bug-fixes/homepage-tabs-signal-regression-politics-tldr.md
@@ -20,7 +20,7 @@
 - Branch: `bugfix/homepage-tabs-signal-regression`
 - Head SHA: `f3d4448c8078be9fef374d762420e2cafd71e3fb`
 - Merge SHA: `c6e0fb6f745f6a19e2a18e2fa40f4e38d0b02d45`
-- GitHub source-of-truth status: canonical record consolidated here on 2026-05-04; legacy `docs/bugs/homepage-tabs-signal-regression-politics-tldr.md` now redirects here.
+- GitHub source-of-truth status: canonical record consolidated here on 2026-05-04; deprecated legacy redirect was removed on 2026-05-04.
 - External references reviewed, if any: PR #114 metadata and the legacy bug report.
 - Google Sheet / Work Log reference, if historically relevant: historical tracker-sync reference only, `docs/operations/tracker-sync/2026-04-26-homepage-tabs-signal-regression-politics-tldr.md`.
 - Branch cleanup status: branch is still present locally at `/Users/bm/dev/worktrees/daily-intel-homepage-tabs-signal-regression`; no deletion was performed in this branch.

--- a/docs/engineering/change-records/2026-05-04-deprecated-folder-removal-and-backfill-closeout.md
+++ b/docs/engineering/change-records/2026-05-04-deprecated-folder-removal-and-backfill-closeout.md
@@ -1,0 +1,116 @@
+# Deprecated Folder Removal And Backfill Closeout
+
+## 1. Objective
+
+Complete the hard consolidation of deprecated duplicate documentation folders after GitHub repo documentation became canonical. This branch verifies that `docs/bugs/` and `docs/changes/` contain only redirect-only legacy records, removes those duplicate files, rewrites active references to canonical paths, and performs a final remediation-document backfill scan for recent merged PRs.
+
+## 2. Baseline
+
+- PR #191 is merged and made GitHub repo documentation canonical for bug-fix, remediation, validation, release, governance, PRD/feature, and branch-cleanup history.
+- PR #192 is merged and added canonical bug-fix records for PR #141 and PR #143.
+- Google Sheet and Google Work Log records are historical references only and were not used as canonical inputs.
+
+## 3. Deprecated Folder Audit Result
+
+All tracked files under `docs/bugs/` and `docs/changes/` were redirect-only legacy records. No unique durable content remained in those files after the PR #191 and PR #192 consolidations.
+
+| Legacy file path | Canonical replacement path | Redirect-only? | Active repo references found? | Action |
+| --- | --- | --- | --- | --- |
+| `docs/bugs/editorial-history-ordering.md` | `docs/engineering/bug-fixes/editorial-history-ordering.md` | yes | Active canonical references were rewritten; historical tracker-sync reference retained by scope. | delete legacy file |
+| `docs/bugs/homepage-tabs-signal-regression-politics-tldr.md` | `docs/engineering/bug-fixes/homepage-tabs-signal-regression-politics-tldr.md` | yes | Active canonical references were rewritten. | delete legacy file |
+| `docs/bugs/2026-04-26-regression-static-stories-editorial-page.md` | `docs/engineering/bug-fixes/2026-04-26-static-stories-editorial-page-regression.md` | yes | Active canonical references were rewritten; historical tracker-sync reference retained by scope. | delete legacy file |
+| `docs/changes/001-public-source-manifest-pr.md` | `docs/product/prd/prd-54-public-source-manifest.md`, `docs/adr/001-public-source-manifest.md`, `docs/engineering/change-records/public-source-manifest-governance.md` | yes | No blocking active references. | delete legacy file |
+| `docs/changes/002-manifest-ingestion-unblock-pr.md` | `docs/engineering/change-records/manifest-ingestion-unblock.md` | yes | Active canonical references were rewritten. | delete legacy file |
+| `docs/changes/003-reuters-verification-blocker.md` | `docs/engineering/testing/2026-04-23-reuters-world-preview-verification-blocker.md` | yes | Active canonical references were rewritten. | delete legacy file |
+| `docs/changes/004-bbc-world-verification-success.md` | `docs/engineering/testing/2026-04-23-bbc-world-preview-verification-success.md` | yes | Active canonical references were rewritten. | delete legacy file |
+| `docs/changes/005-category-1-supply-expansion-pr.md` | `docs/engineering/change-records/category-1-public-source-supply-expansion.md`, `docs/engineering/testing/2026-04-23-bbc-world-preview-verification-success.md`, `docs/product/prd/prd-54-public-source-manifest.md` | yes | No blocking active references. | delete legacy file |
+| `docs/changes/006-homepage-volume-layers-pr.md` | `docs/product/prd/prd-57-homepage-volume-layers.md`, `docs/engineering/change-records/homepage-volume-layers-governance-coverage.md` | yes | No blocking active references. | delete legacy file |
+
+General governance references that forbid new `docs/bugs/` and `docs/changes/` records remain valid and were left in place. Historical `docs/operations/tracker-sync/` references were not edited because tracker-sync files are non-canonical historical compatibility records and are outside this branch's scope.
+
+## 4. Files Deleted Or Retained
+
+Deleted:
+
+- `docs/bugs/2026-04-26-regression-static-stories-editorial-page.md`
+- `docs/bugs/editorial-history-ordering.md`
+- `docs/bugs/homepage-tabs-signal-regression-politics-tldr.md`
+- `docs/changes/001-public-source-manifest-pr.md`
+- `docs/changes/002-manifest-ingestion-unblock-pr.md`
+- `docs/changes/003-reuters-verification-blocker.md`
+- `docs/changes/004-bbc-world-verification-success.md`
+- `docs/changes/005-category-1-supply-expansion-pr.md`
+- `docs/changes/006-homepage-volume-layers-pr.md`
+
+Retained:
+
+- No tracked files remain under `docs/bugs/` or `docs/changes/`.
+- `docs/operations/tracker-sync/` was retained untouched as historical compatibility.
+
+## 5. Reference Rewrites Performed
+
+- Updated canonical bug-fix records that still described legacy `docs/bugs/` redirects as live files.
+- Updated canonical testing records for Reuters and BBC preview validation to identify themselves as the durable records after `docs/changes/` removal.
+- Updated the manifest ingestion unblock change record to identify itself as the durable record after `docs/changes/` removal.
+- Updated the PR #191 audit to mark `docs/bugs/` and `docs/changes/` as removed deprecated folders instead of retained redirect lanes.
+- Updated an active file-changed reference in the editorial panel default-collapse bug-fix record from the deprecated `docs/bugs/` path to the canonical `docs/engineering/bug-fixes/` path.
+
+## 6. Final Missing-Remediation-Doc Scan Result
+
+Reviewed merged PRs #89 through #192 whose title or body matched remediation terms including fix, bug, hotfix, remediation, regression, repair, blocked, schema alignment, migration repair, and validation blocker.
+
+Scan result:
+
+- 80 merged PRs matched the remediation-term query.
+- 68 had direct metadata hits in canonical documentation lanes.
+- 12 required manual lane review because the existing record did not include the PR number, branch, head SHA, or merge SHA.
+
+No genuinely missing canonical remediation records were found. Likely remediation or validation PRs were already covered by one of the canonical lanes:
+
+- `docs/engineering/bug-fixes/`
+- `docs/engineering/change-records/`
+- `docs/engineering/testing/`
+- `docs/operations/controlled-cycles/`
+- `docs/operations/launch-readiness/`
+- `docs/product/prd/`
+
+Manual lane-review outcomes:
+
+| PR | Existing lane outcome | Missing canonical record? |
+| --- | --- | --- |
+| #91 | Documentation upload only; no meaningful remediation record required. | no |
+| #95 | Covered by `docs/engineering/change-records/worktree-ownership-hardening-2026-04-22.md`. | no |
+| #103 | Redeploy-only PR with no changed files; no durable repo-doc remediation record required. | no |
+| #116 | Terminology/audit documentation update; canonical docs were the changed files. | no |
+| #124 | Covered by scheduled-fetch and why-it-matters quality-gate change records. | no |
+| #132 | Covered by `docs/engineering/change-records/witm-template-quality-remediation.md`. | no |
+| #133 | Covered by `docs/engineering/change-records/phase-b-core-context-draft-selector.md`. | no |
+| #134 | Covered by `docs/engineering/change-records/phase-b-artifact-replay-remediation.md`. | no |
+| #135 | Covered by `docs/engineering/testing/2026-04-29-phase-c-track-a-admin-workflow-safety.md`. | no |
+| #136 | Covered by `docs/engineering/change-records/batch-2a-source-governance.md`. | no |
+| #140 | Covered by `docs/engineering/testing/post-pr139-context-witm-post-deploy-validation.md`. | no |
+| #147 | Covered by `docs/engineering/testing/editor-decision-packet-core-context-drafts-20260429.md`. | no |
+
+The scan confirmed that PR #191 and PR #192 closed the known public-card, PR #141, and PR #143 gaps. Some older pre-template records could be enriched with PR number, branch, or SHA metadata in a future pass, but they do not represent missing canonical records.
+
+## 7. New Records Created
+
+- `docs/engineering/change-records/2026-05-04-deprecated-folder-removal-and-backfill-closeout.md`
+
+No new bug-fix records were needed in this branch.
+
+## 8. Remaining Follow-Ups
+
+- None required for `docs/bugs/` or `docs/changes/`; tracked legacy files were removed.
+- Optional future cleanup: enrich older pre-template canonical records with PR/branch/SHA metadata where useful.
+- Separate non-docs follow-up remains available only if explicitly requested: audit dormant Google tracker sync scripts/workflows for decommissioning.
+
+## 9. Explicit Non-Actions
+
+- No Google tracker updates.
+- No Google Work Log updates.
+- No tracker-sync fallback files.
+- No runtime code changes.
+- No workflow or script changes.
+- No production validation.
+- No branch deletion.

--- a/docs/engineering/change-records/2026-05-04-github-source-of-truth-remediation-docs-audit.md
+++ b/docs/engineering/change-records/2026-05-04-github-source-of-truth-remediation-docs-audit.md
@@ -33,8 +33,8 @@ Several standing docs also told agents to update or fall back to Google Sheets d
 | `docs/engineering/bug-fixes/` | canonical bug-fix record lane | Canonical for meaningful defects, regressions, hotfixes, and remediations with root cause. Thin records were found and upgraded where high-priority. |
 | `docs/engineering/bug-fixes/phase1/` | canonical bug-fix record lane | Existing Phase 1 remediation records; left as-is. |
 | `docs/engineering/bug-fixes/templates/` | operating template lane | Template updated with PR/branch/SHA/source-of-truth metadata. |
-| `docs/bugs/` | deprecated/non-canonical record lane | Three legacy duplicate bug reports now redirect to canonical bug-fix records. |
-| `docs/changes/` | deprecated/non-canonical PR note lane | Six legacy PR/change notes now redirect to canonical PRD, ADR, change-record, or testing records. |
+| `docs/bugs/` | removed deprecated/non-canonical record lane | Three redirect-only legacy duplicate bug reports were removed after canonical records were confirmed. |
+| `docs/changes/` | removed deprecated/non-canonical PR note lane | Six redirect-only legacy PR/change notes were removed after canonical records were confirmed. |
 | `docs/engineering/change-records/` | structural change record lane | Canonical for audits, migrations, source-of-truth cleanup, repo-structure cleanup, and governance records. |
 | `docs/engineering/testing/` | validation/testing record lane | Canonical for meaningful validation reports and test evidence. Reuters/BBC preview notes were moved here from `docs/changes/`. |
 | `docs/engineering/incidents/` | incident lane | Folder was absent in this checkout; routing rules still reserve it for governance/process/release/workflow failures. |
@@ -67,15 +67,15 @@ Several standing docs also told agents to update or fall back to Google Sheets d
 
 | Legacy doc | Canonical doc | Classification | Branch action |
 | --- | --- | --- | --- |
-| `docs/bugs/editorial-history-ordering.md` | `docs/engineering/bug-fixes/editorial-history-ordering.md` | duplicate legacy bug report | Legacy file replaced with redirect; canonical metadata upgraded. |
-| `docs/bugs/homepage-tabs-signal-regression-politics-tldr.md` | `docs/engineering/bug-fixes/homepage-tabs-signal-regression-politics-tldr.md` | duplicate legacy bug report | Legacy file replaced with redirect; canonical metadata upgraded. |
-| `docs/bugs/2026-04-26-regression-static-stories-editorial-page.md` | `docs/engineering/bug-fixes/2026-04-26-static-stories-editorial-page-regression.md` | duplicate legacy bug report / thin canonical record | Legacy detail merged into canonical file; legacy file replaced with redirect. |
-| `docs/changes/001-public-source-manifest-pr.md` | `docs/product/prd/prd-54-public-source-manifest.md`, `docs/adr/001-public-source-manifest.md`, `docs/engineering/change-records/public-source-manifest-governance.md` | PR note / change note | Legacy file replaced with redirect. |
-| `docs/changes/002-manifest-ingestion-unblock-pr.md` | `docs/engineering/change-records/manifest-ingestion-unblock.md` | PR note / structural change record | Canonical change-record added; legacy file replaced with redirect. |
-| `docs/changes/003-reuters-verification-blocker.md` | `docs/engineering/testing/2026-04-23-reuters-world-preview-verification-blocker.md` | validation/testing record | Canonical testing record added; legacy file replaced with redirect. |
-| `docs/changes/004-bbc-world-verification-success.md` | `docs/engineering/testing/2026-04-23-bbc-world-preview-verification-success.md` | validation/testing record | Canonical testing record added; legacy file replaced with redirect. |
-| `docs/changes/005-category-1-supply-expansion-pr.md` | `docs/engineering/change-records/category-1-public-source-supply-expansion.md`, `docs/engineering/testing/2026-04-23-bbc-world-preview-verification-success.md`, `docs/product/prd/prd-54-public-source-manifest.md` | PR note / structural change record | Legacy file replaced with redirect. |
-| `docs/changes/006-homepage-volume-layers-pr.md` | `docs/product/prd/prd-57-homepage-volume-layers.md`, `docs/engineering/change-records/homepage-volume-layers-governance-coverage.md` | PR note / change note | Legacy file replaced with redirect. |
+| `docs/bugs/editorial-history-ordering.md` | `docs/engineering/bug-fixes/editorial-history-ordering.md` | duplicate legacy bug report | Legacy redirect removed after canonical metadata was upgraded. |
+| `docs/bugs/homepage-tabs-signal-regression-politics-tldr.md` | `docs/engineering/bug-fixes/homepage-tabs-signal-regression-politics-tldr.md` | duplicate legacy bug report | Legacy redirect removed after canonical metadata was upgraded. |
+| `docs/bugs/2026-04-26-regression-static-stories-editorial-page.md` | `docs/engineering/bug-fixes/2026-04-26-static-stories-editorial-page-regression.md` | duplicate legacy bug report / thin canonical record | Legacy detail was merged into the canonical file; redirect removed. |
+| `docs/changes/001-public-source-manifest-pr.md` | `docs/product/prd/prd-54-public-source-manifest.md`, `docs/adr/001-public-source-manifest.md`, `docs/engineering/change-records/public-source-manifest-governance.md` | PR note / change note | Legacy redirect removed. |
+| `docs/changes/002-manifest-ingestion-unblock-pr.md` | `docs/engineering/change-records/manifest-ingestion-unblock.md` | PR note / structural change record | Canonical change-record added; legacy redirect removed. |
+| `docs/changes/003-reuters-verification-blocker.md` | `docs/engineering/testing/2026-04-23-reuters-world-preview-verification-blocker.md` | validation/testing record | Canonical testing record added; legacy redirect removed. |
+| `docs/changes/004-bbc-world-verification-success.md` | `docs/engineering/testing/2026-04-23-bbc-world-preview-verification-success.md` | validation/testing record | Canonical testing record added; legacy redirect removed. |
+| `docs/changes/005-category-1-supply-expansion-pr.md` | `docs/engineering/change-records/category-1-public-source-supply-expansion.md`, `docs/engineering/testing/2026-04-23-bbc-world-preview-verification-success.md`, `docs/product/prd/prd-54-public-source-manifest.md` | PR note / structural change record | Legacy redirect removed. |
+| `docs/changes/006-homepage-volume-layers-pr.md` | `docs/product/prd/prd-57-homepage-volume-layers.md`, `docs/engineering/change-records/homepage-volume-layers-governance-coverage.md` | PR note / change note | Legacy redirect removed. |
 
 ## 8. Thin Docs Found
 
@@ -102,8 +102,8 @@ Several standing docs also told agents to update or fall back to Google Sheets d
 
 Completed in this branch:
 
-- `docs/bugs/` high-priority duplicates now redirect to canonical bug-fix records.
-- `docs/changes/` files now redirect to canonical PRD, ADR, change-record, or testing records.
+- `docs/bugs/` high-priority duplicates were consolidated into canonical bug-fix records; redirect-only leftovers were removed in the 2026-05-04 hard-consolidation follow-up.
+- `docs/changes/` files were consolidated into canonical PRD, ADR, change-record, or testing records; redirect-only leftovers were removed in the 2026-05-04 hard-consolidation follow-up.
 - Durable Reuters/BBC preview verification details were moved to `docs/engineering/testing/`.
 - Durable manifest ingestion unblock details were moved to `docs/engineering/change-records/`.
 - Public-card cleanup phases were consolidated into one canonical bug-fix/remediation record.

--- a/docs/engineering/change-records/manifest-ingestion-unblock.md
+++ b/docs/engineering/change-records/manifest-ingestion-unblock.md
@@ -3,7 +3,7 @@
 - Date: 2026-04-23
 - Branch: `feature/public-source-manifest-v2`
 - Canonical PRD: `docs/product/prd/prd-54-public-source-manifest.md`
-- Legacy note consolidated from: `docs/changes/002-manifest-ingestion-unblock-pr.md`
+- Canonical record after `docs/changes/` removal: this change record is the durable manifest-ingestion unblock record.
 
 ## Summary
 

--- a/docs/engineering/testing/2026-04-23-bbc-world-preview-verification-success.md
+++ b/docs/engineering/testing/2026-04-23-bbc-world-preview-verification-success.md
@@ -4,7 +4,7 @@
 - Branch: `feature/public-source-manifest-v3`
 - Preview URL: `https://daily-intelligence-aggregator-ybs9-80swm3ghi.vercel.app`
 - Vercel deployment: `dpl_F8toFvs4UHPeoYNLK4UH4YWWDw2m`
-- Legacy note consolidated from: `docs/changes/004-bbc-world-verification-success.md`
+- Canonical record after `docs/changes/` removal: this testing note is the durable verification record.
 
 ## Classification
 

--- a/docs/engineering/testing/2026-04-23-reuters-world-preview-verification-blocker.md
+++ b/docs/engineering/testing/2026-04-23-reuters-world-preview-verification-blocker.md
@@ -5,7 +5,7 @@
 - Preview URL: `https://daily-intelligence-aggregator-git-ba69cc-brandonma25s-projects.vercel.app`
 - Vercel deployment: `dpl_G4EBrPivZAstu92dudtFNKNJmkUf`
 - Deployment URL: `https://daily-intelligence-aggregator-ybs9-crycvfce0.vercel.app`
-- Legacy note consolidated from: `docs/changes/003-reuters-verification-blocker.md`
+- Canonical record after `docs/changes/` removal: this testing note is the durable verification record.
 
 ## Classification
 


### PR DESCRIPTION
## 1. Objective

Complete the hard consolidation after PR #191 and PR #192 by verifying deprecated duplicate folders, removing redirect-only legacy files, rewriting active references to canonical GitHub documentation paths, and running a final remediation-document backfill scan.

## 2. Deprecated folders reviewed

Reviewed tracked files under:

- `docs/bugs/`
- `docs/changes/`

All tracked files in those folders were redirect-only legacy records after the earlier consolidations. No unique durable content remained there.

## 3. Files deleted or retained

Deleted redirect-only legacy files:

- `docs/bugs/2026-04-26-regression-static-stories-editorial-page.md`
- `docs/bugs/editorial-history-ordering.md`
- `docs/bugs/homepage-tabs-signal-regression-politics-tldr.md`
- `docs/changes/001-public-source-manifest-pr.md`
- `docs/changes/002-manifest-ingestion-unblock-pr.md`
- `docs/changes/003-reuters-verification-blocker.md`
- `docs/changes/004-bbc-world-verification-success.md`
- `docs/changes/005-category-1-supply-expansion-pr.md`
- `docs/changes/006-homepage-volume-layers-pr.md`

Retained:

- No tracked files remain under `docs/bugs/` or `docs/changes/`.
- `docs/operations/tracker-sync/` was retained untouched as historical compatibility.

## 4. Reference rewrites

- Rewrote canonical bug-fix records that still described legacy `docs/bugs/` redirects as live files.
- Rewrote Reuters/BBC testing records and the manifest ingestion unblock record so they identify themselves as the durable records after `docs/changes/` removal.
- Rewrote the editorial panel default-collapse file-changed reference from the deprecated bug path to the canonical bug-fix path.
- Updated the PR #191 audit to mark `docs/bugs/` and `docs/changes/` as removed deprecated folders.

Historical tracker-sync references were not edited because tracker-sync is non-canonical historical compatibility and out of scope for this docs-only cleanup.

## 5. Final backfill scan result

Used GitHub PR metadata for merged PRs #89 through #192 and filtered title/body matches for fix, bug, hotfix, remediation, regression, repair, blocked, schema alignment, migration repair, and validation blocker.

Result:

- 80 merged PRs matched the remediation-term query.
- 68 had direct metadata hits in canonical documentation lanes.
- 12 required manual lane review.
- No genuinely missing canonical remediation records were found.

The manual-review set was already covered by truthful canonical lanes or did not require a durable remediation record. No new bug-fix records were needed.

## 6. New docs created

- `docs/engineering/change-records/2026-05-04-deprecated-folder-removal-and-backfill-closeout.md`

## 7. Files changed

- Deleted 9 redirect-only files under `docs/bugs/` and `docs/changes/`.
- Updated canonical bug-fix records under `docs/engineering/bug-fixes/`.
- Updated canonical change records under `docs/engineering/change-records/`.
- Updated canonical testing records under `docs/engineering/testing/`.

## 8. Validation commands and results

- `git diff --check` — PASS
- `git diff --cached --check` — PASS before commit
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name docs/remove-deprecated-duplicate-doc-folders --pr-title "docs: remove deprecated duplicate doc folders"` — PASS
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name docs/remove-deprecated-duplicate-doc-folders --pr-title "docs: remove deprecated duplicate doc folders"` — PASS

`python3 scripts/validate-feature-system-csv.py` was not run separately because `docs/product/feature-system.csv` was not touched.

## 9. Explicit non-actions

- No Google tracker updates.
- No Google Work Log updates.
- No tracker-sync fallback files.
- No runtime code changes.
- No workflows/scripts changes.
- No production validation.
- No branch deletion.
