### PR TITLE
docs: enrich pre-template bug-fix metadata

### DIFF
--- a/docs/engineering/bug-fixes/2026-04-20-artifact10-parity-repair-governance-bugfix.md
+++ b/docs/engineering/bug-fixes/2026-04-20-artifact10-parity-repair-governance-bugfix.md
@@ -4,6 +4,18 @@
 
 PR #75 repairs UI drift after the Artifact 10 global style merge, including typography, token, shell, and stale session-state presentation cleanup.
 
+## GitHub Source-of-Truth Metadata
+
+- Affected object level: Card and Surface Placement.
+- PR: #75, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/75`.
+- Branch: `fix/prd-50-artifact-10-parity-repair`.
+- Head SHA: `8cd81966927df251d803456ca5e2feb74588ee1b`.
+- Merge SHA: `d4150dba5b1e03fcc6eb94baba8b8a163ac19c54`.
+- GitHub source-of-truth status: canonical pre-template bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #75 metadata and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
+
 ## Root Cause
 
 The repair is correctly carried on a `fix/` branch with a `fix:` PR title, so the release governance gate classifies it as a bug-fix. The branch already included a change record, but it did not include the required bug-fix documentation lane under `docs/engineering/bug-fixes/`.

--- a/docs/engineering/bug-fixes/2026-04-22-homepage-release-route-probe-markers.md
+++ b/docs/engineering/bug-fixes/2026-04-22-homepage-release-route-probe-markers.md
@@ -6,6 +6,18 @@
 - Canonical PRD required: no.
 - Scope: release validation route-probe markers for the signed-out Home remediation branch.
 
+## GitHub Source-of-Truth Metadata
+
+- Affected object level: Surface Placement.
+- PR: #97, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/97`.
+- Branch: `fix/signed-out-homepage-qa-remediation`.
+- Head SHA: `00ffcd3ce51d86460ef51ee54fb81b00742e81d8`.
+- Merge SHA: `cd3f8a740196e1df031bb5c4989bb524f8efb6d0`.
+- GitHub source-of-truth status: canonical pre-template bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #97 metadata and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
+
 ## Root Cause
 
 The local release gate still checked older signed-out Home and `/dashboard` copy:

--- a/docs/engineering/bug-fixes/2026-04-24-homepage-category-route-demotion.md
+++ b/docs/engineering/bug-fixes/2026-04-24-homepage-category-route-demotion.md
@@ -3,7 +3,19 @@
 ## Release Metadata
 - Date: 2026-04-24
 - Branch: `feature/prd-55-homepage-volume-layers`
-- PR: pending
+- PR: #105, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/105`
+
+## GitHub Source-of-Truth Metadata
+
+- Affected object level: Surface Placement.
+- PR: #105, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/105`.
+- Branch: `feature/prd-55-homepage-volume-layers`.
+- Head SHA: `13fd964ff5e0f2109cb066fa444e41b978b99e56`.
+- Merge SHA: `9db39d7a4a02cdb41322826e47a39db0e350ce12`.
+- GitHub source-of-truth status: canonical pre-template bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #105 metadata and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
 
 ## Issue Summary
 - Problem addressed: preview behavior could surface homepage content when users visited `/technology`, `/economics`, or `/politics`, creating the false impression that those were standalone category pages.

--- a/docs/engineering/bug-fixes/2026-04-26-prod-homepage-500-ingestion-ssr.md
+++ b/docs/engineering/bug-fixes/2026-04-26-prod-homepage-500-ingestion-ssr.md
@@ -3,7 +3,19 @@
 ## Release Metadata
 - Date: 2026-04-26
 - Branch: `hotfix/prod-homepage-500-ingestion-ssr`
-- PR: pending
+- PR: #108, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/108`
+
+## GitHub Source-of-Truth Metadata
+
+- Affected object level: Surface Placement.
+- PR: #108, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/108`.
+- Branch: `hotfix/prod-homepage-500-ingestion-ssr`.
+- Head SHA: `d3609c1be58aefd765b1f902958492457b0a8704`.
+- Merge SHA: `ff1c7dce7efc4f350ebc043fa5902aaed01185a5`.
+- GitHub source-of-truth status: canonical pre-template bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #108 metadata and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
 
 ## Incident Summary
 - Problem addressed: production `GET /` returned `500` before any outbound feed fetch ran.

--- a/docs/engineering/bug-fixes/auth-callback-provider-error-redirect.md
+++ b/docs/engineering/bug-fixes/auth-callback-provider-error-redirect.md
@@ -4,6 +4,17 @@
 - Problem addressed: provider callback error URLs could remain stuck on `/auth/callback?error=...` in local Playwright environments instead of redirecting to `/?auth=callback-error`.
 - Root cause: the route parsed `NEXT_PUBLIC_SUPABASE_URL` before handling provider error query params, so a missing or empty local Supabase URL could throw before redirect logic ran.
 
+## GitHub Source-of-Truth Metadata
+- Affected object level: Surface Placement.
+- PR: #72, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/72`.
+- Branch: `fix/auth-callback-provider-error-redirect`.
+- Head SHA: `0ae89ffb21641165bef8ac2cf2f8fe9b1558d99e`.
+- Merge SHA: `96dfd8b949f8fa48bc101f28f4e89709937ac2f8`.
+- GitHub source-of-truth status: canonical pre-template bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #72 metadata and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
+
 ## Fix
 - Exact change: handle `error`, `error_code`, and `error_description` query params at the top of the callback route, then make Supabase URL host parsing nullable when the env value is absent.
 - Related PRD: not applicable; targeted auth routing bug fix.

--- a/docs/engineering/bug-fixes/auth-test-stability.md
+++ b/docs/engineering/bug-fixes/auth-test-stability.md
@@ -1,5 +1,16 @@
 # Auth Test Stability
 
+## GitHub Source-of-Truth Metadata
+- Affected object level: Surface Placement test coverage; production content objects were not changed.
+- PR: #27, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/27`.
+- Branch: `fix/auth-test-stability`.
+- Head SHA: `456eb933ee91c84ae0281d272a3149d81c84b004`.
+- Merge SHA: `9cf9c11b8788f8151b0adab2092ddcbc3add46d4`.
+- GitHub source-of-truth status: canonical pre-template bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #27 metadata, file history, and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
+
 ## Failing Tests
 - `src/components/auth/auth-modal.test.tsx`
 - `src/lib/data.auth.test.ts`

--- a/docs/engineering/bug-fixes/editorial-history-ordering.md
+++ b/docs/engineering/bug-fixes/editorial-history-ordering.md
@@ -7,6 +7,7 @@
 - Head SHA: `d2d399acf28e209130e035e978b03ff8feceb5be`
 - Merge SHA: `bdefaedec1bfb8f2eab8c9ff32ecbb73766fe93c`
 - GitHub source-of-truth status: canonical record consolidated here on 2026-05-04; deprecated legacy redirect was removed on 2026-05-04.
+- External references reviewed, if any: GitHub PR #111 metadata and the legacy bug report.
 - Area: `/dashboard/signals/editorial-review`
 - Data source: `signal_posts`
 - Affected object level: Surface Placement.

--- a/docs/engineering/bug-fixes/editorial-panel-default-collapse.md
+++ b/docs/engineering/bug-fixes/editorial-panel-default-collapse.md
@@ -1,5 +1,16 @@
 # Editorial Panel Default Collapse
 
+## GitHub Source-of-Truth Metadata
+- Affected object level: Card and Surface Placement.
+- PR: #110, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/110`.
+- Branch: `fix/editorial-panel-collapse`.
+- Head SHA: `ef6cb23beb80c8555326890e5fbcfc9340888126`.
+- Merge SHA: `55bf58cb7ed65a09f84f4a112da24b93d4653784`.
+- GitHub source-of-truth status: canonical pre-template bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #110 metadata and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
+
 ## Problem
 
 The editorial review page rendered every article's editorial editing panel fully expanded on load. Older and historical articles were difficult to scan because each card included all editable fields, preview simulation, and action controls immediately.

--- a/docs/engineering/bug-fixes/final-slate-composer-live-row-actions.md
+++ b/docs/engineering/bug-fixes/final-slate-composer-live-row-actions.md
@@ -3,6 +3,7 @@
 ## Summary
 - Problem addressed: the editorial review route could show enabled-looking Final Slate Composer placement buttons for rows that were already live or published.
 - Root cause: the composer slot controls only checked whether editorial storage was configured, while the server-side remove action cleared placement without first checking live/published state. Assignment already rejected those rows, producing an error banner while the UI still looked actionable.
+- Affected object level: Card and Surface Placement.
 
 ## Fix
 - Exact change: lock final-slate placement controls for non-persisted, live, already-published, or blocking-decision rows; hide replacement controls for locked rows; keep valid unpublished draft-slate controls enabled; add a server guard preventing remove-from-slate mutations on live or already-published rows.

--- a/docs/engineering/bug-fixes/google-oauth-pkce-callback-fix.md
+++ b/docs/engineering/bug-fixes/google-oauth-pkce-callback-fix.md
@@ -3,6 +3,17 @@
 ## Summary
 Google OAuth could start, but the callback did not reliably complete in hosted environments. This caused failed sign-in attempts, lost sessions after redirect, and preview deployments that could jump to the production domain during auth.
 
+## GitHub Source-of-Truth Metadata
+- Affected object level: Surface Placement.
+- PR: #8, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/8`; #9, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/9`; #12, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/12`.
+- Branch: `feature/google-oauth-production-callback-fix`; `feature/auth-preview-host-fix`; `docs/google-oauth-bug-report`.
+- Head SHA: #8 `9160be28e0ce60855400034b989a32d24bebee77`; #9 `e8f63e9911a0f2b7f0858ebcad0de4a1d18334d1`; #12 `076539365aa73a3ab8f06feb1d74fad40d13b7de`.
+- Merge SHA: #8 `a0a4e0698cc34d302234c1ce0e8800b81f286b60`; #9 `040e326602f6f6ed55cab17623df076d92bd3ec2`; #12 `92cefcd3f3253a1af5b774c28fcbdbdac875efb1`.
+- GitHub source-of-truth status: canonical historical bug-fix record enriched with source-of-truth metadata on 2026-05-04; PR #45 later moved the record into the strict documentation taxonomy.
+- External references reviewed, if any: GitHub PR #8, #9, #12, and #45 metadata; file history; existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
+
 ## Symptoms
 - "The sign-in callback could not be completed"
 - `/?auth=callback-error`

--- a/docs/engineering/bug-fixes/homepage-depth-ranked-pool-remediation.md
+++ b/docs/engineering/bug-fixes/homepage-depth-ranked-pool-remediation.md
@@ -2,6 +2,18 @@
 
 Homepage depth surfaces were unintentionally fed from the already-truncated `briefing.items` list, which is capped to the five-item public editorial layer. As a result, `Developing Now`, `By Category`, and homepage category tabs often had no eligible post-exclusion events to show once Top 5 items were removed.
 
+## GitHub Source-of-Truth Metadata
+
+- Affected object level: Signal, Card, and Surface Placement.
+- PR: #105, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/105`.
+- Branch: `feature/prd-55-homepage-volume-layers`.
+- Head SHA: `13fd964ff5e0f2109cb066fa444e41b978b99e56`.
+- Merge SHA: `9db39d7a4a02cdb41322826e47a39db0e350ce12`.
+- GitHub source-of-truth status: canonical pre-template bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #105 metadata and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
+
 ## Root Cause
 
 `generateDailyBriefing(...)` built a broader ranked candidate list from pipeline `ranked_clusters`, but only the capped `briefing.items` list was preserved on `DashboardData`. `buildHomepageViewModel(...)` then used `data.briefing.items` for both the Top 5 layer and all downstream depth modules, so signed-out category exploration was constrained to the same five events already shown in Top 5.

--- a/docs/engineering/bug-fixes/homepage-editorial-preview-truncation.md
+++ b/docs/engineering/bug-fixes/homepage-editorial-preview-truncation.md
@@ -4,6 +4,17 @@
 - Problem addressed: collapsed homepage `Why it matters` previews could end with accidental mid-word clipping, such as `wa...`, because the UI relied on visual line clamping of the full text.
 - Root cause: the collapsed state rendered the full editorial text and delegated shortening to CSS, so the browser could clip at arbitrary character positions.
 
+## GitHub Source-of-Truth Metadata
+- Affected object level: Card.
+- PR: #100, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/100`.
+- Branch: `codex/signals-admin-editorial-layer`.
+- Head SHA: `4e895c44aad579281e7d612b985efb0470bb2d99`.
+- Merge SHA: `cacb0753de59fc1efe7c72c9655c62625a99991e`.
+- GitHub source-of-truth status: canonical pre-template bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #100 metadata and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
+
 ## Fix
 - Exact change: collapsed homepage `Why it matters` now renders an intentional preview string generated in code. The preview prefers complete sentence boundaries and cleans stored pre-truncated snippets so the summary box does not end with broken `...` text.
 - Related PRD: existing signals admin/editorial layer branch; no new PRD for this scoped remediation.

--- a/docs/engineering/bug-fixes/mobile-navigation-fix.md
+++ b/docs/engineering/bug-fixes/mobile-navigation-fix.md
@@ -3,7 +3,18 @@
 ## Release Metadata
 - Date: 2026-04-19
 - Branch: `fix/mobile-navigation`
-- PR: Not opened yet
+- PR: #55, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/55`
+
+## GitHub Source-of-Truth Metadata
+- Affected object level: Surface Placement.
+- PR: #55, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/55`.
+- Branch: `fix/mobile-navigation`.
+- Head SHA: `e026ecf8ee49ae55f7a7cb68c06e61a4c3a22f17`.
+- Merge SHA: `967247c1c89124a390673971725dfdc140610f53`.
+- GitHub source-of-truth status: canonical pre-template bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #55 metadata and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
 
 ## Issue Summary
 - Problem addressed: mobile users needed a dependable navigation drawer in the shared shell so they could open the menu, dismiss it cleanly, and move between the primary routes on phone-sized viewports.

--- a/docs/engineering/bug-fixes/oauth-session-persistence.md
+++ b/docs/engineering/bug-fixes/oauth-session-persistence.md
@@ -1,5 +1,16 @@
 # Bug Fix: OAuth Session Persistence
 
+## GitHub Source-of-Truth Metadata
+- Affected object level: Surface Placement.
+- PR: no PR found for the historical implementation branches listed below; canonical documentation was backfilled in PR #45, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/45`.
+- Branch: historical branches listed by this record: `feature/auth-real-session`, `feature/google-auth-config-fix`, `feature/oauth-session-finalization-fix`.
+- Head SHA: not recoverable from GitHub PR metadata for the listed historical branches; PR #45 documentation head SHA `96bdd47ab6db18002ec38035d890f69c41dedd64`.
+- Merge SHA: not recoverable from GitHub PR metadata for the listed historical branches; PR #45 documentation merge SHA `c182403f25f98aa40d82073a3eedb24328ee926c`.
+- GitHub source-of-truth status: canonical historical bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #45 metadata, branch-name PR search, file history, and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: the historical branch refs were not found in GitHub PR metadata or remote refs during this pass; no branch deletion was performed in this metadata enrichment branch.
+
 ## Problem
 Google sign-in could start and sometimes appear to complete, but the app did not reliably remember signed-in state afterward. Users could still land on the homepage showing public-mode prompts, and later login attempts could fail with callback-related errors.
 

--- a/docs/engineering/bug-fixes/pr88-webkit-navigation-race.md
+++ b/docs/engineering/bug-fixes/pr88-webkit-navigation-race.md
@@ -4,6 +4,17 @@
 - Problem addressed: PR88's `PR Gate / pr-e2e-webkit` check failed during merge validation.
 - Root cause: The new Playwright audit tests moved between Next.js routes immediately after `domcontentloaded` or URL-change detection. WebKit can still have a prior client-side navigation in flight, which caused `page.goto()` to fail with an interrupted-navigation error.
 
+## GitHub Source-of-Truth Metadata
+- Affected object level: Surface Placement validation coverage.
+- PR: #88, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/88`.
+- Branch: `feature/playwright-ui-audit-automation`.
+- Head SHA: `c357ba5814bc0c507da1fadae2db750b59a274ab`.
+- Merge SHA: `f7475c922b9addb76c9dc725638db875ba255cf0`.
+- GitHub source-of-truth status: canonical pre-template bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #88 metadata, PR #90 metadata for the open stabilization follow-up, and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
+
 ## Fix
 - Exact change: Added a shared audit navigation helper that waits for route load state, verifies the target pathname, and retries only the known interrupted-navigation case. Updated route traversal and desktop navigation tests to use that helper.
 - Related PRD: None. This is unmapped operations QA automation work for PR88.

--- a/docs/engineering/bug-fixes/prd-12-why-this-matters.md
+++ b/docs/engineering/bug-fixes/prd-12-why-this-matters.md
@@ -1,5 +1,16 @@
 # PRD 12 — Why This Matters Bug Notes
 
+## GitHub Source-of-Truth Metadata
+- Affected object level: Signal and Card.
+- PR: #15, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/15`; #16, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/16`; canonical documentation backfill in #45, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/45`.
+- Branch: `feature/why-this-matters-specificity-fix`; `feature/why-this-matters-precision-fix`; `docs/strict-truth-doc-taxonomy-and-prd-backfill`.
+- Head SHA: #15 `6322135eb00d2a4cff1d0a8d8275f397d81230f9`; #16 `b16d09e89d2119007ddf796350d85f5489da852d`; #45 `96bdd47ab6db18002ec38035d890f69c41dedd64`.
+- Merge SHA: #15 `640ac4b1ca5f3b52e88f6eb8d87b15d470757af5`; #16 `2385611c5cfc6c425cfa906013c221cca342479f`; #45 `c182403f25f98aa40d82073a3eedb24328ee926c`.
+- GitHub source-of-truth status: canonical historical bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #15, #16, and #45 metadata; file history; existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
+
 ## Failures Addressed
 - Weak anchors such as pronouns, role words, and malformed fragments appearing as subjects.
 - Repetitive generic explanations across adjacent cards.

--- a/docs/engineering/bug-fixes/prd-13-signal-filtering-layer.md
+++ b/docs/engineering/bug-fixes/prd-13-signal-filtering-layer.md
@@ -1,5 +1,16 @@
 # Bug Fix: PRD 13 Signal Filtering Layer
 
+## GitHub Source-of-Truth Metadata
+- Affected object level: Article and Signal.
+- PR: implementation history maps to #20, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/20`; canonical documentation backfill in #45, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/45`.
+- Branch: `feature/repo-consolidation-main-sync`; `docs/strict-truth-doc-taxonomy-and-prd-backfill`.
+- Head SHA: #20 `af784d5a83972381c94f5e9fcb4a5e451a18dc19`; #45 `96bdd47ab6db18002ec38035d890f69c41dedd64`.
+- Merge SHA: #20 `f8a8ffe734ea6ba49dd0a22cc4b2421a88b951bc`; #45 `c182403f25f98aa40d82073a3eedb24328ee926c`.
+- GitHub source-of-truth status: canonical historical bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #20 and #45 metadata, file history, and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
+
 ## Summary
 - Added a dedicated signal-filtering module that evaluates article quality before downstream clustering and ranking.
 - Stored machine-readable filter metadata on raw articles so filtering behavior is inspectable and tunable.

--- a/docs/engineering/bug-fixes/public-card-cleanup-remediation-2026-05-02.md
+++ b/docs/engineering/bug-fixes/public-card-cleanup-remediation-2026-05-02.md
@@ -10,7 +10,9 @@
 - PR #180, #181, #187, and #189 metadata and PR bodies.
 - Prior Phase 1 change record: `docs/engineering/change-records/2026-05-02-public-card-cleanup-phase-1.md`.
 - GitHub source-of-truth status: canonical consolidated remediation record created on 2026-05-04.
+- External references reviewed, if any: GitHub PR #180, #181, #187, and #189 metadata and prior Phase 1 change record.
 - Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve branch names, head SHAs, merge SHAs, and merge state for all four phases; no branch deletion was performed in this metadata enrichment branch.
 
 ## Phase 1 — PR #180 Public Card Cleanup
 - PR: #180, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/180`

--- a/docs/engineering/bug-fixes/public-context-signals-visibility-remediation.md
+++ b/docs/engineering/bug-fixes/public-context-signals-visibility-remediation.md
@@ -6,6 +6,18 @@
 - Branch: `codex/public-context-signals-visibility-remediation`
 - Object level: Surface Placement
 
+## GitHub Source-of-Truth Metadata
+
+- Affected object level: Signal and Surface Placement.
+- PR: #148, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/148`.
+- Branch: `codex/public-context-signals-visibility-remediation`.
+- Head SHA: `1a89fd8252875845f561bfd578fb9e3e8c9a75a6`.
+- Merge SHA: `07dde932c142eb424d0893f63bd4485899b795d3`.
+- GitHub source-of-truth status: canonical pre-template bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #148 metadata and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the deleted/suspected-deleted branch recovery details; no branch deletion was performed in this metadata enrichment branch.
+
 ## Source Of Truth
 
 - April 29 controlled manual publish verification: `april_29_controlled_manual_publish_verified`

--- a/docs/engineering/bug-fixes/public-schema-preflight-fallback.md
+++ b/docs/engineering/bug-fixes/public-schema-preflight-fallback.md
@@ -6,6 +6,18 @@
 - Root cause: public read helpers reused the full admin/editorial PRD-53 `signal_posts` schema preflight, so missing admin/final-slate columns blocked public rendering of already-published live rows.
 - Effective change type: hotfix / remediation, not net-new feature work.
 
+## GitHub Source-of-Truth Metadata
+
+- Affected object level: Card and Surface Placement.
+- PR: #162, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/162`.
+- Branch: `codex/hotfix-public-schema-preflight-fallback`.
+- Head SHA: `863af2ca788292d45ca5f434246868bb164c93dc`.
+- Merge SHA: `1f31eed95bb88268775c24cb0cc0962d0d5702d5`.
+- GitHub source-of-truth status: canonical pre-template bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #162 metadata and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the deleted/suspected-deleted branch recovery details; no branch deletion was performed in this metadata enrichment branch.
+
 ## Source Of Truth
 
 - Product position: Boot Up is a curated daily intelligence briefing, not a feed.

--- a/docs/engineering/bug-fixes/remove-hardcoded-feed-loading-time-messaging.md
+++ b/docs/engineering/bug-fixes/remove-hardcoded-feed-loading-time-messaging.md
@@ -8,6 +8,17 @@
 - Problem addressed: the route-level loading UI displayed a fixed-duration loading estimate, which created a false expectation that loading should take a predictable amount of time.
 - Root Cause: Static placeholder copy not defined in the artifact system and not tied to real performance.
 
+## GitHub Source-of-Truth Metadata
+- Affected object level: Surface Placement.
+- PR: #94, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/94`.
+- Branch: `fix/v1-production-remediation`.
+- Head SHA: `c6ce9e5cc5e946c2c9c386daf3f1ef51ebc7f996`.
+- Merge SHA: `63f1a748fb55730d305dff3140f70423ad8132c9`.
+- GitHub source-of-truth status: canonical pre-template bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #94 metadata and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
+
 ## Fix
 - Fix: Replaced time-based loading message with neutral loading state.
 - Exact change: replaced the time-based loading sentence with the neutral loading copy `Preparing your feed...` while preserving the existing skeleton layout and component structure.

--- a/docs/engineering/bug-fixes/settings-shell-cleanup.md
+++ b/docs/engineering/bug-fixes/settings-shell-cleanup.md
@@ -1,5 +1,16 @@
 # Settings shell cleanup
 
+## GitHub Source-of-Truth Metadata
+- Affected object level: Surface Placement.
+- PR: #56, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/56`.
+- Branch: `fix/settings-shell-cleanup`.
+- Head SHA: `d8d9807d98eb49db802395e787e37b95c8d99113`.
+- Merge SHA: `f74ccd1ed188e530f98c237e565090d2bba6dd65`.
+- GitHub source-of-truth status: canonical pre-template bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #56 metadata and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
+
 ## Sections affected
 - Profile details
 - Delivery cadence

--- a/docs/engineering/bug-fixes/signed-in-empty-dashboard-fallback.md
+++ b/docs/engineering/bug-fixes/signed-in-empty-dashboard-fallback.md
@@ -1,5 +1,16 @@
 # Signed-In Empty Dashboard Fallback
 
+## GitHub Source-of-Truth Metadata
+- Affected object level: Signal and Surface Placement.
+- PR: #54, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/54`.
+- Branch: `feature/ingestion-v1`.
+- Head SHA: `0c7903edd9b8c71f0ae7bbc21ff2987218fa8e26`.
+- Merge SHA: `bc16e875ad9579acafad3ac768768284a528c151`.
+- GitHub source-of-truth status: canonical pre-template bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #54 metadata and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
+
 ## Root Cause
 
 Signed-out requests used the Phase 1 public pipeline through `getPublicDashboardData()`, but signed-in requests switched immediately to user-scoped `topics`, `sources`, `articles`, `events`, and `article_topics` queries in `getDashboardData()`. When a signed-in user had no bootstrap rows yet, those queries succeeded with empty results and the code returned `mode: "live"` with an empty briefing instead of falling back to the working public pipeline.

--- a/docs/engineering/bug-fixes/signed-out-homepage-qa-remediation-2026-04-22.md
+++ b/docs/engineering/bug-fixes/signed-out-homepage-qa-remediation-2026-04-22.md
@@ -7,6 +7,18 @@
 - Product source of truth: approved UX artifacts 0, 1, 2, 3, 4, 5, 7, and 10, plus the signed-out QA report.
 - Scope: signed-out Home page failures only.
 
+## GitHub Source-of-Truth Metadata
+
+- Affected object level: Card and Surface Placement.
+- PR: #96, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/96`.
+- Branch: `fix/signed-out-homepage-qa-remediation`.
+- Head SHA: `d55007acfd89531e0f4a2d5378c2207ea9231c4b`.
+- Merge SHA: `482a6f9994b55f71d23271067f18c189362bdb22`.
+- GitHub source-of-truth status: canonical pre-template bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #96 metadata and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
+
 ## Artifact Binding
 
 | Fix area | Source used |

--- a/docs/engineering/bug-fixes/v1-production-remediation-2026-04-21.md
+++ b/docs/engineering/bug-fixes/v1-production-remediation-2026-04-21.md
@@ -4,6 +4,17 @@
 - Problem addressed: production-facing UI and workflow behavior had drifted from the locked V1 artifact system. The visible shell still exposed legacy Home, Today, Topics, Sources, History, and Settings navigation; `/account` and `/briefing/[date]` were absent; logged-out soft gates and redirect-after-auth behavior were incomplete.
 - Root cause: V1 component work existed in partial or isolated form, but route-level architecture, auth redirect plumbing, Account data wiring, mobile navigation, and shared detail behavior were not integrated into the production shell.
 
+## GitHub Source-of-Truth Metadata
+- Affected object level: Card and Surface Placement.
+- PR: #89, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/89`.
+- Branch: `fix/v1-production-remediation`.
+- Head SHA: `19d7353155a971d312a4b331ad4020eced3c9b88`.
+- Merge SHA: `156d4f59beb871a6b0cdf48478816be805f92eb3`.
+- GitHub source-of-truth status: canonical pre-template bug-fix record enriched with source-of-truth metadata on 2026-05-04.
+- External references reviewed, if any: GitHub PR #89 metadata and the existing canonical bug-fix record.
+- Google Sheet / Work Log reference, if historically relevant: none used as canonical input.
+- Branch cleanup status: PR metadata and this record preserve the branch recovery details; no branch deletion was performed in this metadata enrichment branch.
+
 ## Fix
 - Exact change: replaced the primary app shell with Home, History, and Account; added `/account`; added `/briefing/[date]`; redirected legacy first-class routes; restored category/history soft gates; restored auth entry links and `redirectTo` behavior; moved V1 Account controls onto `/account`; added schema support for category preferences, newsletter state, and avatar metadata; updated focused unit and Chromium Playwright coverage.
 - Related PRD: PRD-14, PRD-17, PRD-18, PRD-32, PRD-44, PRD-45, PRD-46, PRD-48, and PRD-49.


### PR DESCRIPTION
## Objective
Enrich older canonical bug-fix records with the current GitHub source-of-truth metadata fields without rewriting their historical narrative or creating new remediation records.

## Source-of-truth context
- GitHub repo documentation remains canonical.
- Google Sheet and Google Work Log records are historical reference only.
- This PR does not create tracker-sync fallback files.

## Scope
- Added concise source-of-truth metadata to top-level canonical bug-fix records under `docs/engineering/bug-fixes/`.
- Preserved existing problem/root-cause/fix/validation narratives.
- Excluded `docs/engineering/bug-fixes/templates/` and `docs/engineering/bug-fixes/phase1/`.
- Did not create new bug-fix records.

## Validation
- `git diff --check` - passed.
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name docs/enrich-pre-template-bugfix-metadata --pr-title "docs: enrich pre-template bug-fix metadata"` - passed.
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name docs/enrich-pre-template-bugfix-metadata --pr-title "docs: enrich pre-template bug-fix metadata"` - passed.

## Explicit non-actions
- No Google tracker updates.
- No Google Work Log updates.
- No tracker-sync fallback files.
- No runtime app code changes.
- No workflows/scripts/package changes.
- No schema or migration changes.
- No production data changes.
- No production validation.
- No branch deletion.