### PR TITLE
docs: record Google tracker and Work Log retirement readback

### DIFF
--- a/docs/engineering/change-records/2026-05-04-github-source-of-truth-remediation-docs-audit.md
+++ b/docs/engineering/change-records/2026-05-04-github-source-of-truth-remediation-docs-audit.md
@@ -146,5 +146,6 @@ Mitigation completed:
 ## 13. Remaining Actions, If Any
 
 - Completed follow-up: `.github/workflows/github-sheets-status-sync.yml`, `scripts/github-sheets-sync.mjs`, `scripts/github-sheets/sync.mjs`, related targeted tests, and Google Sheets promotion in production verification were decommissioned in `docs/engineering/change-records/2026-05-04-google-sheets-sync-decommission.md`.
+- Completed follow-up: Google Tracker / Work Log retirement readback recorded in `docs/engineering/change-records/2026-05-04-google-tracker-worklog-retirement-readback.md`.
 - Consider adding a short `docs/engineering/incidents/README.md` if incident records are created later; the folder is reserved but absent in this checkout.
 - Continue to avoid Google Sheet updates and routine tracker-sync fallback creation unless the user explicitly requests a historical Google-reference reconciliation artifact.

--- a/docs/engineering/change-records/2026-05-04-google-tracker-worklog-retirement-readback.md
+++ b/docs/engineering/change-records/2026-05-04-google-tracker-worklog-retirement-readback.md
@@ -1,0 +1,105 @@
+# Google Tracker And Work Log Retirement Readback
+
+## 1. Objective
+
+Record an archival readback between the current GitHub repo documentation system and the retired Google reference artifacts:
+
+- Google Tracker Sheet: `Features Table`
+- Google Work Log: `BOOT_UP_WORK_LOG_v2.md`
+
+This is not a new remediation-document consolidation pass. It exists so future agents and humans understand why the Google Sheet and Google Work Log must not be used as current operational truth.
+
+## 2. Source-Of-Truth Decision
+
+- GitHub repo documentation is canonical for bug-fix history, remediation history, branch-cleanup history, validation records, release/governance records, and repo-side PRD/feature governance metadata.
+- `docs/product/feature-system.csv` is the current repo-side PRD/feature control file.
+- Google Tracker Sheet and Google Work Log records are historical reference inputs only.
+- Do not use Google Sheet or Google Work Log state for active status, next-action queue, closeout, backlog truth, or operational readiness.
+- Do not update Google Sheets, claim Google tracker updates, or create routine tracker-sync fallback files.
+
+## 3. External Artifacts Reviewed
+
+Direct Google artifact access was not performed in this branch. This readback uses the supplied external-reference facts and current repo evidence.
+
+| External artifact | Status in this readback |
+| --- | --- |
+| Google Tracker Sheet `Features Table` | Reviewed through supplied discrepancy facts. |
+| Google Work Log `BOOT_UP_WORK_LOG_v2.md` | Reviewed through supplied discrepancy facts. |
+
+## 4. GitHub Repo Documents Reviewed
+
+- `AGENTS.md`
+- `docs/product/documentation-rules.md`
+- `docs/engineering/change-records/2026-05-04-github-source-of-truth-remediation-docs-audit.md`
+- `docs/engineering/change-records/2026-05-04-deprecated-folder-removal-and-backfill-closeout.md`
+- `docs/engineering/change-records/2026-05-04-google-sheets-sync-decommission.md`
+- `docs/operations/branch-cleanup/2026-05-04-branch-cleanup-reconciliation.md`
+- `docs/product/feature-system.csv`
+- Search scope: `AGENTS.md docs`
+
+## 5. Discrepancy Table
+
+| External artifact | External claim/state | Current GitHub state | Severity | Repo action |
+| --- | --- | --- | --- | --- |
+| Google Sheet `Use Instruction` | `Sheet1 = governed truth`; live workflow updates Sheet1 to Merged/Built. | GitHub repo docs and `docs/product/feature-system.csv` are canonical; Google Sheet is historical only. | High | No repo correction required; this record preserves the conflict. |
+| Google Sheet PRD-24 row | PRD-24 still appears active-ish with `Status = In Review`, `Decision = keep`, and permanent GitHub-to-Google-Sheets sync language. | `docs/product/feature-system.csv` marks PRD-24 `Deprecated`, `Decision = kill`, and describes retired Google tracker sync governance. PRD-24 also says not to justify routine Google writes. | High | No repo correction required. |
+| Google Sheet PRD paths | Older rows use stale paths such as `docs/prd/...`. | Current repo canonical PRD paths are under `docs/product/prd/...`. | Medium | No repo correction required; current CSV paths are canonical. |
+| Google Sheet Intake Queue | Many merged PRs still appear as `Needs Review`, including recent docs/governance work. | GitHub PR metadata and canonical repo docs record merged status, documentation lanes, and closeout decisions. | High | Do not use Intake Queue for current planning or closeout. |
+| Google Work Log source hierarchy | Work Log describes itself as appendable system-of-record and places external docs/Work Log above GitHub repo. | Current repo rules say Google Sheet / Work Log are historical references only and GitHub repo docs are canonical. | High | No repo correction required; external banner recommended. |
+| Google Work Log baseline | Latest merged PR is described as #158, with next step around database-owner migration-history review. | Repo has later merged work through PR #194 and PR #195; PRD-53 migration/schema/controlled-cycle records are in GitHub docs. | High | Do not use Work Log baseline for active next steps. |
+| Google Work Log missing PR #159-#194 | Work Log omits later PRD-53 schema apply, controlled cycles, MVP measurement, controlled exposure, PR #190, PR #191, PR #192, PR #193, and PR #194. | GitHub repo contains the current records across `docs/engineering/change-records/`, `docs/engineering/bug-fixes/`, `docs/engineering/testing/`, `docs/operations/controlled-cycles/`, and `docs/operations/launch-readiness/`. | High | No repo correction required; GitHub remains the recovery ledger. |
+| Google Work Log do-not-do / next-action items | Next actions and constraints are frozen around stale PR #158-era operations. | Current GitHub docs supersede them, including source-of-truth migration, branch cleanup reconciliation, deprecated folder removal, and Google Sheets sync decommission. | High | Future agents must consult GitHub docs first. |
+
+## 6. GitHub Discrepancy Result
+
+No required repo correction was found.
+
+The current GitHub repo docs are internally consistent for this scope:
+
+- GitHub repo documentation is canonical.
+- `docs/product/feature-system.csv` is the active repo-side PRD/feature control file.
+- Google Sheet and Google Work Log records are historical reference inputs only.
+- `docs/operations/tracker-sync/` is historical compatibility only.
+- `docs/bugs/` and `docs/changes/` are not active tracked documentation lanes.
+
+Search results still include historical Google tracker payloads and retired PRD-24 details. Those are not active contradictions because standing rules and decommission records now label them retired or historical.
+
+## 7. Folders Included In Future Discrepancy Analysis
+
+Future discrepancy checks should include:
+
+- `docs/engineering/bug-fixes/`
+- `docs/engineering/change-records/`
+- `docs/engineering/testing/`
+- `docs/engineering/incidents/`
+- `docs/operations/controlled-cycles/`
+- `docs/operations/launch-readiness/`
+- `docs/operations/branch-cleanup/`
+- `docs/operations/tracker-sync/`
+- `docs/product/prd/`
+- `docs/product/feature-system.csv`
+- `AGENTS.md`
+- `docs/product/documentation-rules.md`
+- `docs/engineering/protocols/`
+
+## 8. External Retirement Recommendation
+
+Recommended external banner for both the Google Tracker Sheet and Google Work Log, outside this PR:
+
+```text
+Retired as source of truth after PR #191-#194. Use GitHub repo docs and docs/product/feature-system.csv as canonical.
+```
+
+This branch does not edit the Google artifacts.
+
+## 9. Explicit Non-Actions
+
+- No Google Sheet update.
+- No Google Work Log update.
+- No tracker-sync fallback.
+- No runtime code changes.
+- No workflows or scripts changed.
+- No package files changed.
+- No schema or migration changes.
+- No production validation.
+- No branch deletion.


### PR DESCRIPTION
## Objective
Create a narrow archival readback record comparing the current GitHub repo documentation system against the retired Google Tracker Sheet (`Features Table`) and retired Google Work Log (`BOOT_UP_WORK_LOG_v2.md`).

## External artifacts reviewed
- Google Tracker Sheet: reviewed through supplied discrepancy facts; no Google Sheet edits were made.
- Google Work Log: reviewed through supplied discrepancy facts; no Google Work Log edits were made.

## GitHub documents reviewed
- `AGENTS.md`
- `docs/product/documentation-rules.md`
- `docs/engineering/change-records/2026-05-04-github-source-of-truth-remediation-docs-audit.md`
- `docs/engineering/change-records/2026-05-04-deprecated-folder-removal-and-backfill-closeout.md`
- `docs/engineering/change-records/2026-05-04-google-sheets-sync-decommission.md`
- `docs/operations/branch-cleanup/2026-05-04-branch-cleanup-reconciliation.md`
- `docs/product/feature-system.csv`

## Discrepancy summary
- Google Sheet instructions still describe Sheet1 as governed truth, while the repo now says GitHub docs and `docs/product/feature-system.csv` are canonical.
- Google Sheet PRD-24 state conflicts with repo state: the sheet presents active-ish sync governance, while the repo marks PRD-24 deprecated/kill and PR #194 decommissioned the sync artifacts.
- Google Sheet PRD paths and Intake Queue rows are stale.
- Google Work Log is frozen around PR #158, omits PR #159 through #194, and should not drive current next actions.
- Current GitHub docs are internally consistent for this scope; no direct repo contradiction required correction.

## Repo changes made
- Added `docs/engineering/change-records/2026-05-04-google-tracker-worklog-retirement-readback.md`.
- Added one concise follow-up pointer to `docs/engineering/change-records/2026-05-04-github-source-of-truth-remediation-docs-audit.md`.

## Why no Google edits were made
GitHub repo docs are canonical. The Google Tracker Sheet and Google Work Log are retired as source-of-truth systems and may be used only as historical reference inputs, so this PR records the discrepancy in GitHub without updating either external artifact.

## Validation commands and results
- `git diff --check` - PASS
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name docs/google-reference-retirement-readback --pr-title "docs: record Google tracker and Work Log retirement readback"` - PASS
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name docs/google-reference-retirement-readback --pr-title "docs: record Google tracker and Work Log retirement readback"` - PASS

## Explicit non-actions
- No Google tracker updates.
- No Google Work Log updates.
- No tracker-sync fallback.
- No runtime app behavior changes.
- No workflows/scripts changes.
- No package file changes.
- No schema/migration changes.
- No production data changes.
- No production validation.
- No branch deletion.
