### PR TITLE
remediation: disable cron for Phase A.2 preflight

### DIFF
--- a/docs/engineering/change-records/2026-05-05-phase-a2-cron-disable-preflight.md
+++ b/docs/engineering/change-records/2026-05-05-phase-a2-cron-disable-preflight.md
@@ -1,0 +1,30 @@
+# Phase A.2 Cron Disable Preflight Remediation
+
+## Effective Change Type
+
+Remediation / controlled operations validation.
+
+## Source Of Truth
+
+- Phase A.2 controlled operations prompt.
+- `BOOT_UP_WORK_LOG.md` operational baseline as cited by the prompt.
+- PR #190 deployed composer locked-state bug-fix baseline.
+
+## Summary
+
+Phase A.2 preflight requires production cron to be disabled before any controlled `draft_only` run can set `PIPELINE_CRON_DISABLED_CONFIRMED=true`.
+
+Production inspection showed the deployed Vercel config still included a scheduled `/api/cron/fetch-news` entry. This remediation removes the scheduled cron from `vercel.json` so a later Phase A.2 preflight can truthfully confirm cron-disabled state before attempting production non-live draft creation.
+
+## Scope
+
+- Remove the Vercel cron schedule from `vercel.json`.
+- Preserve the `/api/cron/fetch-news` route and its existing authorization behavior.
+- Do not run cron.
+- Do not run `draft_only`.
+- Do not publish or mutate Signal rows.
+- Do not change source manifests, ranking, WITM templates, homepage schema, admin authority, or database schema.
+
+## PRD Status
+
+No canonical PRD is required. This is an operational safety remediation, not a net-new product capability.

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,1 @@
-{
-  "crons": [
-    {
-      "path": "/api/cron/fetch-news",
-      "schedule": "0 10 * * *"
-    }
-  ]
-}
+{}


### PR DESCRIPTION
## Summary
- removes the scheduled Vercel cron entry from `vercel.json`
- preserves the `/api/cron/fetch-news` route and existing route authorization behavior
- adds a scoped change record for the Phase A.2 preflight remediation

## Governance
- Change type: remediation / controlled operations validation
- Canonical PRD required: No
- Reason: production preflight for Phase A.2 requires cron-disabled state before any controlled `draft_only` run can truthfully set `PIPELINE_CRON_DISABLED_CONFIRMED=true`
- No DB migration
- No source, ranking, WITM, homepage schema, admin authority, publish, or Signal row mutation changes

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('vercel.json','utf8')); console.log('vercel.json valid')"`
- `python3 scripts/release-governance-gate.py`
- `python3 scripts/validate-feature-system-csv.py`
- `npm run lint`
- `npm run test`
- `npm run build`

## Phase A.2 note
This PR does not run cron, `draft_only`, publish, or mutate production rows. It only restores the required preflight condition so Phase A.2 can be reconsidered after merge/deploy verification.
