### PR TITLE
Document Phase X.2 preflight blocker

### DIFF
--- a/docs/engineering/bug-fixes/phase-x1-partial-slate-publish-remediation.md
+++ b/docs/engineering/bug-fixes/phase-x1-partial-slate-publish-remediation.md
@@ -11,12 +11,12 @@
 - Related PRD: PRD-36 and Decisions D1/D2/D3/D5 in `BOOT_UP_WORK_LOG_v2.md`; no new canonical PRD required.
 - PR: #199, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/199`.
 - Branch: `codex/phase-x1-partial-slate-publish`.
-- Head SHA: TBD.
-- Merge SHA: TBD.
-- GitHub source-of-truth status: PR opened for Phase X.1 remediation validation.
+- Head SHA: `baea93c`.
+- Merge SHA: `ec587d03088037722dae3dc38c4d2f2c8b7ac15d`.
+- GitHub source-of-truth status: PR #199 merged on 2026-05-05 at 23:46:36 UTC. All GitHub PR checks completed successfully before merge, including feature-system CSV validation, release governance, lint, unit tests, build, Chromium E2E, WebKit E2E, PR summary, and Vercel preview.
 - External references reviewed, if any: PRs #119/#124/#126/#127/#190 and Phase X handoff context from 2026-05-06.
 - Google Sheet / Work Log reference, if historically relevant: Phase X handoff; no Sheet treated as canonical.
-- Branch cleanup status: pending after merge.
+- Branch cleanup status: pending after merge; local cleanup hit a worktree ownership guard, so no branch deletion was performed in the analyzed session.
 
 ## Terminology Requirement
 - [x] Confirmed object level before coding: Signal, Card, and Surface Placement.
@@ -37,7 +37,9 @@
   - `npm run governance:audit -- --diff-mode local --branch-name codex/phase-x1-partial-slate-publish --pr-title "Phase X.1: partial-slate publish (1-5 rows) — remediation/alignment to PRD-36 and Decision D1"`
 - Human checks:
   - Production publish, draft_only, and pipeline modes were not invoked during this remediation.
+  - Post-merge production static verification confirmed production built merge commit `ec587d0`, public homepage and `/signals` remained on the prior May 1 live set, and the three Phase X draft rows remained non-live.
 
 ## Remaining Risks / Follow-up
 - Phase X.2 must still perform the live publish only after BM provides explicit approved row IDs.
 - The existing Supabase client publish path performs ordered writes with rollback handling; no publish operation was executed in this phase.
+- Phase X.2 preflight later stopped with `blocked_missing_bm_approved_row_ids` because the chat did not include both the approved row ID list and BM editorial responsibility confirmation.

--- a/docs/operations/controlled-cycles/2026-05-06-phase-x2-preflight-blocked-approved-row-ids.md
+++ b/docs/operations/controlled-cycles/2026-05-06-phase-x2-preflight-blocked-approved-row-ids.md
@@ -1,0 +1,126 @@
+# Phase X.2 Preflight Blocked: Approved Row IDs Missing
+
+Date: 2026-05-06
+Branch: `docs/phase-x2-controlled-ops-docs`
+Referenced Codex session: `019df76c-3d72-79c2-bd05-bd810ea8682e`
+Readiness label: `blocked_missing_bm_approved_row_ids`
+
+## Effective Change Type
+
+Remediation / controlled operations validation.
+
+This packet records a blocked Phase X.2 production publish preflight after PR #199 deployed the partial-slate publish remediation. It does not implement a feature, create a PRD, run `dry_run`, run `draft_only`, invoke publish, run cron, mutate production Signal rows, change source manifests, change ranking, change WITM templates, change homepage schema, or alter any environment variables.
+
+Object level: production `signal_posts` Surface Placement and Card-copy readiness were inspected only. No Article, Story Cluster, source, ranking-threshold, WITM-threshold, schema, or public rendering behavior changed.
+
+## Source Of Truth
+
+- `BOOT_UP_WORK_LOG_v2.md`, Decisions D1, D2, D3, and D5, as referenced by the Phase X prompts.
+- Product Position PRD-36 5-card cap discipline.
+- PR #199 partial-slate publish remediation, merged at `ec587d03088037722dae3dc38c4d2f2c8b7ac15d`.
+- PR #119 and PR #124 WITM publish gate.
+- PR #126 controlled modes.
+- PR #190 composer locked-state behavior.
+- GitHub `AGENTS.md` documentation governance: GitHub repo docs are canonical; routine `tracker-sync` files are not created.
+
+Canonical PRD required: No. This is operational execution readiness and blocker documentation for an already-remediated publish path.
+
+## Blocker
+
+Phase X.2 publish execution requires both:
+
+- a BM-approved list of 1-5 row IDs from the Phase X draft set
+- explicit confirmation that BM reviewed the WITM copy of every approved row and accepts editorial responsibility for publishing it
+
+The analyzed session did not contain those inputs. Publish was therefore blocked before any write.
+
+No publish path was invoked. No public rows were changed. No rollback path was exercised.
+
+## Preflight Artifact
+
+Local artifact from the analyzed session:
+
+```text
+/Users/bm/dev/worktrees/daily-intelligence-aggregator-phase-x1-partial-slate-publish/.pipeline-runs/phase-x2-preflight-blocked-2026-05-06T03-57-27-549Z.json
+```
+
+Artifact status:
+
+```text
+blocked_missing_bm_approved_row_ids
+```
+
+Captured at `2026-05-06T03:57:27.549Z`.
+
+## Current Published Live Set
+
+All seven prior rows remained live and published with `published_at = 2026-05-01T07:44:07.384+00:00`.
+
+| Rank | Row ID | Title | Status | Live |
+| ---: | --- | --- | --- | --- |
+| 1 | `0e21b2ea-4a6b-4e2b-8a9b-7f470120e1a5` | Trump signs DHS legislation, ending record-breaking shutdown | `published` | true |
+| 2 | `c94fe250-2a4f-4b35-835c-582cdb9916a6` | Economic Letter Countdown: Most Read Topics from 2025 | `published` | true |
+| 3 | `5bdb8ffe-ab97-40f3-8c62-67864878d646` | A Closer Look at Emerging Market Resilience During Recent Shocks | `published` | true |
+| 4 | `e1edddd2-3792-453e-acab-7b34d5912f99` | The R*-Labor Share Nexus | `published` | true |
+| 5 | `a0f71fc3-5478-442d-8d03-2b3a0a263d41` | The AI Investing Landscape: Insights from Venture Capital | `published` | true |
+| 6 | `87729916-366a-4c0e-a5d1-0fce5f4e47ce` | Anthropic, OpenAI back Warner-Budd workforce data bill | `published` | true |
+| 7 | `a2e9edc7-b9c1-4a10-b6a8-a60ae81c864f` | Congress keeps kicking surveillance reform down the road | `published` | true |
+
+## Phase X Draft Set
+
+These are the only rows eligible for BM approval in the next Phase X.2 prompt.
+
+| Row ID | Title | Editorial status | Live | Published | WITM validation |
+| --- | --- | --- | --- | --- | --- |
+| `27b7017e-9b3a-4e3a-975c-e70320794b8a` | Economic Letter Countdown: Most Read Topics from 2025 | `needs_review` | false | null | `passed` |
+| `5e64e0a5-ba10-4c8d-b29b-957f465a6530` | In What Ways Has U.S. Trade with China Changed? | `needs_review` | false | null | `requires_human_rewrite` |
+| `5e1885b4-961d-4283-9eb4-abe3f02d75db` | The AI Investing Landscape: Insights from Venture Capital | `needs_review` | false | null | `passed` |
+
+Publish eligibility from this snapshot:
+
+- eligible if BM approves and current DB status still matches: `27b7017e-9b3a-4e3a-975c-e70320794b8a`, `5e1885b4-961d-4283-9eb4-abe3f02d75db`
+- blocked until rewritten and revalidated to `passed`: `5e64e0a5-ba10-4c8d-b29b-957f465a6530`
+
+## Production And Composer Checks
+
+Read-only checks in the analyzed session confirmed:
+
+- production was on PR #199 merge commit `ec587d0` or later
+- Vercel production deploy was Ready
+- cron remained disabled through `vercel.json`
+- `ADMIN_EMAILS` included `newsweb2026@gmail.com`
+- static deployed publish code no longer contained the prior exact-seven publish gate
+- public homepage and `/signals` still showed the prior May 1 published set
+- no distinct Phase X draft title leaked publicly
+
+Authenticated composer clicking was not performed in the Phase X.2 blocked prompt because publish authorization inputs were absent.
+
+## Required Next Prompt Inputs
+
+The next Phase X.2 prompt must include:
+
+1. `approved_row_ids`: an explicit list of 1-5 full UUIDs from the Phase X draft set.
+2. An explicit BM statement accepting editorial responsibility for the WITM copy of every approved row.
+3. Confirmation that any row previously marked `requires_human_rewrite` has been rewritten in composer and now reads back as `passed`.
+
+If any approved row is outside the three-row Phase X draft set, or if any approved row has current `why_it_matters_validation_status != passed`, stop before publish.
+
+## Non-Authorization
+
+The blocked preflight did not authorize:
+
+- publish
+- `draft_only`
+- `dry_run`
+- cron re-enable
+- Phase Y
+- source manifest changes
+- ranking changes
+- WITM template changes
+- homepage schema changes
+- direct SQL row surgery
+- rollback or atomicity remediation
+
+## Follow-Up
+
+Phase X.2 remains pending. The first safe next action is a fresh preflight using the exact BM-approved row IDs and current production row statuses. Phase Y remains blocked by the documented single-transaction atomicity hardening risk from PR #199 and must not be started from this record.


### PR DESCRIPTION
## Summary
- add a controlled-cycle record for the Phase X.2 preflight blocked by missing BM-approved row IDs
- update the Phase X.1 partial-slate remediation record with PR #199 merge/check/deploy closeout metadata
- preserve GitHub repo docs as the source of truth and avoid tracker-sync fallback records

## Validation
- git diff --check
- python3 scripts/validate-feature-system-csv.py
- python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name docs/phase-x2-controlled-ops-docs --pr-title "Document Phase X.2 preflight blocker"
- python3 scripts/check-governance-hotspots.py --diff-mode local --branch-name docs/phase-x2-controlled-ops-docs --pr-title "Document Phase X.2 preflight blocker"
- python3 scripts/release-governance-gate.py --diff-mode local --branch-name docs/phase-x2-controlled-ops-docs --pr-title "Document Phase X.2 preflight blocker"