### PR TITLE
hotfix: remove developer subtitle and debug border from /briefing detail page (public surface trust)

### DIFF
--- a/docs/engineering/bug-fixes/briefing-detail-public-debug-artifacts.md
+++ b/docs/engineering/bug-fixes/briefing-detail-public-debug-artifacts.md
@@ -1,0 +1,49 @@
+# Briefing Detail Public Debug Artifacts — Bug-Fix Record
+
+## Summary
+- Problem addressed: logged-out `/briefing/[date]` detail pages exposed a developer subtitle and a visible inherited debug-like frame around public detail cards.
+- Root cause: the detail page rendered `data.briefing.intro` directly even when the public homepage data source populated it with an implementation note, and detail event cards reused the shared `Panel` frame whose `glass-panel` border appeared as an unintended public-surface wrapper.
+- Affected object level: Card and Surface Placement.
+
+## Source Of Truth
+- Cowork frontend UX analysis 2026-05-06, prioritized shortlist Fix 1 and Fix 2.
+- Production URL observed before fix: `https://daily-intelligence-aggregator-ybs9.vercel.app/briefing/2026-05-06`.
+- BOOT_UP_WORK_LOG Decision D3 historical reference: no false freshness; trust matters more than daily automation optics.
+- Canonical PRD required: no.
+
+## Fix
+- Exact change: remove the detail-page subtitle render and replace the detail event card's inherited `Panel` frame with a local border-transparent card frame.
+- Related PRD: none; hotfix only.
+- PR: pending.
+- Branch: `hotfix/briefing-public-artifacts`.
+- Head SHA: pending.
+- Merge SHA: pending.
+- GitHub source-of-truth status: pending PR.
+- External references reviewed, if any: Cowork analysis supplied in prompt and live production DOM check.
+- Google Sheet / Work Log reference, if historically relevant: Work Log Decision D3 was treated as historical context only, not as a canonical write target.
+- Branch cleanup status: pending post-merge cleanup.
+
+## Terminology Requirement
+- [x] Confirmed object level before coding: Card and Surface Placement.
+- [x] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [x] Legacy runtime naming mismatch remains unchanged; no ranking, source, pipeline, or database logic was modified.
+
+## Validation
+- Automated checks:
+  - `npm install` passed.
+  - `npm run test -- src/components/briefing/BriefingDetailView.test.tsx` passed.
+  - `npm run test -- src/components/briefing/BriefingDetailView.test.tsx src/lib/data.test.ts` passed.
+  - `npm run lint` passed.
+  - `npm run test` passed.
+  - `npm run build` passed.
+  - `npx playwright test --project=chromium` passed.
+  - `npx playwright test --project=webkit` passed.
+  - `python3 scripts/validate-feature-system-csv.py` passed with existing slug warnings.
+  - `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name hotfix/briefing-public-artifacts --pr-title "hotfix: remove developer subtitle and debug border from /briefing detail page (public surface trust)"` passed.
+  - `python3 scripts/check-governance-hotspots.py --diff-mode local --branch-name hotfix/briefing-public-artifacts --pr-title "hotfix: remove developer subtitle and debug border from /briefing detail page (public surface trust)"` passed.
+  - `python3 scripts/release-governance-gate.py --diff-mode local --branch-name hotfix/briefing-public-artifacts --pr-title "hotfix: remove developer subtitle and debug border from /briefing detail page (public surface trust)"` passed.
+  - `python3 scripts/pr-governance-audit.py --diff-mode local --branch-name hotfix/briefing-public-artifacts --pr-title "hotfix: remove developer subtitle and debug border from /briefing detail page (public surface trust)"` passed.
+- Human checks: local `/briefing/2026-05-06` rendered the unavailable state without production snapshot data; Vercel preview and production visual confirmation remain required after deployment.
+
+## Remaining Risks / Follow-up
+- Thursday/Friday UI cleanup items from the Cowork analysis remain out of scope for this hotfix.

--- a/src/components/briefing/BriefingDetailView.test.tsx
+++ b/src/components/briefing/BriefingDetailView.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BriefingDetailView } from "@/components/briefing/BriefingDetailView";
+import type { BriefingItem, DashboardData } from "@/lib/types";
+
+const developerSubtitle =
+  "The homepage renders from today's published signal set instead of triggering feed ingestion during SSR.";
+
+function createItem(): BriefingItem {
+  return {
+    id: "signal-1",
+    topicId: "finance",
+    topicName: "Finance",
+    title: "Economic letter countdown",
+    whatHappened: "The latest published briefing item is available for public readers.",
+    keyPoints: [
+      "First public detail point",
+      "Second public detail point",
+      "Third public detail point",
+    ],
+    whyItMatters: "This keeps public briefing detail focused on reader-facing context.",
+    sources: [{ title: "Federal Reserve", url: "https://example.com/fed" }],
+    estimatedMinutes: 4,
+    read: false,
+    priority: "top",
+    matchedKeywords: ["finance"],
+    matchScore: 8,
+    publishedAt: "2026-05-06T09:00:00.000Z",
+    sourceCount: 1,
+    relatedArticles: [
+      {
+        title: "Economic update",
+        url: "https://example.com/fed",
+        sourceName: "Federal Reserve",
+      },
+    ],
+    importanceScore: 82,
+    importanceLabel: "High",
+    rankingSignals: ["Ranked high because the event has clear system-level implications."],
+    displayState: "new",
+  };
+}
+
+function createData(): DashboardData {
+  const item = createItem();
+
+  return {
+    mode: "public",
+    briefing: {
+      id: "published-homepage-2026-05-06",
+      briefingDate: "2026-05-06T09:00:00.000Z",
+      title: "Daily Executive Briefing",
+      intro: developerSubtitle,
+      readingWindow: "4 minutes",
+      items: [item],
+    },
+    publicRankedItems: [item],
+    topics: [
+      { id: "finance", name: "Finance", description: "Finance coverage", color: "#1f4f46" },
+      { id: "tech", name: "Tech", description: "Tech coverage", color: "#294f86" },
+      { id: "politics", name: "Politics", description: "Politics coverage", color: "#8a5a11" },
+    ],
+    sources: [
+      {
+        id: "fed",
+        name: "Federal Reserve",
+        feedUrl: "https://example.com/feed",
+        status: "active",
+        topicName: "Finance",
+      },
+    ],
+    homepageDiagnostics: {
+      totalArticlesFetched: 1,
+      totalCandidateEvents: 1,
+      sourceCountsByCategory: { tech: 0, finance: 1, politics: 0 },
+    },
+  };
+}
+
+describe("BriefingDetailView", () => {
+  it("does not render the developer subtitle or inherited panel border on public detail cards", () => {
+    render(<BriefingDetailView data={createData()} viewer={null} />);
+
+    expect(screen.getByRole("heading", { name: "Daily Executive Briefing" })).toBeInTheDocument();
+    expect(screen.queryByText(developerSubtitle)).not.toBeInTheDocument();
+
+    const [detailCard] = screen.getAllByTestId("briefing-detail-card");
+    expect(detailCard).not.toHaveClass("glass-panel");
+    expect(detailCard).toHaveClass("border-transparent");
+  });
+});

--- a/src/components/briefing/BriefingDetailView.tsx
+++ b/src/components/briefing/BriefingDetailView.tsx
@@ -44,9 +44,6 @@ export function BriefingDetailView({
             <h1 className="text-2xl font-semibold tracking-normal text-[var(--text-primary)] md:text-[32px] md:leading-[1.25]">
               {data.briefing.title}
             </h1>
-            <p className="max-w-2xl text-base text-[var(--text-secondary)]">
-              {data.briefing.intro}
-            </p>
             <div className="flex flex-wrap gap-2">
               <Badge>{topEvents.length} {topEvents.length === 1 ? "top event" : "top events"}</Badge>
               <Badge>{data.briefing.readingWindow}</Badge>
@@ -117,7 +114,10 @@ function BriefingEventDetailCard({
   featured: boolean;
 }) {
   return (
-    <Panel className={cn("p-5", featured && "p-6")}>
+    <div
+      className={cn("rounded-card border border-transparent bg-[var(--card)] p-5", featured && "p-6")}
+      data-testid="briefing-detail-card"
+    >
       <article className="space-y-5">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="flex items-start gap-3">
@@ -193,7 +193,7 @@ function BriefingEventDetailCard({
           </section>
         ) : null}
       </article>
-    </Panel>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- Remove the rendered developer subtitle from the public `/briefing/[date]` detail header.
- Replace the detail event card's inherited `Panel` frame with a local border-transparent frame so the visible public debug-like border is gone without changing card content.
- Add a focused component regression test and a canonical bug-fix record.

## Source of truth
- Cowork frontend UX analysis 2026-05-06, prioritized Fix 1 and Fix 2.
- Production observation: `https://daily-intelligence-aggregator-ybs9.vercel.app/briefing/2026-05-06`.
- BOOT_UP_WORK_LOG Decision D3: no false freshness; trust matters more than daily automation optics.

## Governance
- Change type: hotfix.
- Canonical PRD required: no.
- Scope: logged-out public `/briefing/[date]` UI only.
- Not changed: backend, database, source manifest, ranking, WITM templates, eligibility filters, pipeline modes, editorial admin, homepage, `/signals`, category tabs, cron, publish paths, or production data.

## Validation
- `npm install` passed.
- `npm run test -- src/components/briefing/BriefingDetailView.test.tsx` passed.
- `npm run test -- src/components/briefing/BriefingDetailView.test.tsx src/lib/data.test.ts` passed.
- `npm run lint` passed.
- `npm run test` passed: 79 files, 592 tests.
- `npm run build` passed.
- `npx playwright test --project=chromium` passed: 33 tests.
- `npx playwright test --project=webkit` passed: 33 tests.
- `python3 scripts/validate-feature-system-csv.py` passed with existing slug warnings.
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name hotfix/briefing-public-artifacts --pr-title "hotfix: remove developer subtitle and debug border from /briefing detail page (public surface trust)"` passed.
- `python3 scripts/check-governance-hotspots.py --diff-mode local --branch-name hotfix/briefing-public-artifacts --pr-title "hotfix: remove developer subtitle and debug border from /briefing detail page (public surface trust)"` passed.
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name hotfix/briefing-public-artifacts --pr-title "hotfix: remove developer subtitle and debug border from /briefing detail page (public surface trust)"` passed.
- `python3 scripts/pr-governance-audit.py --diff-mode local --branch-name hotfix/briefing-public-artifacts --pr-title "hotfix: remove developer subtitle and debug border from /briefing detail page (public surface trust)"` passed.

## Local visual note
Local `/briefing/2026-05-06` rendered the unavailable state because the local environment does not have the production published snapshot. Preview validation must inspect the production-like snapshot page before merge.