### PR TITLE
bug-fix: remove internal editorial vocabulary from /briefing and /signals public surfaces

### DIFF
--- a/docs/engineering/bug-fixes/public-surface-copy-remediation-2026-05-07.md
+++ b/docs/engineering/bug-fixes/public-surface-copy-remediation-2026-05-07.md
@@ -14,11 +14,11 @@
 ## Fix
 - Exact change: remove the public `/briefing/[date]` `Why this ranks here` block, suppress the `What happened` section only when it duplicates the lead copy exactly, filter internal `/signals` tag badges, and replace the `/signals` internal header badge with reader-facing `Signals`.
 - Related PRD: none; bug-fix / public surface copy remediation only.
-- PR: pending.
+- PR: #202, `https://github.com/brandonma25/daily-intelligence-aggregator/pull/202`.
 - Branch: `bugfix/public-surface-copy-remediation`.
-- Head SHA: pending.
+- Head SHA: `4a9f348e37236f642dbda22ca1006f2f6441ea10` before PR metadata update.
 - Merge SHA: pending.
-- GitHub source-of-truth status: pending PR.
+- GitHub source-of-truth status: PR open.
 - External references reviewed, if any: Cowork analysis supplied in prompt, Product Position guidance supplied in prompt, and PR #201 scoped hotfix precedent.
 - Google Sheet / Work Log reference, if historically relevant: none used as a write target.
 - Branch cleanup status: pending post-merge cleanup.

--- a/docs/engineering/bug-fixes/public-surface-copy-remediation-2026-05-07.md
+++ b/docs/engineering/bug-fixes/public-surface-copy-remediation-2026-05-07.md
@@ -1,0 +1,57 @@
+# Public Surface Copy Remediation - Bug-Fix Record
+
+## Summary
+- Problem addressed: logged-out `/briefing/[date]` and `/signals` public pages exposed internal editorial vocabulary, generated ranking explanations, duplicated card copy, and architecture-facing breadcrumb language.
+- Root cause: the briefing detail card rendered generated homepage ranking-explanation text as reader copy and displayed the same card summary in both the lead and `What happened` slot when those fields matched; `/signals` rendered raw editorial tags and an internal header badge directly.
+- Affected object level: Card and Surface Placement.
+
+## Source Of Truth
+- Cowork frontend UX analysis 2026-05-06, prioritized shortlist Fix 3 and Fix 4.
+- Product Position guidance supplied with this remediation: signal cards should expose reader-facing card structure and should not surface unexplained importance or internal vocabulary.
+- PR #201 pattern: scoped public-surface bug fixes with no backend, data, ranking, source, pipeline, or admin-surface changes.
+- Canonical PRD required: no.
+
+## Fix
+- Exact change: remove the public `/briefing/[date]` `Why this ranks here` block, suppress the `What happened` section only when it duplicates the lead copy exactly, filter internal `/signals` tag badges, and replace the `/signals` internal header badge with reader-facing `Signals`.
+- Related PRD: none; bug-fix / public surface copy remediation only.
+- PR: pending.
+- Branch: `bugfix/public-surface-copy-remediation`.
+- Head SHA: pending.
+- Merge SHA: pending.
+- GitHub source-of-truth status: pending PR.
+- External references reviewed, if any: Cowork analysis supplied in prompt, Product Position guidance supplied in prompt, and PR #201 scoped hotfix precedent.
+- Google Sheet / Work Log reference, if historically relevant: none used as a write target.
+- Branch cleanup status: pending post-merge cleanup.
+
+## Fix Decisions
+- Fix 3a: removed the public `Why this ranks here` block because the available text is generated template copy from the homepage view model, not a trusted reader-facing card-specific field. The reader-facing `Why it matters` copy remains.
+- Fix 3b: treated the duplicate as a component-level presentation issue; the detail card now renders `What happened` only when it is distinct from the lead paragraph.
+- Fix 3c: removed the generated `Why this ranks here` block from public detail cards because identical template fallback text is not trustworthy as card-specific reasoning.
+- Fix 4a: removed raw internal tag labels from public `/signals` card metadata while preserving category tags such as `Finance`; no replacement tier badge was added because the public homepage/briefing surfaces do not already use a matching card-badge label.
+- Fix 4b: replaced `Published editorial layer` with `Signals`, matching the route-level public surface without claiming false freshness.
+
+## Terminology Requirement
+- [x] Confirmed object level before coding: Card and Surface Placement.
+- [x] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [x] Legacy runtime naming remains unchanged; no ranking, source, pipeline, WITM template, eligibility, or database logic was modified.
+
+## Validation
+- Automated checks:
+  - `npm install` passed with existing dependency audit warnings.
+  - `npm run test -- src/components/briefing/BriefingDetailView.test.tsx src/app/signals/page.test.tsx` passed.
+  - `npm run lint` passed.
+  - `npm run test` passed.
+  - `npm run build` passed with existing workspace-root and module-type warnings.
+  - `git diff --check` passed.
+  - `python3 scripts/validate-feature-system-csv.py` passed with existing PRD slug warnings.
+  - `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name bugfix/public-surface-copy-remediation --pr-title "bug-fix: remove internal editorial vocabulary from /briefing and /signals public surfaces"` passed.
+  - `python3 scripts/check-governance-hotspots.py --diff-mode local --branch-name bugfix/public-surface-copy-remediation --pr-title "bug-fix: remove internal editorial vocabulary from /briefing and /signals public surfaces"` passed.
+  - `python3 scripts/release-governance-gate.py --diff-mode local --branch-name bugfix/public-surface-copy-remediation --pr-title "bug-fix: remove internal editorial vocabulary from /briefing and /signals public surfaces"` passed.
+  - `python3 scripts/pr-governance-audit.py --diff-mode local --branch-name bugfix/public-surface-copy-remediation --pr-title "bug-fix: remove internal editorial vocabulary from /briefing and /signals public surfaces"` passed.
+- Human checks:
+  - Local browser `/signals` confirmed `Published editorial layer`, `watch`, and `High` were absent and the `Signals` public badge rendered.
+  - Local browser `/briefing/2026-05-06` did not have production snapshot data available, but confirmed `Why this ranks here` and `confirmed-event rail` were absent from the rendered page.
+  - Preview and production verification remain pending deployment.
+
+## Remaining Risks / Follow-up
+- Cowork Fix 5 and Fix 6 remain separate and out of scope for this PR.

--- a/src/app/signals/page.test.tsx
+++ b/src/app/signals/page.test.tsx
@@ -125,6 +125,38 @@ describe("public signals page", () => {
     expect(screen.queryByRole("heading", { name: "Context Signals" })).not.toBeInTheDocument();
   }, 10000);
 
+  it("renders reader-facing breadcrumb copy instead of internal editorial layer language", async () => {
+    getPublicSignalsPageState.mockResolvedValue({
+      kind: "published",
+      posts: Array.from({ length: 3 }, (_, index) => createPublishedPost(index + 1)),
+    });
+
+    const Page = (await import("@/app/signals/page")).default;
+    render(await Page());
+
+    expect(screen.getByText("Signals")).toBeInTheDocument();
+    expect(screen.getByText("3 signals")).toBeInTheDocument();
+    expect(screen.queryByText("Published editorial layer")).not.toBeInTheDocument();
+  }, 10000);
+
+  it("removes internal editorial tag labels while keeping the public category", async () => {
+    getPublicSignalsPageState.mockResolvedValue({
+      kind: "published",
+      posts: [
+        createPublishedPost(1, {
+          tags: ["Finance", "watch", "High"],
+        }),
+      ],
+    });
+
+    const Page = (await import("@/app/signals/page")).default;
+    render(await Page());
+
+    expect(screen.getByText("Finance")).toBeInTheDocument();
+    expect(screen.queryByText("watch")).not.toBeInTheDocument();
+    expect(screen.queryByText("High")).not.toBeInTheDocument();
+  }, 10000);
+
   it("shows a public-safe unavailable state without internal schema details", async () => {
     getPublicSignalsPageState.mockResolvedValue({
       kind: "temporarily_unavailable",

--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -18,6 +18,8 @@ export const metadata: Metadata = {
   title: "Published Signals",
 };
 
+const INTERNAL_PUBLIC_SIGNAL_TAGS = new Set(["critical", "high", "watch"]);
+
 export default async function PublicSignalsPage() {
   const state = await getPublicSignalsPageState();
   const posts = state.kind === "published" ? state.posts : [];
@@ -46,7 +48,7 @@ export default async function PublicSignalsPage() {
       <div className="space-y-5">
         <header className="space-y-4 border-b border-[var(--border)] pb-5">
           <div className="flex flex-wrap items-center gap-2">
-            <Badge>Published editorial layer</Badge>
+            <Badge>Signals</Badge>
             {hasPublishedPosts ? <Badge>{posts.length} signals</Badge> : <Badge>Briefing pending</Badge>}
           </div>
           <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
@@ -137,7 +139,7 @@ function SignalSection({
                 <div className="min-w-0 space-y-3">
                   <div>
                     <div className="flex flex-wrap gap-2">
-                      {post.tags.map((tag) => (
+                      {getPublicSignalTags(post).map((tag) => (
                         <Badge key={tag}>{tag}</Badge>
                       ))}
                     </div>
@@ -186,6 +188,10 @@ function SignalSection({
 
 function getPublicSignalDisplayRank(post: EditorialSignalPost) {
   return post.finalSlateRank ?? post.rank;
+}
+
+function getPublicSignalTags(post: EditorialSignalPost) {
+  return post.tags.filter((tag) => !INTERNAL_PUBLIC_SIGNAL_TAGS.has(tag.trim().toLowerCase()));
 }
 
 function isCorePublicSignal(post: EditorialSignalPost) {

--- a/src/components/briefing/BriefingDetailView.test.tsx
+++ b/src/components/briefing/BriefingDetailView.test.tsx
@@ -89,4 +89,20 @@ describe("BriefingDetailView", () => {
     expect(detailCard).not.toHaveClass("glass-panel");
     expect(detailCard).toHaveClass("border-transparent");
   });
+
+  it("does not render internal ranking explanation copy on public detail cards", () => {
+    render(<BriefingDetailView data={createData()} viewer={null} />);
+
+    expect(screen.queryByText(/why this ranks here/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/confirmed-event rail/i)).not.toBeInTheDocument();
+  });
+
+  it("does not duplicate the lead paragraph in the What happened section", () => {
+    const item = createItem();
+
+    render(<BriefingDetailView data={createData()} viewer={null} />);
+
+    expect(screen.getAllByText(item.whatHappened)).toHaveLength(1);
+    expect(screen.queryByText("What happened")).not.toBeInTheDocument();
+  });
 });

--- a/src/components/briefing/BriefingDetailView.tsx
+++ b/src/components/briefing/BriefingDetailView.tsx
@@ -113,6 +113,8 @@ function BriefingEventDetailCard({
   rank: number;
   featured: boolean;
 }) {
+  const showWhatHappened = hasDistinctReaderCopy(event.whatHappened, event.summary);
+
   return (
     <div
       className={cn("rounded-card border border-transparent bg-[var(--card)] p-5", featured && "p-6")}
@@ -142,16 +144,16 @@ function BriefingEventDetailCard({
           <p className="mt-3 text-base text-[var(--text-secondary)]">{event.summary}</p>
         </div>
 
-        <section className="space-y-2">
-          <p className="section-label">What happened</p>
-          <p className="text-base text-[var(--text-primary)]">{event.whatHappened}</p>
-        </section>
+        {showWhatHappened ? (
+          <section className="space-y-2">
+            <p className="section-label">What happened</p>
+            <p className="text-base text-[var(--text-primary)]">{event.whatHappened}</p>
+          </section>
+        ) : null}
 
         <section className="rounded-card border border-[var(--border)] bg-[var(--bg)] px-4 py-3">
           <p className="section-label">Why it matters</p>
           <p className="mt-2 text-base text-[var(--text-primary)]">{event.whyItMatters}</p>
-          <p className="mt-3 section-label">Why this ranks here</p>
-          <p className="mt-2 text-base text-[var(--text-secondary)]">{event.whyThisIsHere}</p>
         </section>
 
         {event.rankingSignals.length ? (
@@ -195,6 +197,17 @@ function BriefingEventDetailCard({
       </article>
     </div>
   );
+}
+
+function hasDistinctReaderCopy(value: string, comparison: string) {
+  const normalizedValue = normalizeReaderCopy(value);
+  const normalizedComparison = normalizeReaderCopy(comparison);
+
+  return Boolean(normalizedValue) && normalizedValue !== normalizedComparison;
+}
+
+function normalizeReaderCopy(value: string) {
+  return value.replace(/\s+/g, " ").trim().toLowerCase();
 }
 
 function CategorySoftGate({ redirectTo }: { redirectTo: string }) {


### PR DESCRIPTION
## Change Type
bug-fix / public surface copy remediation

## Source of Truth
- Cowork frontend UX analysis 2026-05-06, Fix 3 and Fix 4
- Product Position guidance supplied for public signal card structure and no internal vocabulary
- PR #201 scoped public-surface hotfix pattern

## Scope
- Remove the generated `/briefing/[date]` public `Why this ranks here` block.
- Suppress `What happened` on briefing detail cards only when it duplicates the lead paragraph exactly.
- Filter internal `/signals` tags (`watch`, `High`, `Critical`) while preserving reader-facing category tags such as `Finance`.
- Replace `/signals` header badge `Published editorial layer` with `Signals`.

## Out of Scope
- No backend, database, pipeline, source manifest, ranking, WITM template, editorial filter, or admin-surface changes.
- No Fix 5 or Fix 6 work.
- No homepage, category-tab, tier naming, page-title, empty-state, brand, or breadcrumb cleanup beyond the specific `/signals` header badge.

## Validation
- `npm install` passed with existing dependency audit warnings.
- `npm run test -- src/components/briefing/BriefingDetailView.test.tsx src/app/signals/page.test.tsx` passed.
- `npm run lint` passed.
- `npm run test` passed.
- `npm run build` passed with existing workspace-root and module-type warnings.
- `git diff --check` passed.
- `python3 scripts/validate-feature-system-csv.py` passed with existing PRD slug warnings.
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name bugfix/public-surface-copy-remediation --pr-title "bug-fix: remove internal editorial vocabulary from /briefing and /signals public surfaces"` passed.
- `python3 scripts/check-governance-hotspots.py --diff-mode local --branch-name bugfix/public-surface-copy-remediation --pr-title "bug-fix: remove internal editorial vocabulary from /briefing and /signals public surfaces"` passed.
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name bugfix/public-surface-copy-remediation --pr-title "bug-fix: remove internal editorial vocabulary from /briefing and /signals public surfaces"` passed.
- `python3 scripts/pr-governance-audit.py --diff-mode local --branch-name bugfix/public-surface-copy-remediation --pr-title "bug-fix: remove internal editorial vocabulary from /briefing and /signals public surfaces"` passed.
- Local browser `/signals` confirmed the internal labels were gone and the public `Signals` badge rendered.
- Local browser `/briefing/2026-05-06` did not have production snapshot data locally, but the removed internal ranking strings were absent.
