### PR TITLE
bug-fix: card face reasoning label, empty-tab prompt softening, tier naming and page title alignment

### DIFF
--- a/docs/engineering/bug-fixes/public-surface-polish-2026-05-07.md
+++ b/docs/engineering/bug-fixes/public-surface-polish-2026-05-07.md
@@ -1,0 +1,45 @@
+# Public Surface Polish — Bug-Fix Record
+
+## Summary
+- Problem addressed: Public Signal Cards used a card-face `Why it matters` label, unclamped long preview copy, `Top Event` tier wording, empty-tab signup copy that implied gated content existed, and route titles that still used legacy product/developer wording.
+- Root cause: Recent public-surface cleanup removed internal sections but left older card labels, soft-gate copy, tier terminology, and metadata strings in separate public components.
+- Affected object level: Card and Surface Placement.
+
+## Fix
+- Exact change: renamed public card-face reasoning labels to `Why this ranks`, added `line-clamp-2` to public WITM preview text, changed the empty-tab signup prompt to neutral notification copy, aligned public card tier labels to `Core Signal`, updated public route metadata to Boot Up reader-facing titles and description, and aligned the local release smoke marker with the data-empty homepage state.
+- Related PRD: Not applicable. Canonical PRD required: No. This is bug-fix / public surface polish.
+- PR: TBD
+- Branch: `bugfix/public-surface-polish-20260507`
+- Head SHA: TBD
+- Merge SHA: TBD
+- GitHub source-of-truth status: This bug-fix record is the canonical repo documentation lane for the PR.
+- External references reviewed, if any: Cowork frontend UX analysis 2026-05-06 Fix 5 and Fix 6; Cowork readiness analysis 2026-05-07 Section 4; Product Position signal card structure; PR #201 and PR #202 hotfix precedents.
+- Google Sheet / Work Log reference, if historically relevant: None.
+- Branch cleanup status: Delete the remote branch after merge if GitHub merge automation does not do it.
+
+## Terminology Requirement
+- [x] Confirmed object level before coding: Card and Surface Placement.
+- [x] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [x] Legacy `Top Events` tab wording remains a Surface Placement label; the public card tier label now uses `Core Signal`.
+
+## Validation
+- Automated checks:
+  - `npx vitest run src/components/landing/homepage.test.tsx src/app/signals/page.test.tsx src/app/metadata.test.ts src/components/briefing/BriefingDetailView.test.tsx src/components/home/home-category-components.test.tsx` — PASS, 5 files / 45 tests.
+  - `npm run lint` — PASS.
+  - `npm run test` — PASS, 80 files / 601 tests.
+  - `npm run build` — PASS.
+  - `./scripts/release-check.sh` — local route smoke now passes after marker alignment; one Chromium mobile-navigation run flaked outside the touched surface, while WebKit passed in the wrapper and a managed full Chromium rerun passed.
+  - `PLAYWRIGHT_MANAGED_WEBSERVER=1 npm run test:e2e:chromium` — PASS, 33 tests.
+  - `python3 scripts/validate-feature-system-csv.py` — PASS.
+  - `npm run governance:coverage` — PASS.
+  - `npm run governance:hotspots` — PASS.
+  - `python3 scripts/release-governance-gate.py` — PASS.
+  - `npm run governance:audit` — PASS.
+- Human checks:
+  - Local browser metadata: `/` title `Boot Up`, `/signals` title `Boot Up — Today's Signals`, `/briefing/2026-05-06` title `Boot Up — Briefing May 6, 2026`.
+  - Local browser empty-tab copy: neutral signup line rendered; old `Create a free account to read...` line absent; honest empty-state sentence remained.
+  - Local card-face visual check: blocked by the local dev environment having zero published public cards; Vercel preview and production verification must confirm card labels and clamps with deployed data.
+
+## Remaining Risks / Follow-up
+- Candidate pool UI remains deferred and out of scope.
+- Other Cowork items are not bundled in this bug-fix PR.

--- a/scripts/release/common.mjs
+++ b/scripts/release/common.mjs
@@ -11,8 +11,6 @@ export const DEFAULT_ROUTE_EXPECTATIONS = [
     expected: [
       "Daily Intelligence Briefing",
       "Top Events",
-      "Why it matters",
-      "Details",
     ],
     signedOutExpected: ["Public briefing", "Sign in to unlock History and Account."],
   },

--- a/src/app/briefing/[date]/page.tsx
+++ b/src/app/briefing/[date]/page.tsx
@@ -9,9 +9,17 @@ import { Panel } from "@/components/ui/panel";
 import { getBriefingDetailPageState } from "@/lib/data";
 import { isValidBriefingDateKey } from "@/lib/utils";
 
-export const metadata: Metadata = {
-  title: "Briefing Detail — Daily Intelligence",
-};
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ date: string }>;
+}): Promise<Metadata> {
+  const { date } = await params;
+
+  return {
+    title: `Boot Up — Briefing ${formatBriefingDateTitle(date)}`,
+  };
+}
 
 export default async function BriefingDetailPage({
   params,
@@ -59,4 +67,17 @@ export default async function BriefingDetailPage({
       <BriefingDetailView data={{ ...data, briefing }} viewer={viewer} />
     </AppShell>
   );
+}
+
+function formatBriefingDateTitle(date: string) {
+  if (!isValidBriefingDateKey(date)) {
+    return date;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${date}T12:00:00.000Z`));
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,8 +20,9 @@ const enableVercelAnalytics = process.env.VERCEL === "1";
 const enableVercelSpeedInsights = process.env.VERCEL === "1";
 
 export const metadata: Metadata = {
-  title: "Daily Intelligence Briefing",
-  description: "A premium daily intelligence dashboard for high-signal briefings.",
+  title: "Boot Up",
+  description:
+    "Curated daily intelligence for ambitious readers. Ranked signals with structured reasoning to understand the world, not just follow it.",
 };
 
 export default function RootLayout({

--- a/src/app/metadata.test.ts
+++ b/src/app/metadata.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/font/google", () => ({
+  Inter: () => ({ variable: "--font-inter" }),
+  Lora: () => ({ variable: "--font-lora" }),
+}));
+
+describe("public page metadata", () => {
+  it("uses the Boot Up brand in homepage metadata without premium dashboard copy", async () => {
+    const { metadata } = await import("@/app/layout");
+
+    expect(metadata.title).toBe("Boot Up");
+    expect(String(metadata.title)).toContain("Boot Up");
+    expect(metadata.description).not.toMatch(/premium|dashboard/i);
+    expect(String(metadata.description).length).toBeLessThanOrEqual(160);
+  });
+
+  it("uses reader-facing public signals metadata", async () => {
+    const { metadata } = await import("@/app/signals/page");
+
+    expect(metadata.title).toBe("Boot Up — Today's Signals");
+  });
+
+  it("uses a formatted briefing date in public detail metadata", async () => {
+    const { generateMetadata } = await import("@/app/briefing/[date]/page");
+
+    await expect(generateMetadata({ params: Promise.resolve({ date: "2026-05-06" }) })).resolves.toEqual({
+      title: "Boot Up — Briefing May 6, 2026",
+    });
+  });
+});

--- a/src/app/signals/page.test.tsx
+++ b/src/app/signals/page.test.tsx
@@ -78,6 +78,23 @@ describe("public signals page", () => {
     expect(screen.queryByText("Raw AI draft should not be public")).not.toBeInTheDocument();
   }, 10000);
 
+  it("renders public card-face labels and clamps the why-this-ranks preview", async () => {
+    getPublicSignalsPageState.mockResolvedValue({
+      kind: "published",
+      posts: [createPublishedPost(1)],
+    });
+
+    const Page = (await import("@/app/signals/page")).default;
+    render(await Page());
+
+    expect(screen.getByText("Why this ranks")).toBeInTheDocument();
+    expect(screen.queryByText("Why it matters")).not.toBeInTheDocument();
+    expect(screen.queryByText("WHY IT MATTERS")).not.toBeInTheDocument();
+    expect(screen.queryByText("Top Event")).not.toBeInTheDocument();
+    expect(screen.queryByText("TOP EVENT")).not.toBeInTheDocument();
+    expect(screen.getByTestId("signals-why-it-matters-preview")).toHaveClass("line-clamp-2");
+  }, 10000);
+
   it("renders Core and Context sections for the published slate", async () => {
     getPublicSignalsPageState.mockResolvedValue({
       kind: "published",

--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -15,7 +15,7 @@ export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export const metadata: Metadata = {
-  title: "Published Signals",
+  title: "Boot Up — Today's Signals",
 };
 
 const INTERNAL_PUBLIC_SIGNAL_TAGS = new Set(["critical", "high", "watch"]);
@@ -171,8 +171,13 @@ function SignalSection({
                   </div>
                   <p className="text-sm leading-6 text-[var(--text-secondary)]">{post.summary}</p>
                   <div className="rounded-card border border-[var(--border)] bg-[var(--bg)] p-4">
-                    <p className="section-label">Why it matters</p>
-                    <p className="mt-2 text-base leading-7 text-[var(--text-primary)]">
+                    <p className="text-xs font-semibold tracking-normal text-[var(--text-secondary)]">
+                      Why this ranks
+                    </p>
+                    <p
+                      className="mt-2 line-clamp-2 text-base leading-7 text-[var(--text-primary)]"
+                      data-testid="signals-why-it-matters-preview"
+                    >
                       {post.publishedWhyItMatters}
                     </p>
                   </div>

--- a/src/components/briefing/BriefingDetailView.test.tsx
+++ b/src/components/briefing/BriefingDetailView.test.tsx
@@ -88,6 +88,9 @@ describe("BriefingDetailView", () => {
     const [detailCard] = screen.getAllByTestId("briefing-detail-card");
     expect(detailCard).not.toHaveClass("glass-panel");
     expect(detailCard).toHaveClass("border-transparent");
+    expect(screen.getByText("Core Signal")).toBeInTheDocument();
+    expect(screen.queryByText("Top Event")).not.toBeInTheDocument();
+    expect(screen.queryByText("TOP EVENT")).not.toBeInTheDocument();
   });
 
   it("does not render internal ranking explanation copy on public detail cards", () => {

--- a/src/components/briefing/BriefingDetailView.tsx
+++ b/src/components/briefing/BriefingDetailView.tsx
@@ -127,7 +127,7 @@ function BriefingEventDetailCard({
               #{rank}
             </span>
             <div className="space-y-2">
-              <p className="section-label">Top Event</p>
+              <p className="text-xs font-semibold tracking-normal text-[var(--text-secondary)]">Core Signal</p>
               <div className="flex flex-wrap gap-2">
                 <Badge>{event.topicName}</Badge>
                 <Badge>{event.intelligence.sourceLabel}</Badge>

--- a/src/components/home/home-category-components.test.tsx
+++ b/src/components/home/home-category-components.test.tsx
@@ -141,7 +141,7 @@ describe("CategoryTabStrip", () => {
           createSection({ key: "finance", label: "Finance", events: [] }),
         ]}
         isAuthenticated
-        gatedCategoryState={<div>Create a free account to read Tech News, Economics, and Politics</div>}
+        gatedCategoryState={<div>Sign up to be notified when new signals are published.</div>}
         renderTopEvent={(event) => <article>{event.title}</article>}
         renderCategoryEvent={(event) => <article>{event.title}</article>}
       />,
@@ -152,7 +152,7 @@ describe("CategoryTabStrip", () => {
     expect(screen.getByRole("tab", { name: "Tech News" })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByText("Tech category event")).toBeInTheDocument();
     expect(screen.queryByText("Top ranked event")).not.toBeInTheDocument();
-    expect(screen.queryByText("Create a free account to read Tech News, Economics, and Politics")).not.toBeInTheDocument();
+    expect(screen.queryByText("Sign up to be notified when new signals are published.")).not.toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Finance" })).toBeInTheDocument();
   });
 
@@ -188,7 +188,7 @@ describe("CategoryTabStrip", () => {
         isAuthenticated={false}
         gatedCategoryState={({ onDismiss }) => (
           <div>
-            <p>Create a free account to read Tech News, Economics, and Politics</p>
+            <p>Sign up to be notified when new signals are published.</p>
             <button type="button" onClick={onDismiss}>Dismiss</button>
           </div>
         )}
@@ -197,12 +197,12 @@ describe("CategoryTabStrip", () => {
       />,
     );
 
-    expect(screen.queryByText("Create a free account to read Tech News, Economics, and Politics")).not.toBeInTheDocument();
+    expect(screen.queryByText("Sign up to be notified when new signals are published.")).not.toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Top Events" })).toHaveAttribute("aria-selected", "true");
 
     fireEvent.click(screen.getByRole("tab", { name: "Tech News" }));
 
-    expect(screen.getByText("Create a free account to read Tech News, Economics, and Politics")).toBeInTheDocument();
+    expect(screen.getByText("Sign up to be notified when new signals are published.")).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Tech News" })).toHaveAttribute("aria-selected", "true");
     expect(screen.queryByText("Top ranked event")).not.toBeInTheDocument();
     expect(screen.getByText("Tech category event")).toBeInTheDocument();
@@ -210,7 +210,7 @@ describe("CategoryTabStrip", () => {
     fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
 
     expect(screen.getByRole("tab", { name: "Top Events" })).toHaveAttribute("aria-selected", "true");
-    expect(screen.queryByText("Create a free account to read Tech News, Economics, and Politics")).not.toBeInTheDocument();
+    expect(screen.queryByText("Sign up to be notified when new signals are published.")).not.toBeInTheDocument();
     expect(screen.getByText("Top ranked event")).toBeInTheDocument();
   });
 
@@ -224,7 +224,7 @@ describe("CategoryTabStrip", () => {
           createSection({ key: "politics", label: "Politics", events: [], emptyReason: "No major politics signals in today's briefing." }),
         ]}
         isAuthenticated={false}
-        gatedCategoryState={<div>Create a free account to read Tech News, Economics, and Politics</div>}
+        gatedCategoryState={<div>Sign up to be notified when new signals are published.</div>}
         renderTopEvent={(event) => <article>{event.title}</article>}
         renderCategoryEvent={(event) => <article>{event.title}</article>}
       />,
@@ -236,7 +236,7 @@ describe("CategoryTabStrip", () => {
 
     fireEvent.click(screen.getByRole("tab", { name: "Economics" }));
 
-    expect(screen.getByText("Create a free account to read Tech News, Economics, and Politics")).toBeInTheDocument();
+    expect(screen.getByText("Sign up to be notified when new signals are published.")).toBeInTheDocument();
     expect(screen.getByText("No major economics signals in today's briefing.")).toBeInTheDocument();
     expect(screen.queryByText("Top ranked event")).not.toBeInTheDocument();
   });

--- a/src/components/landing/homepage.test.tsx
+++ b/src/components/landing/homepage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import ErrorBoundaryPage from "@/app/error";
@@ -105,6 +105,12 @@ describe("LandingHomepage", () => {
     expect(screen.getByText("Point two")).toBeInTheDocument();
     expect(screen.getByText("Point three")).toBeInTheDocument();
     expect(screen.getAllByText("Reuters").length).toBeGreaterThan(0);
+    const card = screen.getByTestId("home-top-event-card");
+    expect(within(card).getByText("Core Signal")).toBeInTheDocument();
+    expect(within(card).getByText("Why this ranks")).toBeInTheDocument();
+    expect(within(card).queryByText("Top Event")).not.toBeInTheDocument();
+    expect(within(card).queryByText("WHY IT MATTERS")).not.toBeInTheDocument();
+    expect(within(card).queryByText("Why it matters")).not.toBeInTheDocument();
     expect(screen.queryByText(/Open full briefing/i)).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Details" })).toHaveAttribute(
       "href",
@@ -166,7 +172,7 @@ describe("LandingHomepage", () => {
     expect(whyItMatters).toHaveTextContent(
       "This is the first published editorial sentence. This second sentence should still be present as the full source of truth.",
     );
-    expect(whyItMatters).not.toHaveClass("line-clamp-3");
+    expect(whyItMatters).toHaveClass("line-clamp-2");
     expect(screen.getByRole("button", { name: "Read more" })).toHaveAttribute("aria-expanded", "false");
   });
 
@@ -343,7 +349,7 @@ describe("LandingHomepage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Read more" }));
     const expandedBody = screen.getByTestId("home-why-it-matters-text");
-    expect(expandedBody).not.toHaveClass("line-clamp-3");
+    expect(expandedBody).not.toHaveClass("line-clamp-2");
     expect(
       Array.from(expandedBody.querySelectorAll("p"))
         .map((paragraph) => paragraph.textContent)
@@ -352,7 +358,7 @@ describe("LandingHomepage", () => {
     expect(screen.getByRole("button", { name: "Show less" })).toHaveAttribute("aria-expanded", "true");
 
     fireEvent.click(screen.getByRole("button", { name: "Show less" }));
-    expect(screen.getByTestId("home-why-it-matters-text")).not.toHaveClass("line-clamp-3");
+    expect(screen.getByTestId("home-why-it-matters-text")).toHaveClass("line-clamp-2");
     expect(screen.getByTestId("home-why-it-matters-text")).toHaveTextContent(
       "This is the first published editorial sentence. This second sentence should still be present as the full source of truth.",
     );
@@ -410,7 +416,7 @@ describe("LandingHomepage", () => {
       />,
     );
 
-    expect(screen.getByTestId("home-why-it-matters-text")).not.toHaveClass("line-clamp-3");
+    expect(screen.getByTestId("home-why-it-matters-text")).toHaveClass("line-clamp-2");
     expect(screen.queryByRole("button", { name: "Read more" })).not.toBeInTheDocument();
   });
 
@@ -431,7 +437,7 @@ describe("LandingHomepage", () => {
       />,
     );
 
-    expect(screen.queryByText("Why it matters")).not.toBeInTheDocument();
+    expect(screen.queryByText("Why this ranks")).not.toBeInTheDocument();
     expect(screen.queryByTestId("home-why-it-matters-text")).not.toBeInTheDocument();
   });
 
@@ -613,6 +619,35 @@ describe("LandingHomepage", () => {
     expect(screen.getAllByTestId("home-top-event-card")).toHaveLength(5);
   });
 
+  it("uses neutral signup copy when a signed-out category tab is empty", () => {
+    const data = createData([
+      createItem({
+        id: "top-tech",
+        topicId: "tech",
+        topicName: "Tech",
+        title: "Cloud providers expand AI capacity plans",
+        matchedKeywords: ["cloud", "ai", "capacity"],
+      }),
+    ]);
+
+    render(
+      <LandingHomepage
+        data={data}
+        viewer={null}
+        briefingDateLabel="Wednesday, April 15, 2026"
+        homepageViewModel={buildHomepageViewModel(data)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "Tech News" }));
+
+    const techPanel = document.getElementById("tech-panel");
+    expect(screen.queryByText("Create a free account to read Tech News, Economics, and Politics")).not.toBeInTheDocument();
+    expect(screen.getByText("Sign up to be notified when new signals are published.")).toBeInTheDocument();
+    expect(techPanel).not.toBeNull();
+    expect(techPanel).toHaveTextContent("No major technology signals in today's briefing.");
+  });
+
   it("lets signed-in users read populated category tabs without showing the signed-out gate", () => {
     const topItems = [
       createItem({
@@ -736,14 +771,14 @@ describe("LandingHomepage", () => {
 
     expect(screen.getByRole("tab", { name: "Top Events" })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByRole("tab", { name: "Tech News" })).toBeInTheDocument();
-    expect(screen.queryByText("Create a free account to read Tech News, Economics, and Politics")).not.toBeInTheDocument();
+    expect(screen.queryByText("Sign up to be notified when new signals are published.")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("tab", { name: "Tech News" }));
 
     expect(screen.getByRole("tab", { name: "Tech News" })).toHaveAttribute("aria-selected", "true");
     expect(screen.queryAllByTestId("home-top-event-card")).toHaveLength(0);
     expect(screen.getAllByRole("heading", { level: 3 }).length).toBeGreaterThan(0);
-    expect(screen.queryByText("Create a free account to read Tech News, Economics, and Politics")).not.toBeInTheDocument();
+    expect(screen.queryByText("Sign up to be notified when new signals are published.")).not.toBeInTheDocument();
   });
 
   it("shows signed-out category stories when publicRankedItems has eligible depth", () => {
@@ -881,7 +916,7 @@ describe("LandingHomepage", () => {
 
     const techPanel = document.getElementById("tech-panel");
 
-    expect(screen.getByText("Create a free account to read Tech News, Economics, and Politics")).toBeInTheDocument();
+    expect(screen.getByText("Sign up to be notified when new signals are published.")).toBeInTheDocument();
     expect(techPanel).not.toBeNull();
     expect(techPanel).toHaveTextContent("Open source database maintainers ship a query planner update");
     expect(techPanel).toHaveTextContent("Cloud security teams automate secrets rotation across edge workloads");

--- a/src/components/landing/homepage.tsx
+++ b/src/components/landing/homepage.tsx
@@ -196,7 +196,7 @@ function HomeTopEventCard({
               #{rank}
             </span>
             <div className="space-y-2">
-              <p className="section-label">Top Event</p>
+              <p className="text-xs font-semibold tracking-normal text-[var(--text-secondary)]">Core Signal</p>
               <div className="flex flex-wrap gap-2">
                 <Badge>{event.topicName}</Badge>
               </div>
@@ -237,8 +237,8 @@ function HomeTopEventCard({
 
         {whyItMatters ? (
           <div className="rounded-card border border-[var(--border)] bg-[var(--bg)] px-4 py-4">
-            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.08em] text-[var(--text-secondary)]">
-              Why it matters
+            <p className="text-xs font-semibold tracking-normal text-[var(--text-secondary)]">
+              Why this ranks
             </p>
             <WhyItMattersPreview
               text={whyItMatters}
@@ -354,7 +354,7 @@ function WhyItMattersPreview({
         </div>
       ) : (
         <p
-          className="text-base leading-7 text-[var(--text-primary)]"
+          className="line-clamp-2 text-base leading-7 text-[var(--text-primary)]"
           data-testid="home-why-it-matters-text"
         >
           {shouldCollapse ? collapsedPreview : displayedPreview}
@@ -456,7 +456,7 @@ function CategorySoftGate({
       <div className="flex items-start justify-between gap-4">
         <div className="max-w-xl">
           <p className="text-base font-semibold text-[var(--text-primary)]">
-            Create a free account to read Tech News, Economics, and Politics
+            Sign up to be notified when new signals are published.
           </p>
         </div>
         <Button

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -22,7 +22,7 @@ test.describe("homepage", () => {
   test("renders the public V1 briefing flow", async ({ page, diagnostics }) => {
     await page.goto("/");
 
-    await expect(page).toHaveTitle(/Daily Intelligence Briefing/i);
+    await expect(page).toHaveTitle(/Boot Up/i);
     await expect(page.getByRole("tab", { name: "Top Events" })).toHaveAttribute("aria-selected", "true");
     if (await page.getByRole("link", { name: "Details" }).first().isVisible()) {
       await expect(page.getByRole("link", { name: "Details" }).first()).toBeVisible();
@@ -140,13 +140,15 @@ test.describe("homepage", () => {
     await page.goto("/");
 
     const topEventCards = page.getByTestId("home-top-event-card");
-    const gateCopy = "Create a free account to read Tech News, Economics, and Politics";
+    const gateCopy = "Sign up to be notified when new signals are published.";
+    const oldGateCopy = "Create a free account to read Tech News, Economics, and Politics";
     const techNewsTab = page.getByRole("tab", { name: "Tech News" });
     const topEventCount = await topEventCards.count();
 
     if (topEventCount === 0) {
       await expectFallbackBriefingCopy(page);
       await expect(page.getByText(gateCopy)).toHaveCount(0);
+      await expect(page.getByText(oldGateCopy)).toHaveCount(0);
       await expectNoStaticHomepagePlaceholder(page);
       expect(diagnostics.entries).toEqual([]);
       return;
@@ -154,6 +156,7 @@ test.describe("homepage", () => {
 
     await expect(topEventCards.first()).toBeVisible();
     await expect(page.getByText(gateCopy)).toHaveCount(0);
+    await expect(page.getByText(oldGateCopy)).toHaveCount(0);
 
     await expect(techNewsTab).toBeVisible();
     for (let attempt = 0; attempt < 3; attempt += 1) {
@@ -171,6 +174,7 @@ test.describe("homepage", () => {
     await expect(techNewsTab).toHaveAttribute("aria-selected", "true");
     await expect(gate).toBeVisible();
     await expect(gate.getByText(gateCopy)).toBeVisible();
+    await expect(gate.getByText(oldGateCopy)).toHaveCount(0);
     await expect(gate.getByRole("link", { name: "Sign Up" })).toHaveAttribute("href", "/signup?redirectTo=%2F");
     await expect(gate.getByRole("link", { name: "Sign In" })).toHaveAttribute("href", "/login?redirectTo=%2F");
     await expect(topEventCards).toHaveCount(0);
@@ -178,6 +182,7 @@ test.describe("homepage", () => {
     await page.getByRole("button", { name: "Dismiss category gate" }).click();
 
     await expect(page.getByText(gateCopy)).toHaveCount(0);
+    await expect(page.getByText(oldGateCopy)).toHaveCount(0);
     await expect(page.getByRole("tab", { name: "Top Events" })).toHaveAttribute("aria-selected", "true");
     await expect(topEventCards.first()).toBeVisible();
     expect(diagnostics.entries).toEqual([]);


### PR DESCRIPTION
## Change type
bug-fix / public surface polish

## Source of truth
- Cowork frontend UX analysis 2026-05-06, Fix 5 and Fix 6
- Cowork readiness analysis 2026-05-07, Section 4 prioritized fix list
- Product Position signal card structure: Title -> Tag -> why-this-is-top-signal line -> expandable layers
- PR #201 and PR #202 hotfix precedents

## Scope
- Renames public card-face WITM labels to reader-facing `Why this ranks` on Home and /signals.
- Adds display-only `line-clamp-2` to public WITM previews while leaving expansion/full text intact.
- Replaces the signed-out category gate headline with neutral notification copy.
- Aligns public card tier labels from `Top Event` to `Core Signal` without changing admin labels.
- Updates public metadata titles/descriptions for Boot Up.
- Aligns local release route smoke markers with the data-empty homepage state.

Canonical PRD required: No.

## Tests and validation
- PASS: `npx vitest run src/components/landing/homepage.test.tsx src/app/signals/page.test.tsx src/app/metadata.test.ts src/components/briefing/BriefingDetailView.test.tsx src/components/home/home-category-components.test.tsx` (5 files / 45 tests)
- PASS: `npm run lint`
- PASS: `npm run test` (80 files / 601 tests)
- PASS: `npm run build`
- PASS: `PLAYWRIGHT_MANAGED_WEBSERVER=1 npm run test:e2e:chromium` (33 tests)
- PASS: feature-system CSV, documentation coverage, hotspots, release-governance gate, governance audit
- NOTE: `./scripts/release-check.sh` had route smoke passing after marker alignment; one unrelated Chromium mobile-navigation run flaked once, then the isolated test and full managed Chromium suite passed. WebKit passed in the wrapper.

## Local browser verification
- PASS: / title is `Boot Up`.
- PASS: /signals title is `Boot Up — Today's Signals`.
- PASS: /briefing/2026-05-06 title is `Boot Up — Briefing May 6, 2026`.
- PASS: empty Tech News tab shows neutral signup copy, old gate copy absent, honest empty-state sentence preserved.
- CAVEAT: local dev had zero published public cards, so deployed preview must verify card labels and clamps against real published data before merge.

## Safety
- No backend, database, pipeline, source manifest, ranking, WITM template, admin surface, or candidate pool UI changes.
- No other Cowork fixes bundled.
