### PR TITLE
bug-fix: duplicate card content, empty-tab gate removal, category taxonomy reconciliation

### DIFF
--- a/docs/engineering/bug-fixes/public-card-tabs-remediation-2026-05-08.md
+++ b/docs/engineering/bug-fixes/public-card-tabs-remediation-2026-05-08.md
@@ -21,9 +21,9 @@
 ## Fix
 - Exact change: dedupe Home Card key points against title, lead summary, and `whatHappened`; render the signed-out category gate only when the active category tab has content; rename public tabs to `Tech`, `Finance`, and `Politics`; and allow the top published set to populate category tabs whenever no broader non-top depth pool exists.
 - Related PRD: None.
-- PR: TBD.
+- PR: https://github.com/brandonma25/daily-intelligence-aggregator/pull/205.
 - Branch: `fix/public-card-tabs-remediation-20260508`.
-- Head SHA: TBD.
+- Head SHA at PR creation: `cb6520f5a9c24ddf76cd987849a362677ce2bb72`.
 - Merge SHA: TBD.
 - GitHub source-of-truth status: pending PR.
 - External references reviewed, if any: prompt-supplied Cowork analyses, Product Position guidance, production homepage payload, PR #202, PR #204.

--- a/docs/engineering/bug-fixes/public-card-tabs-remediation-2026-05-08.md
+++ b/docs/engineering/bug-fixes/public-card-tabs-remediation-2026-05-08.md
@@ -1,0 +1,60 @@
+# Public Card Tabs Remediation - Bug-Fix Record
+
+## Summary
+- Problem addressed: published Home Cards repeated the lead summary as the first bullet, empty signed-out category tabs showed the signup gate before the honest empty state, and category navigation used labels and filtering that left the current three-card published slate out of matching tabs.
+- Root cause: the Home Card only deduped key points against the title, the category tab component rendered the signed-out gate for every signed-out category tab regardless of content count, and the public tab labels plus fallback filter drifted from the runtime `signal_posts.tags` values and current three-row published slate shape.
+- Affected object level: Card and Surface Placement.
+
+## Source Of Truth
+- Cowork eliminate-only analysis 2026-05-08 subtraction-lens shortlist.
+- Cowork frontend UX analysis 2026-05-06 taxonomy mismatch diagnosis.
+- Production homepage HTML/RSC payload fetched 2026-05-08 from `https://daily-intelligence-aggregator-ybs9.vercel.app/`.
+- Product Position fail-closed empty-state principle, no false freshness, and Signal Card structure guidance supplied by PM.
+- PR #202 and PR #204 GitHub diffs.
+- Canonical PRD required: No.
+
+## Diagnosis
+- Fix A: `src/components/landing/homepage.tsx` rendered `event.summary` as the lead paragraph and then rendered `event.keyPoints` after filtering only against the title. Production RSC data showed all three cards had identical `whatHappened` and first `keyPoints` text. PR #202 fixed this pattern only in `src/components/briefing/BriefingDetailView.tsx`, so the Home Card variant remained unchanged.
+- Fix B: `src/components/home/CategoryTabStrip.tsx` rendered `gatedCategoryState` whenever a signed-out category tab was active. PR #204 only softened the gate copy in `src/components/landing/homepage.tsx`, so empty tabs still showed signup controls before the empty-state sentence.
+- Fix C: `signal_posts` has `tags`, not a dedicated category column. Production tags surfaced through Home data as `["Finance", "watch", "High"]` for both finance cards and `["Tech", "watch", "High"]` for the tech card. Tab labels were `Tech News` and `Economics`, while filtering used normalized keys `tech`, `finance`, and `politics`. A second frontend-only gap excluded all top-card IDs unless the published set had exactly five rows, so the current three-row slate could not populate category tabs even when categories matched.
+
+## Fix
+- Exact change: dedupe Home Card key points against title, lead summary, and `whatHappened`; render the signed-out category gate only when the active category tab has content; rename public tabs to `Tech`, `Finance`, and `Politics`; and allow the top published set to populate category tabs whenever no broader non-top depth pool exists.
+- Related PRD: None.
+- PR: TBD.
+- Branch: `fix/public-card-tabs-remediation-20260508`.
+- Head SHA: TBD.
+- Merge SHA: TBD.
+- GitHub source-of-truth status: pending PR.
+- External references reviewed, if any: prompt-supplied Cowork analyses, Product Position guidance, production homepage payload, PR #202, PR #204.
+- Google Sheet / Work Log reference, if historically relevant: none used as a write target.
+- Branch cleanup status: pending post-merge cleanup.
+
+## Terminology Requirement
+- [x] Confirmed object level before coding: Card and Surface Placement.
+- [x] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [x] Legacy `signal_posts` naming remains treated as Surface Placement plus Card copy/read-model storage.
+
+## Validation
+- Automated checks:
+  - `npm install` - PASS with existing audit warnings.
+  - `npx vitest run src/components/landing/homepage.test.tsx src/components/home/home-category-components.test.tsx src/lib/homepage-model.test.ts` - PASS, 3 files / 67 tests.
+  - `npx vitest run src/components/landing/homepage.test.tsx src/app/signals/page.test.tsx src/app/metadata.test.ts src/components/briefing/BriefingDetailView.test.tsx src/components/home/home-category-components.test.tsx src/lib/homepage-model.test.ts` - PASS, 6 files / 80 tests.
+  - `npm run lint` - PASS.
+  - `npm run test` - PASS, 80 files / 603 tests.
+  - `npm run build` - PASS with existing workspace-root and module-type warnings.
+  - `PLAYWRIGHT_MANAGED_WEBSERVER=1 npm run test:e2e:chromium` - PASS, 33 tests.
+  - `PLAYWRIGHT_MANAGED_WEBSERVER=1 npm run test:e2e:webkit` - PASS, 33 tests.
+  - `python3 scripts/validate-feature-system-csv.py` - PASS with existing PRD slug warnings.
+  - `npm run governance:coverage` - PASS.
+  - `npm run governance:hotspots` - PASS.
+  - `python3 scripts/release-governance-gate.py` - PASS.
+  - `npm run governance:audit` - PASS.
+  - `git diff --check` - PASS.
+- Human checks:
+  - Local browser QA on `http://localhost:3000/` confirmed `Top Events`, `Tech`, `Finance`, and `Politics` tabs render; `Tech News` and `Economics` tabs are absent; empty signed-out category tabs render the honest empty-state sentence without `category-soft-gate`.
+  - Post-deploy production verification pending.
+
+## Remaining Risks / Follow-up
+- Cowork eliminate-list residual items remain deferred: mobile bottom nav and Developing/Updated badges.
+- No backend, schema, migration, source manifest, ranking, WITM template, eligibility filter, admin surface, publish path, pipeline, or production data writes are included.

--- a/src/components/home/CategoryTabStrip.tsx
+++ b/src/components/home/CategoryTabStrip.tsx
@@ -64,7 +64,7 @@ export function CategoryTabStrip({
       topEventsTab,
       ...visibleCategorySections.map((section) => ({
         key: section.key,
-        label: section.key === "tech" ? "Tech News" : section.label,
+        label: section.label,
       })),
     ],
     [visibleCategorySections],
@@ -128,48 +128,44 @@ export function CategoryTabStrip({
         {topEventsContent}
       </TabsContent>
 
-      {visibleCategorySections.map((section) => (
-        <TabsContent
-          key={section.key}
-          id={`${section.key}-panel`}
-          active={safeActiveTab === section.key}
-        >
-          {activeCategoryIsGated ? (
-            <div className="space-y-5">
-              {renderedGatedCategoryState}
-              <div className="grid gap-4">
-                {section.events.length ? (
-                  section.events.map((event, index) => (
-                    <div key={event.id}>{renderCategoryEvent(event, section, index)}</div>
-                  ))
-                ) : (
-                  <div
-                    className="rounded-card border border-[var(--border)] bg-[var(--card)] px-4 py-5 text-sm text-[var(--text-secondary)]"
-                    role="status"
-                  >
-                    {section.emptyReason}
-                  </div>
-                )}
+      {visibleCategorySections.map((section) => {
+        const sectionHasEvents = section.events.length > 0;
+        const shouldRenderGate =
+          activeCategoryIsGated && safeActiveTab === section.key && sectionHasEvents;
+        const sectionContent = (
+          <div className="grid gap-4">
+            {sectionHasEvents ? (
+              section.events.map((event, index) => (
+                <div key={event.id}>{renderCategoryEvent(event, section, index)}</div>
+              ))
+            ) : (
+              <div
+                className="rounded-card border border-[var(--border)] bg-[var(--card)] px-4 py-5 text-sm text-[var(--text-secondary)]"
+                role="status"
+              >
+                {section.emptyReason}
               </div>
-            </div>
-          ) : (
-            <div className="grid gap-4">
-              {section.events.length ? (
-                section.events.map((event, index) => (
-                  <div key={event.id}>{renderCategoryEvent(event, section, index)}</div>
-                ))
-              ) : (
-                <div
-                  className="rounded-card border border-[var(--border)] bg-[var(--card)] px-4 py-5 text-sm text-[var(--text-secondary)]"
-                  role="status"
-                >
-                  {section.emptyReason}
-                </div>
-              )}
-            </div>
-          )}
-        </TabsContent>
-      ))}
+            )}
+          </div>
+        );
+
+        return (
+          <TabsContent
+            key={section.key}
+            id={`${section.key}-panel`}
+            active={safeActiveTab === section.key}
+          >
+            {shouldRenderGate ? (
+              <div className="space-y-5">
+                {renderedGatedCategoryState}
+                {sectionContent}
+              </div>
+            ) : (
+              sectionContent
+            )}
+          </TabsContent>
+        );
+      })}
     </Tabs>
   );
 }

--- a/src/components/home/home-category-components.test.tsx
+++ b/src/components/home/home-category-components.test.tsx
@@ -97,7 +97,7 @@ describe("CategoryTabStrip", () => {
     );
 
     expect(screen.getByRole("tab", { name: "Top Events" })).toHaveAttribute("aria-selected", "true");
-    expect(screen.getByRole("tab", { name: "Tech News" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Tech" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Finance" })).toBeInTheDocument();
     expect(screen.getByText("Top ranked event")).toBeInTheDocument();
   });
@@ -147,9 +147,9 @@ describe("CategoryTabStrip", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("tab", { name: "Tech News" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Tech" }));
 
-    expect(screen.getByRole("tab", { name: "Tech News" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Tech" })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByText("Tech category event")).toBeInTheDocument();
     expect(screen.queryByText("Top ranked event")).not.toBeInTheDocument();
     expect(screen.queryByText("Sign up to be notified when new signals are published.")).not.toBeInTheDocument();
@@ -172,7 +172,7 @@ describe("CategoryTabStrip", () => {
     );
 
     expect(screen.getByRole("tab", { name: "Top Events" })).toHaveAttribute("aria-selected", "true");
-    expect(screen.getByRole("tab", { name: "Tech News" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Tech" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Finance" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Politics" })).toBeInTheDocument();
     expect(screen.getByText("Top ranked event")).toBeInTheDocument();
@@ -200,10 +200,10 @@ describe("CategoryTabStrip", () => {
     expect(screen.queryByText("Sign up to be notified when new signals are published.")).not.toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Top Events" })).toHaveAttribute("aria-selected", "true");
 
-    fireEvent.click(screen.getByRole("tab", { name: "Tech News" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Tech" }));
 
     expect(screen.getByText("Sign up to be notified when new signals are published.")).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Tech News" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Tech" })).toHaveAttribute("aria-selected", "true");
     expect(screen.queryByText("Top ranked event")).not.toBeInTheDocument();
     expect(screen.getByText("Tech category event")).toBeInTheDocument();
 
@@ -219,8 +219,8 @@ describe("CategoryTabStrip", () => {
       <CategoryTabStrip
         topEvents={[createEvent({ id: "top-1", title: "Top ranked event" })]}
         categorySections={[
-          createSection({ key: "tech", label: "Technology", events: [], emptyReason: "No major technology signals in today's briefing." }),
-          createSection({ key: "finance", label: "Economics", events: [], emptyReason: "No major economics signals in today's briefing." }),
+          createSection({ key: "tech", label: "Tech", events: [], emptyReason: "No major tech signals in today's briefing." }),
+          createSection({ key: "finance", label: "Finance", events: [], emptyReason: "No major finance signals in today's briefing." }),
           createSection({ key: "politics", label: "Politics", events: [], emptyReason: "No major politics signals in today's briefing." }),
         ]}
         isAuthenticated={false}
@@ -230,14 +230,14 @@ describe("CategoryTabStrip", () => {
       />,
     );
 
-    expect(screen.getByRole("tab", { name: "Tech News" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Economics" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Tech" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Finance" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Politics" })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("tab", { name: "Economics" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Finance" }));
 
-    expect(screen.getByText("Sign up to be notified when new signals are published.")).toBeInTheDocument();
-    expect(screen.getByText("No major economics signals in today's briefing.")).toBeInTheDocument();
+    expect(screen.queryByText("Sign up to be notified when new signals are published.")).not.toBeInTheDocument();
+    expect(screen.getByText("No major finance signals in today's briefing.")).toBeInTheDocument();
     expect(screen.queryByText("Top ranked event")).not.toBeInTheDocument();
   });
 });

--- a/src/components/landing/homepage.test.tsx
+++ b/src/components/landing/homepage.test.tsx
@@ -48,10 +48,11 @@ function createData(
   options: {
     publicRankedItems?: BriefingItem[] | null;
     homepageFreshnessNotice?: DashboardData["homepageFreshnessNotice"];
+    mode?: DashboardData["mode"];
   } = {},
 ): DashboardData {
   return {
-    mode: "live",
+    mode: options.mode ?? "live",
     briefing: {
       id: "briefing-1",
       briefingDate: "2026-04-15T09:00:00.000Z",
@@ -116,6 +117,31 @@ describe("LandingHomepage", () => {
       "href",
       "/briefing/2026-04-15",
     );
+  });
+
+  it("does not repeat the lead summary as a homepage card bullet", () => {
+    const duplicateSummary = "Cloud AI capacity expanded across three hyperscalers.";
+    const data = createData([
+      createItem({
+        id: "duplicate-summary-card",
+        title: "Hyperscalers expand AI capacity",
+        whatHappened: duplicateSummary,
+        keyPoints: [duplicateSummary],
+      }),
+    ]);
+
+    render(
+      <LandingHomepage
+        data={data}
+        viewer={null}
+        briefingDateLabel="Wednesday, April 15, 2026"
+        homepageViewModel={buildHomepageViewModel(data)}
+      />,
+    );
+
+    const card = screen.getByTestId("home-top-event-card");
+    expect(within(card).getAllByText(duplicateSummary)).toHaveLength(1);
+    expect(within(card).queryByTestId("home-top-event-key-points")).not.toBeInTheDocument();
   });
 
   it("renders Top Events from the supplied homepage model instead of raw briefing items", () => {
@@ -619,14 +645,14 @@ describe("LandingHomepage", () => {
     expect(screen.getAllByTestId("home-top-event-card")).toHaveLength(5);
   });
 
-  it("uses neutral signup copy when a signed-out category tab is empty", () => {
+  it("hides the signup gate when a signed-out category tab is empty", () => {
     const data = createData([
       createItem({
-        id: "top-tech",
-        topicId: "tech",
-        topicName: "Tech",
-        title: "Cloud providers expand AI capacity plans",
-        matchedKeywords: ["cloud", "ai", "capacity"],
+        id: "top-finance",
+        topicId: "finance",
+        topicName: "Finance",
+        title: "Treasury yields climb after inflation surprise",
+        matchedKeywords: ["treasury", "inflation", "rates"],
       }),
     ]);
 
@@ -639,13 +665,93 @@ describe("LandingHomepage", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("tab", { name: "Tech News" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Tech" }));
 
     const techPanel = document.getElementById("tech-panel");
     expect(screen.queryByText("Create a free account to read Tech News, Economics, and Politics")).not.toBeInTheDocument();
-    expect(screen.getByText("Sign up to be notified when new signals are published.")).toBeInTheDocument();
+    expect(screen.queryByText("Sign up to be notified when new signals are published.")).not.toBeInTheDocument();
     expect(techPanel).not.toBeNull();
-    expect(techPanel).toHaveTextContent("No major technology signals in today's briefing.");
+    expect(techPanel).toHaveTextContent("No major tech signals in today's briefing.");
+  });
+
+  it("routes Finance and Tech cards into matching category tabs when the published set has no depth pool", () => {
+    const financeItem = createItem({
+      id: "published-finance-1",
+      topicId: "finance",
+      topicName: "Finance",
+      title: "Treasury yields climb after inflation surprise",
+      matchedKeywords: ["Finance", "watch"],
+      homepageClassification: {
+        primaryCategory: "finance",
+        secondaryCategories: [],
+        confidence: 0.95,
+        scores: { tech: 0, finance: 12, politics: 0 },
+        matchedSignals: { tech: [], finance: ["treasury"], politics: [] },
+      },
+    });
+    const secondFinanceItem = createItem({
+      id: "published-finance-2",
+      topicId: "finance",
+      topicName: "Finance",
+      title: "Trade flows reroute through Asia suppliers",
+      matchedKeywords: ["Finance", "watch"],
+      homepageClassification: {
+        primaryCategory: "finance",
+        secondaryCategories: [],
+        confidence: 0.95,
+        scores: { tech: 0, finance: 12, politics: 0 },
+        matchedSignals: { tech: [], finance: ["trade"], politics: [] },
+      },
+    });
+    const techItem = createItem({
+      id: "published-tech-1",
+      topicId: "tech",
+      topicName: "Tech",
+      title: "AI infrastructure deal expands",
+      matchedKeywords: ["Tech", "watch"],
+      homepageClassification: {
+        primaryCategory: "tech",
+        secondaryCategories: [],
+        confidence: 0.95,
+        scores: { tech: 12, finance: 0, politics: 0 },
+        matchedSignals: { tech: ["ai"], finance: [], politics: [] },
+      },
+    });
+    const data = createData([financeItem, secondFinanceItem, techItem], { mode: "public" });
+
+    render(
+      <LandingHomepage
+        data={data}
+        viewer={null}
+        briefingDateLabel="Wednesday, April 15, 2026"
+        homepageViewModel={buildHomepageViewModel(data)}
+      />,
+    );
+
+    expect(screen.getByRole("tab", { name: "Tech" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Finance" })).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Tech News" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Economics" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Finance" }));
+    const financePanel = document.getElementById("finance-panel");
+    expect(financePanel).not.toBeNull();
+    expect(financePanel).toHaveTextContent("Treasury yields climb after inflation surprise");
+    expect(financePanel).toHaveTextContent("Trade flows reroute through Asia suppliers");
+    expect(financePanel).not.toHaveTextContent("AI infrastructure deal expands");
+    expect(screen.getByText("Sign up to be notified when new signals are published.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Tech" }));
+    const techPanel = document.getElementById("tech-panel");
+    expect(techPanel).not.toBeNull();
+    expect(techPanel).toHaveTextContent("AI infrastructure deal expands");
+    expect(techPanel).not.toHaveTextContent("Treasury yields climb after inflation surprise");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Politics" }));
+    const politicsPanel = document.getElementById("politics-panel");
+    expect(politicsPanel).not.toBeNull();
+    expect(politicsPanel).toHaveTextContent("No major politics signals in today's briefing.");
+    expect(screen.queryByText("Sign up to be notified when new signals are published.")).not.toBeInTheDocument();
   });
 
   it("lets signed-in users read populated category tabs without showing the signed-out gate", () => {
@@ -770,12 +876,12 @@ describe("LandingHomepage", () => {
     );
 
     expect(screen.getByRole("tab", { name: "Top Events" })).toHaveAttribute("aria-selected", "true");
-    expect(screen.getByRole("tab", { name: "Tech News" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Tech" })).toBeInTheDocument();
     expect(screen.queryByText("Sign up to be notified when new signals are published.")).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("tab", { name: "Tech News" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Tech" }));
 
-    expect(screen.getByRole("tab", { name: "Tech News" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Tech" })).toHaveAttribute("aria-selected", "true");
     expect(screen.queryAllByTestId("home-top-event-card")).toHaveLength(0);
     expect(screen.getAllByRole("heading", { level: 3 }).length).toBeGreaterThan(0);
     expect(screen.queryByText("Sign up to be notified when new signals are published.")).not.toBeInTheDocument();
@@ -912,7 +1018,7 @@ describe("LandingHomepage", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("tab", { name: "Tech News" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Tech" }));
 
     const techPanel = document.getElementById("tech-panel");
 
@@ -921,7 +1027,7 @@ describe("LandingHomepage", () => {
     expect(techPanel).toHaveTextContent("Open source database maintainers ship a query planner update");
     expect(techPanel).toHaveTextContent("Cloud security teams automate secrets rotation across edge workloads");
     expect(screen.queryByText("Cloud providers expand AI capacity plans")).not.toBeInTheDocument();
-    expect(techPanel).not.toHaveTextContent("No major technology signals in today's briefing.");
+    expect(techPanel).not.toHaveTextContent("No major tech signals in today's briefing.");
   });
 
   it("renders debug diagnostics for QA when enabled", () => {

--- a/src/components/landing/homepage.tsx
+++ b/src/components/landing/homepage.tsx
@@ -172,9 +172,7 @@ function HomeTopEventCard({
 }) {
   const titleNormalized = event.title.trim();
   const keyPoints = Array.isArray(event.keyPoints)
-    ? event.keyPoints
-        .map((point) => point.trim())
-        .filter((point) => Boolean(point) && point !== titleNormalized)
+    ? getDistinctKeyPoints(event.keyPoints, [event.title, event.summary, event.whatHappened])
     : [];
   const sourceNames = event.relatedArticles
     .map((article) => article.sourceName.trim())
@@ -307,6 +305,48 @@ function HomeTopEventCard({
       </article>
     </Panel>
   );
+}
+
+function getDistinctKeyPoints(points: string[], comparisons: string[]) {
+  const seen = new Set<string>();
+
+  return points
+    .map((point) => point.trim())
+    .filter((point) => {
+      const normalizedPoint = normalizeReaderCopy(point);
+
+      if (!normalizedPoint || seen.has(normalizedPoint)) {
+        return false;
+      }
+
+      seen.add(normalizedPoint);
+      return comparisons.every((comparison) => isMateriallyDistinctReaderCopy(normalizedPoint, comparison));
+    });
+}
+
+function isMateriallyDistinctReaderCopy(normalizedPoint: string, comparison: string) {
+  const normalizedComparison = normalizeReaderCopy(comparison);
+
+  if (!normalizedComparison || normalizedPoint === normalizedComparison) {
+    return !normalizedComparison;
+  }
+
+  const shorter = normalizedPoint.length < normalizedComparison.length ? normalizedPoint : normalizedComparison;
+  const longer = shorter === normalizedPoint ? normalizedComparison : normalizedPoint;
+
+  if (shorter.length < 40) {
+    return true;
+  }
+
+  return !(longer.startsWith(shorter) && shorter.length / longer.length >= 0.85);
+}
+
+function normalizeReaderCopy(value: string) {
+  return value
+    .replace(/\s+/g, " ")
+    .replace(/[.…]+$/g, "")
+    .trim()
+    .toLowerCase();
 }
 
 const WHY_IT_MATTERS_PREVIEW_THRESHOLD = 220;

--- a/src/lib/homepage-model.test.ts
+++ b/src/lib/homepage-model.test.ts
@@ -41,10 +41,11 @@ function createData(
   items: BriefingItem[],
   options: {
     publicRankedItems?: BriefingItem[] | null;
+    mode?: DashboardData["mode"];
   } = {},
 ): DashboardData {
   return {
-    mode: "live",
+    mode: options.mode ?? "live",
     briefing: {
       id: "briefing-1",
       briefingDate: "2026-04-15T09:00:00.000Z",
@@ -151,7 +152,7 @@ describe("buildHomepageViewModel", () => {
 
     expect(financeSection?.events).toHaveLength(0);
     expect(financeSection?.state).toBe("empty");
-    expect(financeSection?.emptyReason).toBe("No major economics signals in today's briefing.");
+    expect(financeSection?.emptyReason).toBe("No major finance signals in today's briefing.");
   });
 
   it("keeps Top 5 sourced from briefing items while depth layers use publicRankedItems", () => {
@@ -1167,7 +1168,7 @@ describe("buildHomepageViewModel", () => {
     expect(tabIds.some((id) => !topIds.has(id))).toBe(true);
   });
 
-  it("filters the editorial Top 5 into category tabs only when no broader ranked depth pool exists", () => {
+  it("filters the public editorial set into category tabs only when no broader ranked depth pool exists", () => {
     const items = [
       createItem({ id: "published-tech-1", topicId: "tech", topicName: "Tech", title: "AI infrastructure deal expands", matchedKeywords: ["Tech", "watch"], sourceCount: 1 }),
       createItem({ id: "published-tech-2", topicId: "tech", topicName: "Tech", title: "Enterprise AI merger closes", matchedKeywords: ["Tech", "context"], sourceCount: 1 }),
@@ -1176,7 +1177,7 @@ describe("buildHomepageViewModel", () => {
       createItem({ id: "published-politics-1", topicId: "politics", topicName: "Politics", title: "US Iran diplomacy narrows", matchedKeywords: ["Politics", "watch"], sourceCount: 1 }),
     ];
 
-    const model = buildHomepageViewModel(createData(items));
+    const model = buildHomepageViewModel(createData(items, { mode: "public" }));
 
     expect(model.categorySections.find((section) => section.key === "tech")?.events.map((event) => event.id)).toEqual([
       "published-tech-1",

--- a/src/lib/homepage-model.ts
+++ b/src/lib/homepage-model.ts
@@ -119,7 +119,6 @@ export type HomepageViewModel = {
 
 const TOP_EVENTS_LIMIT = 4;
 const MIN_PUBLIC_TOP_EVENTS = 3;
-const EDITORIAL_SIGNAL_SET_SIZE = 5;
 const CATEGORY_TAB_LIMIT = 6;
 const DEVELOPING_NOW_EVENT_LIMIT = 10;
 const CATEGORY_PREVIEW_LIMIT = 3;
@@ -217,6 +216,7 @@ export function buildHomepageViewModel(
     topLayerEvents,
     depthLayerEvents,
     topSignalEventIds,
+    allowTopLayerFallback: data.mode === "public",
   });
   const categoryTabSourceEvents = categoryTabPool.sourceEvents;
   const excludedCategoryTabIds = new Set(categoryTabPool.initialExcludedEventIds);
@@ -520,16 +520,18 @@ function resolveCategoryTabPool({
   topLayerEvents,
   depthLayerEvents,
   topSignalEventIds,
+  allowTopLayerFallback,
 }: {
   topLayerEvents: HomepageEvent[];
   depthLayerEvents: HomepageEvent[];
   topSignalEventIds: Set<string>;
+  allowTopLayerFallback: boolean;
 }) {
   const nonTopCategoryDepthEvents = depthLayerEvents.filter(
     (event) => Boolean(event.classification.primaryCategory) && !topSignalEventIds.has(event.id),
   );
   const usesTopLayerFallback =
-    nonTopCategoryDepthEvents.length === 0 && topLayerEvents.length === EDITORIAL_SIGNAL_SET_SIZE;
+    allowTopLayerFallback && nonTopCategoryDepthEvents.length === 0 && topLayerEvents.length > 0;
 
   return {
     sourceEvents: usesTopLayerFallback ? topLayerEvents : depthLayerEvents,
@@ -750,9 +752,9 @@ function sanitizeWhyItMatters(
 function getCategoryTabLabel(categoryKey: HomepageCategoryKey) {
   switch (categoryKey) {
     case "tech":
-      return "Technology";
+      return "Tech";
     case "finance":
-      return "Economics";
+      return "Finance";
     case "politics":
       return "Politics";
   }
@@ -761,9 +763,9 @@ function getCategoryTabLabel(categoryKey: HomepageCategoryKey) {
 function getCategoryTabEmptyReason(categoryKey: HomepageCategoryKey) {
   switch (categoryKey) {
     case "tech":
-      return "No major technology signals in today's briefing.";
+      return "No major tech signals in today's briefing.";
     case "finance":
-      return "No major economics signals in today's briefing.";
+      return "No major finance signals in today's briefing.";
     case "politics":
       return "No major politics signals in today's briefing.";
   }

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -142,7 +142,7 @@ test.describe("homepage", () => {
     const topEventCards = page.getByTestId("home-top-event-card");
     const gateCopy = "Sign up to be notified when new signals are published.";
     const oldGateCopy = "Create a free account to read Tech News, Economics, and Politics";
-    const techNewsTab = page.getByRole("tab", { name: "Tech News" });
+    const techTab = page.getByRole("tab", { name: "Tech" });
     const topEventCount = await topEventCards.count();
 
     if (topEventCount === 0) {
@@ -158,11 +158,11 @@ test.describe("homepage", () => {
     await expect(page.getByText(gateCopy)).toHaveCount(0);
     await expect(page.getByText(oldGateCopy)).toHaveCount(0);
 
-    await expect(techNewsTab).toBeVisible();
+    await expect(techTab).toBeVisible();
     for (let attempt = 0; attempt < 3; attempt += 1) {
-      await techNewsTab.click();
+      await techTab.click();
 
-      if ((await techNewsTab.getAttribute("aria-selected")) === "true") {
+      if ((await techTab.getAttribute("aria-selected")) === "true") {
         break;
       }
 
@@ -171,7 +171,7 @@ test.describe("homepage", () => {
 
     const gate = page.getByTestId("category-soft-gate");
 
-    await expect(techNewsTab).toHaveAttribute("aria-selected", "true");
+    await expect(techTab).toHaveAttribute("aria-selected", "true");
     await expect(gate).toBeVisible();
     await expect(gate.getByText(gateCopy)).toBeVisible();
     await expect(gate.getByText(oldGateCopy)).toHaveCount(0);


### PR DESCRIPTION
## Effective change type

bug-fix / public surface remediation

Canonical PRD required: No.

## Source of truth used

- Cowork eliminate-only analysis 2026-05-08 (subtraction-lens shortlist)
- Cowork frontend UX analysis 2026-05-06 (taxonomy mismatch diagnosis)
- Production screenshot 2026-05-08 12:28 PM Asia/Taipei
- Product Position.pdf principles cited in the prompt: fail-closed empty state, no false freshness, signal card structure
- PR #202 and PR #204 production/code gap analysis

## Diagnosis and chosen approach

### Fix A: duplicate homepage card content

Root cause: the homepage card rendered `event.summary` as the lead paragraph and then rendered `event.keyPoints` immediately below. Published signal posts build the first key point from the same summary, so the same sentence appeared twice on every homepage card.

Code surface: `src/components/landing/homepage.tsx` now filters key points in `HomeTopEventCard` before the bullet list (`getDistinctKeyPoints(event.keyPoints, [event.title, event.summary, event.whatHappened])`).

PR #202 gap: PR #202 fixed the briefing detail view's WHAT HAPPENED duplication path in `src/components/briefing/BriefingDetailView.tsx`, but it did not touch the homepage `HomeTopEventCard`, so production kept duplicating the summary on the homepage.

Chosen approach: keep the lead paragraph, and render bullet points only when they are materially distinct from title, summary, and `whatHappened`. No card redesign.

### Fix B: empty category tab signup gate

Root cause: signed-out category tabs rendered the signup gate for every category tab, including zero-content tabs, before the honest empty-state sentence.

Code surface: `src/components/home/CategoryTabStrip.tsx` now requires `section.events.length > 0` before rendering the logged-out gate. Empty tabs render only the empty-state status. Logged-in behavior and populated tabs are unchanged.

Chosen approach: hide the gate on zero-content category tabs only.

### Fix C: category taxonomy reconciliation

Diagnosis: `signal_posts` does not have a dedicated `category` column in this read model; the live category value comes through `tags`. The current live rows carry `Finance` for cards #1/#2 and `Tech` for card #3. Public category keys are `tech`, `finance`, and `politics`; the mismatch was frontend-facing labels (`Tech News`, `Economics`) plus the public tab pool excluding all top-layer cards when the published slate had fewer than five cards.

Code surfaces:
- `src/lib/signals-editorial.ts` stores `tags` on `signal_posts`.
- `src/lib/data.ts` infers `Finance`, `Politics`, or `Tech` from `post.tags`.
- `src/lib/homepage-model.ts` filters tabs by `event.classification.primaryCategory === category.key` and now allows a public-mode top-layer fallback when no non-top category pool exists.
- `src/components/home/CategoryTabStrip.tsx` now renders category labels directly.

Chosen approach: preferred frontend-only path. Rename the public tabs to match the existing data values: `Tech`, `Finance`, `Politics`. `Finance` maps to finance-tagged rows; `Tech` maps to tech-tagged rows; `Politics` remains empty when there is no politics content. No signal_posts mutation, migration, schema, backend, source manifest, ranking, WITM, eligibility, or admin changes.

## Tests added/updated

- `src/components/landing/homepage.test.tsx`: summary text is not duplicated as a homepage card bullet; empty zero-content tabs hide the signup gate; Finance-tagged and Tech-tagged cards surface under matching tabs; Politics renders the honest empty state without the gate.
- `src/components/home/home-category-components.test.tsx`: empty signed-out category tabs hide the gate while populated category tabs still render cards.
- `src/lib/homepage-model.test.ts`: public-mode category tab fallback still surfaces category content when the published slate has no separate depth pool.
- `tests/homepage.spec.ts`: public tab label expectation updated from `Tech News` to `Tech`.

## Validation

- `npm install` PASS (existing npm audit warnings only: 1 moderate, 1 high)
- Targeted tests PASS: `npx vitest run src/components/landing/homepage.test.tsx src/components/home/home-category-components.test.tsx src/lib/homepage-model.test.ts`
- Existing public-surface tests PASS: `npx vitest run src/components/landing/homepage.test.tsx src/app/signals/page.test.ts src/app/metadata.test.ts src/components/briefing/BriefingDetailView.test.tsx src/components/home/home-category-components.test.tsx src/lib/homepage-model.test.ts`
- `npm run lint` PASS
- `npm run test` PASS
- `npm run build` PASS
- `PLAYWRIGHT_MANAGED_WEBSERVER=1 npm run test:e2e:chromium` PASS
- `PLAYWRIGHT_MANAGED_WEBSERVER=1 npm run test:e2e:webkit` PASS
- `python3 scripts/validate-feature-system-csv.py` PASS
- `npm run governance:coverage` PASS
- `npm run governance:hotspots` PASS
- `python3 scripts/release-governance-gate.py` PASS
- `npm run governance:audit` PASS
- `git diff --check` PASS
- Local browser QA PASS: `Tech`, `Finance`, and `Politics` tabs render without the stale `Tech News`/`Economics` labels; empty category gate count is zero.