### PR TITLE
remediation: keep draft-only Core/Context selection aligned

### DIFF
--- a/docs/engineering/bug-fixes/controlled-draft-only-core-context-selection-remediation.md
+++ b/docs/engineering/bug-fixes/controlled-draft-only-core-context-selection-remediation.md
@@ -1,0 +1,42 @@
+# Controlled Draft-Only Core/Context Selection Remediation - Bug-Fix Record
+
+## Summary
+- Problem addressed: The controlled `draft_only` seven-row product-target path could persist seven Core/Context-eligible rows that did not match the dry-run report's five Core plus two Context slate shape.
+- Root cause: The live-RSS draft selector applied the `core,context` allowlist and `PIPELINE_DRAFT_MAX_ROWS=7` as a flat ranked slice, so extra Core-eligible rows could displace Context rows before persistence.
+- Affected object level: Signal / Surface Placement.
+
+## Fix
+- Exact change: For the approved seven-row controlled draft-only path, select up to five `core_signal_eligible` rows and up to two `context_signal_eligible` rows from the same ranked candidate pool, preserving fail-closed exclusion of Depth rows.
+- Related PRD: No new PRD required; this is controlled operations remediation for the existing Phase 1 editorial cycle validation path.
+- PR: TBD.
+- Branch: `fix/controlled-draft-only-core-context-selection-20260508`.
+- Head SHA: TBD.
+- Merge SHA: TBD.
+- GitHub source-of-truth status: pending PR.
+- External references reviewed, if any: BOOT_UP_WORK_LOG_v2 decisions supplied by PM; Product Position fail-closed and signal-card principles supplied by PM; PR #141 controlled draft cap remediation; PR #205 category public-surface remediation; live `draft_only` artifact and database readback from the 2026-05-08 second editorial cycle.
+- Google Sheet / Work Log reference, if historically relevant: draft work-log entry prepared in the operational handoff.
+- Branch cleanup status: pending post-merge cleanup.
+
+## Terminology Requirement
+- Before implementation, read `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`.
+- [x] Confirmed object level before coding: Signal / Surface Placement.
+- [x] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [x] Legacy `signal_posts` naming remains treated as Surface Placement plus editorial read-model storage.
+
+## Validation
+- Automated checks:
+  - `npx vitest run src/lib/pipeline/controlled-runner.test.ts src/lib/pipeline/controlled-execution.test.ts` - PASS, 2 files / 37 tests.
+  - `npm run lint` - PASS.
+  - `npm run test` - PASS, 80 files / 604 tests.
+  - `npm run build` - PASS with existing workspace-root and module-type warnings.
+  - `python3 scripts/validate-feature-system-csv.py` - PASS with existing PRD slug warnings.
+  - `npm run governance:coverage` - PASS.
+  - `npm run governance:hotspots` - PASS.
+  - `python3 scripts/release-governance-gate.py --diff-mode local --branch-name fix/controlled-draft-only-core-context-selection-20260508 --pr-title "remediation: keep draft-only Core/Context selection aligned"` - PASS.
+  - `npm run governance:audit` - PASS.
+  - `git diff --check` - PASS.
+- Human checks: Chrome production QA confirmed the non-live drafts did not change the public homepage.
+
+## Remaining Risks / Follow-up
+- Current 2026-05-08 draft rows were already created by the pre-fix selector and should not be published as the target Core+Context slate without BM direction.
+- A corrected draft-only cycle requires BM instruction on whether to discard or supersede the current non-live draft rows before re-running.

--- a/docs/engineering/bug-fixes/controlled-draft-only-core-context-selection-remediation.md
+++ b/docs/engineering/bug-fixes/controlled-draft-only-core-context-selection-remediation.md
@@ -8,9 +8,9 @@
 ## Fix
 - Exact change: For the approved seven-row controlled draft-only path, select up to five `core_signal_eligible` rows and up to two `context_signal_eligible` rows from the same ranked candidate pool, preserving fail-closed exclusion of Depth rows.
 - Related PRD: No new PRD required; this is controlled operations remediation for the existing Phase 1 editorial cycle validation path.
-- PR: TBD.
+- PR: https://github.com/brandonma25/daily-intelligence-aggregator/pull/206.
 - Branch: `fix/controlled-draft-only-core-context-selection-20260508`.
-- Head SHA: TBD.
+- Head SHA at PR creation: `7a8fd1d65d3ea88441edf85286c7f5a9d42061a4`.
 - Merge SHA: TBD.
 - GitHub source-of-truth status: pending PR.
 - External references reviewed, if any: BOOT_UP_WORK_LOG_v2 decisions supplied by PM; Product Position fail-closed and signal-card principles supplied by PM; PR #141 controlled draft cap remediation; PR #205 category public-surface remediation; live `draft_only` artifact and database readback from the 2026-05-08 second editorial cycle.

--- a/src/lib/pipeline/controlled-runner.test.ts
+++ b/src/lib/pipeline/controlled-runner.test.ts
@@ -477,6 +477,69 @@ describe("runControlledPipeline", () => {
     expect(getPersistedItemIds()).not.toContain("item-9");
   });
 
+  it("draft_only product-target cap keeps Context rows when more than five Core rows rank first", async () => {
+    const items = [
+      buildItem(1),
+      buildItem(2),
+      buildItem(3),
+      buildItem(4),
+      buildItem(5),
+      buildItem(6),
+      buildItem(7),
+      buildItem(8, "context_signal_eligible"),
+      buildItem(9, "context_signal_eligible"),
+      buildItem(10, "depth_only"),
+    ];
+    generateDailyBriefing.mockResolvedValueOnce({
+      briefing: {
+        id: "briefing-product-target-context-preserved",
+        briefingDate: "2026-04-27T12:00:00.000Z",
+        title: "Daily Executive Briefing",
+        intro: "Controlled test briefing.",
+        readingWindow: "20 minutes",
+        items: items.slice(0, 5),
+      },
+      publicRankedItems: items,
+      pipelineRun: {
+        run_id: "pipeline-product-target-context-preserved",
+        num_clusters: 10,
+      },
+    });
+
+    const { runControlledPipeline } = await import("@/lib/pipeline/controlled-runner");
+    const report = await runControlledPipeline(buildConfig({
+      mode: "draft_only",
+      briefingDateOverride: "2026-04-29",
+      testRunId: "core-context-product-target-context-preserved",
+      draftTierAllowlist: ["core_signal_eligible", "context_signal_eligible"],
+      draftMaxRows: 7,
+    }));
+
+    expect(getPersistedItemIds()).toEqual([
+      "item-1",
+      "item-2",
+      "item-3",
+      "item-4",
+      "item-5",
+      "item-8",
+      "item-9",
+    ]);
+    expect(getPersistedItemIds()).not.toContain("item-6");
+    expect(getPersistedItemIds()).not.toContain("item-7");
+    expect(getPersistedItemIds()).not.toContain("item-10");
+    expect(report.proposedTopFive.map((row) => row.title)).toEqual([
+      "Generated signal 1",
+      "Generated signal 2",
+      "Generated signal 3",
+      "Generated signal 4",
+      "Generated signal 5",
+    ]);
+    expect(report.proposedContextRows.map((row) => row.title)).toEqual([
+      "Generated signal 8",
+      "Generated signal 9",
+    ]);
+  });
+
   it("draft_only product-target cap never selects more than seven Core and Context rows", async () => {
     const items = [
       buildItem(1),

--- a/src/lib/pipeline/controlled-runner.ts
+++ b/src/lib/pipeline/controlled-runner.ts
@@ -17,6 +17,30 @@ import type { BriefingItem, SignalSelectionEligibilityTier } from "@/lib/types";
 
 type ReplayArtifact = ControlledPipelineReport;
 
+const CONTROLLED_PRODUCT_TARGET_CORE_COUNT = 5;
+const CONTROLLED_PRODUCT_TARGET_CONTEXT_COUNT = 2;
+const CONTROLLED_PRODUCT_TARGET_ROW_COUNT =
+  CONTROLLED_PRODUCT_TARGET_CORE_COUNT + CONTROLLED_PRODUCT_TARGET_CONTEXT_COUNT;
+
+function usesCoreContextProductTarget(config: ControlledPipelineConfig) {
+  return (
+    config.draftMaxRows === CONTROLLED_PRODUCT_TARGET_ROW_COUNT &&
+    config.draftTierAllowlist?.includes("core_signal_eligible") &&
+    config.draftTierAllowlist.includes("context_signal_eligible")
+  );
+}
+
+function selectCoreContextProductTargetItems(candidates: BriefingItem[]) {
+  const coreItems = candidates
+    .filter((item) => item.selectionEligibility?.tier === "core_signal_eligible")
+    .slice(0, CONTROLLED_PRODUCT_TARGET_CORE_COUNT);
+  const contextItems = candidates
+    .filter((item) => item.selectionEligibility?.tier === "context_signal_eligible")
+    .slice(0, CONTROLLED_PRODUCT_TARGET_CONTEXT_COUNT);
+
+  return [...coreItems, ...contextItems];
+}
+
 function selectDraftOnlyItems(input: {
   briefingItems: BriefingItem[];
   publicRankedItems: BriefingItem[];
@@ -30,6 +54,10 @@ function selectDraftOnlyItems(input: {
 
   const allowedTiers = new Set(config.draftTierAllowlist ?? ["core_signal_eligible"]);
   const candidates = publicRankedItems.length > 0 ? publicRankedItems : briefingItems;
+  if (usesCoreContextProductTarget(config)) {
+    return selectCoreContextProductTargetItems(candidates);
+  }
+
   const selected = candidates.filter((item) => {
     const tier = item.selectionEligibility?.tier;
 


### PR DESCRIPTION
## Summary
- fixes the controlled `draft_only` seven-row selector so the approved product-target path persists up to 5 Core rows plus up to 2 Context rows
- prevents extra Core-eligible rows from displacing Context rows when `PIPELINE_DRAFT_MAX_ROWS=7` and `PIPELINE_DRAFT_TIER_ALLOWLIST=core,context`
- adds a regression test for the exact observed mismatch and a bug-fix tracking record

## Operational note
- No publish path was invoked.
- Existing 2026-05-08 non-live draft rows were created before this fix and should not be published as the target Core+Context slate without BM direction.

## Validation
- `npx vitest run src/lib/pipeline/controlled-runner.test.ts src/lib/pipeline/controlled-execution.test.ts`
- `npm run lint`
- `npm run test`
- `npm run build`
- `python3 scripts/validate-feature-system-csv.py`
- `npm run governance:coverage`
- `npm run governance:hotspots`
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name fix/controlled-draft-only-core-context-selection-20260508 --pr-title "remediation: keep draft-only Core/Context selection aligned"`
- `npm run governance:audit`
- `git diff --check`