### PR TITLE
remediation: align draft-only WITM validation context

### DIFF
--- a/docs/engineering/bug-fixes/controlled-draft-only-witm-validation-context-remediation.md
+++ b/docs/engineering/bug-fixes/controlled-draft-only-witm-validation-context-remediation.md
@@ -1,0 +1,42 @@
+# Controlled Draft-Only WITM Validation Context Remediation - Bug-Fix Record
+
+## Summary
+- Problem addressed: The controlled `draft_only` report could mark a generated Core/Context WITM as `requires_human_rewrite` while persisted `signal_posts` rows stored the same WITM as `passed`.
+- Root cause: The controlled report validated WITM copy with title, eligibility, accessibility, and event-type context, but `signal_posts` persistence recomputed validation without that context when no precomputed validation payload was supplied.
+- Affected object level: Signal / Surface Placement.
+
+## Fix
+- Exact change: Recompute fallback persisted WITM validation with the same Core/Context context fields used by the controlled pipeline report, while still preserving supplied validation metadata when present.
+- Related PRD: No new PRD required; this is controlled operations remediation for the existing Phase 1 editorial cycle validation path.
+- PR: TBD.
+- Branch: `fix/draft-only-witm-validation-context-20260508`.
+- Head SHA at PR creation: TBD.
+- Merge SHA: TBD.
+- GitHub source-of-truth status: pending PR.
+- External references reviewed, if any: BOOT_UP_WORK_LOG_v2 decisions supplied by PM; Product Position fail-closed principles supplied by PM; live `draft_only` artifact and database readback from the 2026-05-08 second editorial cycle; PR #206 selection remediation.
+- Google Sheet / Work Log reference, if historically relevant: draft work-log entry prepared in the operational handoff.
+- Branch cleanup status: pending post-merge cleanup.
+
+## Terminology Requirement
+- Before implementation, read `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`.
+- [x] Confirmed object level before coding: Signal / Surface Placement.
+- [x] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [x] Legacy `signal_posts` naming remains treated as Surface Placement plus editorial read-model storage.
+
+## Validation
+- Automated checks:
+  - `npx vitest run src/lib/signals-editorial.test.ts src/lib/pipeline/controlled-runner.test.ts src/lib/pipeline/controlled-execution.test.ts` - PASS, 3 files / 104 tests.
+  - `npm run lint` - PASS.
+  - `npm run test` - PASS, 80 files / 605 tests.
+  - `npm run build` - PASS with existing workspace-root and module-type warnings.
+  - `python3 scripts/validate-feature-system-csv.py` - PASS with existing PRD slug warnings.
+  - `npm run governance:coverage` - PASS.
+  - `npm run governance:hotspots` - PASS.
+  - `python3 scripts/release-governance-gate.py --diff-mode local --branch-name fix/draft-only-witm-validation-context-20260508 --pr-title "remediation: align draft-only WITM validation context"` - PASS.
+  - `npm run governance:audit` - PASS.
+  - `git diff --check` - PASS.
+- Human checks: Chrome production QA confirmed the non-live drafts did not change the public homepage.
+
+## Remaining Risks / Follow-up
+- Current 2026-05-08 draft rows were created before this fix and include persisted validation statuses that should not be used for publish approval without BM-directed remediation or rerun.
+- Corrected draft-only output requires a new run after this fix is deployed and after BM decides how to handle the existing non-live draft rows.

--- a/docs/engineering/bug-fixes/controlled-draft-only-witm-validation-context-remediation.md
+++ b/docs/engineering/bug-fixes/controlled-draft-only-witm-validation-context-remediation.md
@@ -8,9 +8,9 @@
 ## Fix
 - Exact change: Recompute fallback persisted WITM validation with the same Core/Context context fields used by the controlled pipeline report, while still preserving supplied validation metadata when present.
 - Related PRD: No new PRD required; this is controlled operations remediation for the existing Phase 1 editorial cycle validation path.
-- PR: TBD.
+- PR: https://github.com/brandonma25/daily-intelligence-aggregator/pull/207.
 - Branch: `fix/draft-only-witm-validation-context-20260508`.
-- Head SHA at PR creation: TBD.
+- Head SHA at PR creation: `671931c513ff8001b329af9f126925d9e7fc685d`.
 - Merge SHA: TBD.
 - GitHub source-of-truth status: pending PR.
 - External references reviewed, if any: BOOT_UP_WORK_LOG_v2 decisions supplied by PM; Product Position fail-closed principles supplied by PM; live `draft_only` artifact and database readback from the 2026-05-08 second editorial cycle; PR #206 selection remediation.

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -1481,6 +1481,41 @@ describe("signals editorial workflow", () => {
     expect(rows[1].why_it_matters_validation_status).toBe("passed");
   });
 
+  it("draft_only mode recomputes WITM validation with Core/Context context before persistence", async () => {
+    const rows: SignalPostRow[] = [];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+
+    const { persistSignalPostsForBriefing } = await loadEditorialModule();
+    const result = await persistSignalPostsForBriefing({
+      briefingDate: "2026-05-08",
+      mode: "draft_only",
+      items: [
+        {
+          ...createBriefingItem(1),
+          title: "Economic Letter Countdown: Most Read Topics from 2025",
+          aiWhyItMatters:
+            "Economic Letter Countdown: Most Read Topics from 2025, which matters because it shows which inflation, labor, and growth questions dominated institutional attention.",
+          selectionEligibility: {
+            tier: "core_signal_eligible" as const,
+            reasons: [],
+            warnings: [],
+            contentAccessibility: "full_text_available" as const,
+            accessibleTextLength: 1200,
+            eventType: "macro_data_release",
+          },
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].why_it_matters_validation_status).toBe("requires_human_rewrite");
+    expect(rows[0].why_it_matters_validation_failures).toEqual(["unsupported_structural_claim"]);
+    expect(rows[0].why_it_matters_validation_details).toContain(
+      "unsupported_structural_claim: Core WITM is attached to a retrospective or meta-story that needs selection review before publication.",
+    );
+  });
+
   it("draft_only mode preserves supplied WITM validation metadata instead of recomputing it", async () => {
     const rows: SignalPostRow[] = [];
     createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -885,7 +885,13 @@ function mapBriefingItemToSignalPost(item: BriefingItem, index: number): Editori
     item.importanceLabel,
   ].filter((value): value is string => Boolean(value));
   const aiWhyItMatters = normalizeEditorialText(item.aiWhyItMatters ?? item.whyItMatters);
-  const validation = item.whyItMattersValidation ?? validateWhyItMatters(aiWhyItMatters);
+  const validation = item.whyItMattersValidation ?? validateWhyItMatters(aiWhyItMatters, {
+    title: item.title,
+    eligibilityTier: item.selectionEligibility?.tier ?? "core_signal_eligible",
+    contentAccessibility: item.selectionEligibility?.contentAccessibility ?? null,
+    accessibleTextLength: item.selectionEligibility?.accessibleTextLength ?? null,
+    eventType: item.selectionEligibility?.eventType ?? item.eventIntelligence?.eventType ?? null,
+  });
 
   return {
     id: `candidate-${index + 1}`,


### PR DESCRIPTION
## Summary
- fixes the controlled `draft_only` persistence path so fallback WITM validation uses the same title, eligibility, accessibility, and event-type context as the controlled report
- prevents report/database disagreement where a row is reported as `requires_human_rewrite` but persisted as `passed`
- preserves explicitly supplied validation metadata and adds a regression test for the observed mismatch

## Operational note
- No publish path was invoked.
- No production data was mutated by this PR.
- Existing 2026-05-08 non-live draft rows were created before this fix and should not be used for publish approval without BM-directed remediation or a corrected rerun.

## Validation
- `npx vitest run src/lib/signals-editorial.test.ts src/lib/pipeline/controlled-runner.test.ts src/lib/pipeline/controlled-execution.test.ts`
- `npm run lint`
- `npm run test`
- `npm run build`
- `python3 scripts/validate-feature-system-csv.py`
- `npm run governance:coverage`
- `npm run governance:hotspots`
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name fix/draft-only-witm-validation-context-20260508 --pr-title "remediation: align draft-only WITM validation context"`
- `npm run governance:audit`
- `git diff --check`