### PR TITLE
Guard signal posts against missing source URLs

### DIFF
--- a/docs/engineering/bug-fixes/source-url-prewrite-guard-2026-05-10.md
+++ b/docs/engineering/bug-fixes/source-url-prewrite-guard-2026-05-10.md
@@ -1,0 +1,43 @@
+# Source URL Pre-Write Guard — Bug-Fix Record
+
+## Summary
+- Problem addressed: Three manual smoke-test Surface Placement rows were inserted with empty `source_url`, and two later reached `approved` status even though they had no reviewable public source authority.
+- Root cause: Manual `draft_only` persistence built signal-card rows and WITM validation metadata before enforcing that at least one public `http://` or `https://` source URL existed.
+- Affected object level: Surface Placement + Card copy read model (`signal_posts` legacy/runtime table name), not canonical Signal identity.
+
+## Fix
+- Exact change: Delete the three invalid non-live rows, skip missing-source candidates before draft insertion, report skipped candidates with `missing_public_source_url`, block approval/final-slate assignment/final-slate readiness/publish readiness for missing public URLs, and add a database constraint preventing empty or non-http(s) `signal_posts.source_url`.
+- Related PRD: Not required. This is bug-fix / data remediation aligned to the existing Boot Up MVP editorial source-of-truth.
+- PR: Pending.
+- Branch: `bugfix/source-url-prewrite-guard-20260510`
+- Head SHA: This commit.
+- Merge SHA: Pending.
+- GitHub source-of-truth status: This record is the repo-side bug-fix record for the remediation.
+- External references reviewed, if any: None.
+- Google Sheet / Work Log reference, if historically relevant: None.
+- Branch cleanup status: Pending PR lifecycle.
+
+## Terminology Requirement
+- Before implementation, read `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`.
+- [x] Confirmed object level before coding: Surface Placement + Card copy.
+- [x] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [x] If legacy naming is inconsistent, document it instead of silently expanding it.
+
+## Validation
+- Automated checks:
+  - `npm run test -- src/lib/signals-editorial.test.ts src/lib/final-slate-readiness.test.ts` passed.
+  - `npm run lint` passed.
+  - `npm run test` passed.
+  - `npm run build` passed.
+  - `python3 scripts/release-governance-gate.py` passed after adding the no-PRD remediation change record.
+  - `python3 scripts/validate-documentation-coverage.py` passed.
+  - Local app load check returned HTTP 200 at `http://localhost:3000/`.
+- Human checks:
+  - Production data readback confirmed the three invalid rows were deleted.
+  - Production data readback found zero empty or non-http(s) `source_url` rows in the scanned `signal_posts` set.
+  - Production public routes `/`, `/signals`, and `/briefing/2026-05-06` returned HTTP 200.
+  - Production cron endpoint `/api/cron/fetch-news` returned HTTP 401 without credentials.
+  - Vercel deployed cron list returned `crons: []`.
+
+## Remaining Risks / Follow-up
+- The database constraint is present as a repo migration and should be applied through the normal migration/deploy path for production enforcement. Application-level guards already prevent draft insertion, approval, final-slate assignment, and publish readiness for missing public URLs after this code is deployed.

--- a/docs/engineering/change-records/source-url-prewrite-guard-remediation-2026-05-10.md
+++ b/docs/engineering/change-records/source-url-prewrite-guard-remediation-2026-05-10.md
@@ -1,0 +1,29 @@
+# Source URL Pre-Write Guard Remediation — Change Record
+
+## Classification
+- Change type: bug-fix / data remediation.
+- Canonical PRD required: No.
+- Reason: This aligns the manual draft insertion, approval, final-slate, and publish-readiness paths with the existing Boot Up MVP source-backed editorial standard. It does not add a net-new product feature or system capability.
+
+## Scope
+- Prevent `signal_posts` Surface Placement rows from being inserted without at least one public `http://` or `https://` source URL.
+- Report skipped draft candidates with `missing_public_source_url` before persistence.
+- Block approval, final-slate assignment, final-slate readiness, and publish readiness for source-empty rows.
+- Add a database-level source URL guard only after confirming production has no legitimate historical empty-source rows.
+
+## Non-Goals
+- No source manifest changes.
+- No ingestion source additions.
+- No ranking, WITM template, eligibility filter, or schema redesign.
+- No cron re-enable.
+- No automatic publish or replacement row insertion.
+
+## Supporting Record
+- Bug-fix record: `docs/engineering/bug-fixes/source-url-prewrite-guard-2026-05-10.md`
+
+## Validation Summary
+- Production source-empty inventory after cleanup: 0 rows.
+- Target invalid smoke-test rows remaining after cleanup: 0 rows.
+- Public routes checked: `/`, `/signals`, `/briefing/2026-05-06`.
+- Cron state checked: deployed cron list empty; unauthenticated cron endpoint returned HTTP 401.
+- Local validation checked: targeted tests, full test suite, lint, build, release governance gate, documentation coverage, and local HTTP 200 load.

--- a/scripts/pipeline-controlled-test.ts
+++ b/scripts/pipeline-controlled-test.ts
@@ -75,6 +75,7 @@ async function main() {
     manifestCoverageWarnings: report.selectionSummary.manifestCoverageWarnings,
     insertedCount: persistence?.insertedCount ?? 0,
     insertedPostIds: persistence?.insertedPostIds ?? [],
+    skippedCandidates: persistence?.skippedCandidates ?? [],
     message: persistence?.message ?? "Dry run completed without Supabase writes.",
   }, null, 2));
 

--- a/src/lib/final-slate-readiness.test.ts
+++ b/src/lib/final-slate-readiness.test.ts
@@ -269,7 +269,35 @@ describe("final slate readiness", () => {
     expect(result.rowFailures["signal-7"]).toEqual(
       expect.arrayContaining([
         "Selected row must be approved before final slate readiness.",
-        "Selected row is missing source URL.",
+        "Selected row is missing a valid public source URL.",
+      ]),
+    );
+    expect(result.failures).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "missing_public_source_url",
+          rowId: "signal-7",
+        }),
+      ]),
+    );
+  });
+
+  it("rejects non-http source URLs for selected final-slate rows", () => {
+    const result = validateFinalSlateReadiness(
+      validSlate({
+        1: {
+          sourceUrl: "ftp://example.com/source",
+        },
+      }),
+    );
+
+    expect(result.ready).toBe(false);
+    expect(result.failures).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "missing_public_source_url",
+          rowId: "signal-1",
+        }),
       ]),
     );
   });

--- a/src/lib/final-slate-readiness.ts
+++ b/src/lib/final-slate-readiness.ts
@@ -44,9 +44,26 @@ export type FinalSlateReadinessResult = {
   selectedRows: FinalSlateValidationRow[];
 };
 
+export const MISSING_PUBLIC_SOURCE_URL_REASON = "missing_public_source_url";
+
 const CORE_RANK_SET = new Set<number>(FINAL_SLATE_CORE_RANKS);
 const CONTEXT_RANK_SET = new Set<number>(FINAL_SLATE_CONTEXT_RANKS);
 const FINAL_RANK_SET = new Set<number>(FINAL_SLATE_RANKS);
+
+export function isValidPublicSourceUrl(value: string | null | undefined) {
+  const normalized = value?.trim() ?? "";
+
+  if (!normalized) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(normalized);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
 
 export function getFinalSlateTierForRank(rank: number): FinalSlateTier | null {
   if (CORE_RANK_SET.has(rank)) {
@@ -222,8 +239,13 @@ function addRowContentFailures(
     addRowFailure(row, "Selected row is missing source name.", "missing_source_name", rank);
   }
 
-  if (!row.sourceUrl?.trim()) {
-    addRowFailure(row, "Selected row is missing source URL.", "missing_source_url", rank);
+  if (!isValidPublicSourceUrl(row.sourceUrl)) {
+    addRowFailure(
+      row,
+      "Selected row is missing a valid public source URL.",
+      MISSING_PUBLIC_SOURCE_URL_REASON,
+      rank,
+    );
   }
 }
 

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -868,6 +868,36 @@ describe("signals editorial workflow", () => {
     expect(rows[0].published_at).toBeNull();
   });
 
+  it("blocks approval when a row is missing a valid public source URL", async () => {
+    const rows = [
+      createRow({
+        id: "signal-1",
+        source_url: "",
+      }),
+    ];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { approveSignalPost } = await loadEditorialModule();
+    const result = await approveSignalPost({
+      postId: "signal-1",
+      editedWhyItMatters: createValidWhyItMatters(),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      code: "missing_public_source_url",
+      message: "missing_public_source_url: Add a valid public source URL before approval.",
+    });
+    expect(rows[0].editorial_status).toBe("needs_review");
+    expect(rows[0].edited_why_it_matters).toBeNull();
+    expect(rows[0].approved_at).toBeNull();
+  });
+
   it("blocks approval when the human rewrite still fails validation", async () => {
     const rows = [
       createRow({
@@ -1028,6 +1058,28 @@ describe("signals editorial workflow", () => {
 
     expect(result.ok).toBe(false);
     expect(result.code).toBe("publish_blocked");
+    expect(rows.some((row) => row.editorial_status === "published")).toBe(false);
+  });
+
+  it("blocks publishing selected final-slate rows without a public source URL", async () => {
+    const rows = createPartialFinalSlate(3, {
+      2: {
+        source_url: "",
+      },
+    });
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { publishApprovedSignals } = await loadEditorialModule();
+    const result = await publishApprovedSignals();
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("publish_blocked");
+    expect(result.message).toContain("Selected row is missing a valid public source URL.");
     expect(rows.some((row) => row.editorial_status === "published")).toBe(false);
   });
 
@@ -1481,6 +1533,94 @@ describe("signals editorial workflow", () => {
     expect(rows[1].why_it_matters_validation_status).toBe("passed");
   });
 
+  it("draft_only mode skips candidates without a valid public source URL before insertion", async () => {
+    const rows: SignalPostRow[] = [];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+
+    const { persistSignalPostsForBriefing } = await loadEditorialModule();
+    const result = await persistSignalPostsForBriefing({
+      briefingDate: "2026-05-10",
+      mode: "draft_only",
+      items: [
+        {
+          ...createBriefingItem(1),
+          title: "Manual benchmark without URL",
+          sources: [{ title: "Morning Brew / BLS", url: "" }],
+          relatedArticles: [],
+        },
+        {
+          ...createBriefingItem(2),
+          title: "Valid public source candidate",
+          sources: [{ title: "Reuters", url: " https://example.com/source-2 " }],
+          relatedArticles: [],
+        },
+        {
+          ...createBriefingItem(3),
+          title: "Private newsletter source only",
+          sources: [{ title: "TLDR", url: "newsletter://private/issue" }],
+          relatedArticles: [],
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.insertedCount).toBe(1);
+    expect(result.skippedCandidates).toEqual([
+      {
+        title: "Manual benchmark without URL",
+        candidateOrigin: "Morning Brew / BLS",
+        pipelineRank: 1,
+        reason: "missing_public_source_url",
+      },
+      {
+        title: "Private newsletter source only",
+        candidateOrigin: "TLDR",
+        pipelineRank: 3,
+        reason: "missing_public_source_url",
+      },
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      rank: 2,
+      title: "Valid public source candidate",
+      source_name: "Reuters",
+      source_url: "https://example.com/source-2",
+      editorial_status: "needs_review",
+      is_live: false,
+      published_at: null,
+    });
+  });
+
+  it("draft_only mode fails visibly when every candidate is missing a public source URL", async () => {
+    const rows: SignalPostRow[] = [];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+
+    const { persistSignalPostsForBriefing } = await loadEditorialModule();
+    const result = await persistSignalPostsForBriefing({
+      briefingDate: "2026-05-10",
+      mode: "draft_only",
+      items: [
+        {
+          ...createBriefingItem(1),
+          sources: [{ title: "Private benchmark", url: "" }],
+          relatedArticles: [],
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.insertedCount).toBe(0);
+    expect(result.skippedCandidates).toEqual([
+      {
+        title: "Generated Signal 1",
+        candidateOrigin: "Private benchmark",
+        pipelineRank: 1,
+        reason: "missing_public_source_url",
+      },
+    ]);
+    expect(rows).toHaveLength(0);
+  });
+
   it("draft_only mode recomputes WITM validation with Core/Context context before persistence", async () => {
     const rows: SignalPostRow[] = [];
     createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
@@ -1911,6 +2051,37 @@ describe("signals editorial workflow", () => {
     });
 
     expect(result.ok).toBe(false);
+    expect(rows[0].final_slate_rank).toBeNull();
+    expect(rows[0].final_slate_tier).toBeNull();
+  });
+
+  it("blocks rows without public source URLs from final-slate assignment", async () => {
+    const rows = [
+      createRow({
+        id: "signal-1",
+        editorial_status: "approved",
+        editorial_decision: "approved",
+        source_url: "",
+      }),
+    ];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+    safeGetUser.mockResolvedValue({
+      user: { id: "admin-1", email: "admin@example.com" },
+      supabase: {},
+      sessionCookiePresent: true,
+    });
+
+    const { assignSignalPostToFinalSlateSlot } = await loadEditorialModule();
+    const result = await assignSignalPostToFinalSlateSlot({
+      postId: "signal-1",
+      finalSlateRank: 1,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      code: "missing_public_source_url",
+      message: "missing_public_source_url: Add a valid public source URL before final-slate assignment.",
+    });
     expect(rows[0].final_slate_rank).toBeNull();
     expect(rows[0].final_slate_tier).toBeNull();
   });

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -18,6 +18,8 @@ import {
   FINAL_SLATE_MIN_PUBLIC_ROWS,
   getFinalSlateTierForRank,
   isFinalSlateRank,
+  isValidPublicSourceUrl,
+  MISSING_PUBLIC_SOURCE_URL_REASON,
   validateFinalSlateReadiness,
   type FinalSlateTier,
   type FinalSlateValidationFailure,
@@ -373,6 +375,7 @@ export type EditorialMutationResult = {
     | "decision_updated"
     | "draft_saved"
     | "empty_editorial_text"
+    | "missing_public_source_url"
     | "not_admin"
     | "not_authenticated"
     | "not_found"
@@ -385,11 +388,19 @@ export type EditorialMutationResult = {
     | "storage_error";
 };
 
+export type SkippedSignalPostCandidate = {
+  title: string;
+  candidateOrigin: string;
+  pipelineRank: number;
+  reason: typeof MISSING_PUBLIC_SOURCE_URL_REASON;
+};
+
 export type SignalSnapshotPersistenceResult = {
   ok: boolean;
   briefingDate: string;
   insertedCount: number;
   insertedPostIds?: string[];
+  skippedCandidates?: SkippedSignalPostCandidate[];
   mode?: SignalPostPersistenceMode;
   message: string;
 };
@@ -429,6 +440,16 @@ type SignalPostsSchemaPreflightResult =
       missingColumns: string[];
       message: string;
     };
+
+type SignalPostCandidateSource = {
+  sourceName: string;
+  sourceUrl: string;
+};
+
+type BuiltSignalPostCandidates = {
+  candidates: EditorialSignalPost[];
+  skippedCandidates: SkippedSignalPostCandidate[];
+};
 
 let signalPostsSchemaPreflightPromise: Promise<SignalPostsSchemaPreflightResult> | null = null;
 let publicSignalPostsSchemaPreflightPromise: Promise<SignalPostsSchemaPreflightResult> | null = null;
@@ -649,6 +670,15 @@ function getPublishedSlateAuditSchemaPreflight(
 
 function normalizeEditorialText(value: string | null | undefined) {
   return value?.trim() ?? "";
+}
+
+function normalizePublicSourceUrl(value: string | null | undefined) {
+  const normalized = normalizeEditorialText(value);
+  return isValidPublicSourceUrl(normalized) ? normalized : "";
+}
+
+function buildMissingPublicSourceUrlMessage(action: string) {
+  return `${MISSING_PUBLIC_SOURCE_URL_REASON}: Add a valid public source URL before ${action}.`;
 }
 
 function normalizeDateValue(value: string | null | undefined) {
@@ -877,8 +907,11 @@ function mapStoredPublishedSlate(
 // Converts MVP BriefingItem view-models into signal_posts placement candidates.
 // The persisted rows are editorial/public placement rows, not durable Signal
 // history or Phase 2 progression identity.
-function mapBriefingItemToSignalPost(item: BriefingItem, index: number): EditorialSignalPost {
-  const leadSource = item.sources[0] ?? item.relatedArticles?.[0];
+function mapBriefingItemToSignalPost(
+  item: BriefingItem,
+  index: number,
+  source: SignalPostCandidateSource,
+): EditorialSignalPost {
   const tags = [
     item.topicName,
     item.signalRole,
@@ -898,8 +931,8 @@ function mapBriefingItemToSignalPost(item: BriefingItem, index: number): Editori
     briefingDate: null,
     rank: index + 1,
     title: item.title,
-    sourceName: leadSource?.title ?? "Unknown source",
-    sourceUrl: leadSource?.url ?? "",
+    sourceName: source.sourceName,
+    sourceUrl: source.sourceUrl,
     summary: item.whatHappened,
     tags,
     signalScore: item.importanceScore ?? item.matchScore ?? null,
@@ -955,8 +988,76 @@ function getValidationFailureMessage(validation: WhyItMattersValidationResult) {
     : "Why it matters requires a human rewrite before publishing.";
 }
 
-function buildSignalPostCandidates(items: BriefingItem[]) {
-  return items.slice(0, SIGNAL_POST_CANDIDATE_DEPTH_LIMIT).map(mapBriefingItemToSignalPost);
+function getBriefingItemSourceCandidates(item: BriefingItem): SignalPostCandidateSource[] {
+  return [
+    ...item.sources.map((source) => ({
+      sourceName: normalizeEditorialText(source.title) || "Unknown source",
+      sourceUrl: normalizeEditorialText(source.url),
+    })),
+    ...(item.relatedArticles ?? []).map((article) => ({
+      sourceName: normalizeEditorialText(article.sourceName || article.title) || "Unknown source",
+      sourceUrl: normalizeEditorialText(article.url),
+    })),
+  ];
+}
+
+function selectPublicSourceForBriefingItem(item: BriefingItem): SignalPostCandidateSource | null {
+  const source = getBriefingItemSourceCandidates(item).find((candidate) =>
+    isValidPublicSourceUrl(candidate.sourceUrl),
+  );
+
+  if (!source) {
+    return null;
+  }
+
+  return {
+    sourceName: source.sourceName,
+    sourceUrl: normalizePublicSourceUrl(source.sourceUrl),
+  };
+}
+
+function buildSkippedCandidateForBriefingItem(
+  item: BriefingItem,
+  pipelineRank: number,
+): SkippedSignalPostCandidate {
+  const origin = getBriefingItemSourceCandidates(item)[0]?.sourceName ?? item.topicName ?? "unknown";
+
+  return {
+    title: item.title,
+    candidateOrigin: origin,
+    pipelineRank,
+    reason: MISSING_PUBLIC_SOURCE_URL_REASON,
+  };
+}
+
+function buildSkippedCandidateForSignalPost(post: EditorialSignalPost): SkippedSignalPostCandidate {
+  return {
+    title: post.title,
+    candidateOrigin: post.sourceName || "unknown",
+    pipelineRank: post.rank,
+    reason: MISSING_PUBLIC_SOURCE_URL_REASON,
+  };
+}
+
+function buildSignalPostCandidates(items: BriefingItem[]): BuiltSignalPostCandidates {
+  const candidates: EditorialSignalPost[] = [];
+  const skippedCandidates: SkippedSignalPostCandidate[] = [];
+
+  items.slice(0, SIGNAL_POST_CANDIDATE_DEPTH_LIMIT).forEach((item, index) => {
+    const source = selectPublicSourceForBriefingItem(item);
+
+    if (!source) {
+      skippedCandidates.push(buildSkippedCandidateForBriefingItem(item, index + 1));
+      return;
+    }
+
+    candidates.push(mapBriefingItemToSignalPost(item, index, source));
+  });
+
+  return {
+    candidates,
+    skippedCandidates,
+  };
 }
 
 function parseEditorialSortTime(value: string | null | undefined) {
@@ -1107,28 +1208,43 @@ async function persistSignalPostCandidates(
   input: {
     briefingDate: string;
     candidates: EditorialSignalPost[];
+    skippedCandidates?: SkippedSignalPostCandidate[];
     mode?: SignalPostPersistenceMode;
   },
 ): Promise<SignalSnapshotPersistenceResult> {
   const briefingDate = normalizeDateValue(input.briefingDate) ?? new Date().toISOString().slice(0, 10);
   const mode = input.mode ?? "normal";
+  const preSkippedCandidates = input.skippedCandidates ?? [];
+  const sourceReadyCandidates = input.candidates.filter((post) =>
+    isValidPublicSourceUrl(post.sourceUrl),
+  );
+  const skippedCandidates = [
+    ...preSkippedCandidates,
+    ...input.candidates
+      .filter((post) => !isValidPublicSourceUrl(post.sourceUrl))
+      .map(buildSkippedCandidateForSignalPost),
+  ];
 
-  if (input.candidates.length === 0) {
+  if (sourceReadyCandidates.length === 0) {
     return {
       ok: false,
       briefingDate,
       insertedCount: 0,
       mode,
-      message: "The current signal pipeline returned no structurally eligible signal posts for editorial review.",
+      skippedCandidates,
+      message: skippedCandidates.length > 0
+        ? `No signal posts were persisted because ${skippedCandidates.length} candidate(s) were missing a valid public source URL.`
+        : "The current signal pipeline returned no structurally eligible signal posts for editorial review.",
     };
   }
 
-  if (mode !== "draft_only" && input.candidates.length < TOP_SIGNAL_SET_SIZE) {
+  if (mode !== "draft_only" && sourceReadyCandidates.length < TOP_SIGNAL_SET_SIZE) {
     return {
       ok: false,
       briefingDate,
       insertedCount: 0,
-      message: `The current signal pipeline returned ${input.candidates.length} signal posts. Persisting the daily snapshot requires at least five.`,
+      skippedCandidates,
+      message: `The current signal pipeline returned ${sourceReadyCandidates.length} source-ready signal posts. Persisting the daily snapshot requires at least five.`,
     };
   }
 
@@ -1150,6 +1266,7 @@ async function persistSignalPostCandidates(
       ok: false,
       briefingDate,
       insertedCount: 0,
+      skippedCandidates,
       message: `The current signal snapshot could not be checked: ${existingResult.error.message}`,
     };
   }
@@ -1160,7 +1277,7 @@ async function persistSignalPostCandidates(
       .map((row) => row.rank)
       .filter((rank): rank is number => typeof rank === "number"),
   );
-  const missingCandidates = input.candidates.filter((post) => !existingRanks.has(post.rank));
+  const missingCandidates = sourceReadyCandidates.filter((post) => !existingRanks.has(post.rank));
 
   if (missingCandidates.length === 0) {
     return {
@@ -1168,6 +1285,7 @@ async function persistSignalPostCandidates(
       briefingDate,
       insertedCount: 0,
       insertedPostIds: [],
+      skippedCandidates,
       mode,
       message: "The daily signal snapshot already exists for this briefing date.",
     };
@@ -1222,6 +1340,7 @@ async function persistSignalPostCandidates(
       ok: false,
       briefingDate,
       insertedCount: 0,
+      skippedCandidates,
       message: `The current Top 5 could not be persisted for editing: ${insertResult.error.message}`,
     };
   }
@@ -1233,6 +1352,7 @@ async function persistSignalPostCandidates(
     insertedPostIds: ((insertResult.data ?? []) as Array<{ id: string | null }>)
       .map((row) => row.id)
       .filter((id): id is string => Boolean(id)),
+    skippedCandidates,
     mode,
     message:
       missingCandidates.length === TOP_SIGNAL_SET_SIZE
@@ -1269,9 +1389,12 @@ export async function persistSignalPostsForBriefing(input: {
     };
   }
 
+  const builtCandidates = buildSignalPostCandidates(input.items);
+
   return persistSignalPostCandidates(client, {
     briefingDate: input.briefingDate,
-    candidates: buildSignalPostCandidates(input.items),
+    candidates: builtCandidates.candidates,
+    skippedCandidates: builtCandidates.skippedCandidates,
     mode: input.mode,
   });
 }
@@ -1852,6 +1975,38 @@ async function approveSignalPostWithContext(
     };
   }
 
+  const sourceLookup = await context.client
+    .from("signal_posts")
+    .select("id, source_url")
+    .eq("id", input.postId)
+    .maybeSingle();
+
+  if (sourceLookup.error) {
+    return {
+      ok: false,
+      code: "storage_error",
+      message: "The signal post could not be loaded for approval.",
+    };
+  }
+
+  if (!sourceLookup.data) {
+    return {
+      ok: false,
+      code: "not_found",
+      message: "The signal post could not be found.",
+    };
+  }
+
+  const sourceReadyPost = sourceLookup.data as Pick<StoredSignalPost, "id" | "source_url">;
+
+  if (!isValidPublicSourceUrl(sourceReadyPost.source_url)) {
+    return {
+      ok: false,
+      code: "missing_public_source_url",
+      message: buildMissingPublicSourceUrlMessage("approval"),
+    };
+  }
+
   const now = new Date().toISOString();
   const validation = validateWhyItMatters(editorialText);
 
@@ -2019,7 +2174,9 @@ export async function approveSignalPosts(input: {
 
   if (failedResults.length > 0) {
     const nonStorageFailure = failedResults.every((result) =>
-      result.code === "publish_blocked" || result.code === "empty_editorial_text",
+      result.code === "publish_blocked" ||
+      result.code === "empty_editorial_text" ||
+      result.code === "missing_public_source_url",
     );
 
     return {
@@ -2113,7 +2270,7 @@ async function loadDecisionTarget(
 ) {
   const lookup = await context.client
     .from("signal_posts")
-    .select("id, briefing_date, editorial_status, editorial_decision, final_slate_rank, final_slate_tier, is_live, published_at")
+    .select("id, briefing_date, source_url, editorial_status, editorial_decision, final_slate_rank, final_slate_tier, is_live, published_at")
     .eq("id", postId)
     .maybeSingle();
 
@@ -2129,6 +2286,7 @@ async function loadDecisionTarget(
     StoredSignalPost,
     | "id"
     | "briefing_date"
+    | "source_url"
     | "editorial_status"
     | "editorial_decision"
     | "final_slate_rank"
@@ -2381,7 +2539,7 @@ export async function assignSignalPostToFinalSlateSlot(input: {
 
   const lookup = await context.client
     .from("signal_posts")
-    .select("id, briefing_date, editorial_status, editorial_decision, is_live, published_at")
+    .select("id, briefing_date, source_url, editorial_status, editorial_decision, is_live, published_at")
     .eq("id", input.postId)
     .maybeSingle();
 
@@ -2395,7 +2553,7 @@ export async function assignSignalPostToFinalSlateSlot(input: {
 
   const post = lookup.data as Pick<
     StoredSignalPost,
-    "id" | "briefing_date" | "editorial_status" | "editorial_decision" | "is_live" | "published_at"
+    "id" | "briefing_date" | "source_url" | "editorial_status" | "editorial_decision" | "is_live" | "published_at"
   >;
   const briefingDate = normalizeDateValue(post.briefing_date);
 
@@ -2420,6 +2578,14 @@ export async function assignSignalPostToFinalSlateSlot(input: {
       ok: false,
       code: "publish_blocked",
       message: "Rejected, held, rewrite-requested, or removed rows cannot be assigned to the final slate.",
+    };
+  }
+
+  if (!isValidPublicSourceUrl(post.source_url)) {
+    return {
+      ok: false,
+      code: "missing_public_source_url",
+      message: buildMissingPublicSourceUrlMessage("final-slate assignment"),
     };
   }
 
@@ -2621,6 +2787,14 @@ export async function replaceSignalPostInFinalSlate(input: {
       ok: false,
       code: "publish_blocked",
       message: "Rejected, held, rewrite-requested, or removed rows cannot be used as replacements.",
+    };
+  }
+
+  if (!isValidPublicSourceUrl(replacement.source_url)) {
+    return {
+      ok: false,
+      code: "missing_public_source_url",
+      message: buildMissingPublicSourceUrlMessage("final-slate replacement"),
     };
   }
 

--- a/supabase/migrations/20260510110000_signal_posts_public_source_url_guard.sql
+++ b/supabase/migrations/20260510110000_signal_posts_public_source_url_guard.sql
@@ -1,0 +1,6 @@
+alter table public.signal_posts
+  drop constraint if exists signal_posts_public_source_url_check;
+
+alter table public.signal_posts
+  add constraint signal_posts_public_source_url_check
+  check (btrim(source_url) <> '' and source_url ~* '^https?://');

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -176,6 +176,8 @@ create table if not exists public.signal_posts (
   is_live boolean not null default false,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
+  constraint signal_posts_public_source_url_check
+    check (btrim(source_url) <> '' and source_url ~* '^https?://'),
   check (
     (final_slate_rank is null and final_slate_tier is null)
     or (final_slate_rank between 1 and 5 and final_slate_tier = 'core')


### PR DESCRIPTION
## Summary
- deletes the invalid source-empty smoke-test rows from the remediation record and adds the source URL guard that prevents the same write path from recurring
- skips missing-source candidates before `draft_only` / manual signal-post insertion and reports `missing_public_source_url` in `skippedCandidates`
- blocks approval, final-slate assignment, final-slate readiness, and publish readiness when `source_url` is missing or not `http://` / `https://`
- adds a database constraint migration for `signal_posts.source_url`

## Root Cause
Manual draft persistence built `signal_posts` rows and WITM validation metadata before enforcing that at least one reviewable public source URL existed.

## Governance
- Effective change type: bug-fix / data remediation
- Canonical PRD required: no
- Supporting records:
  - `docs/engineering/bug-fixes/source-url-prewrite-guard-2026-05-10.md`
  - `docs/engineering/change-records/source-url-prewrite-guard-remediation-2026-05-10.md`

## Validation
- `npm run test -- src/lib/signals-editorial.test.ts src/lib/final-slate-readiness.test.ts`
- `npm run lint`
- `npm run test`
- `npm run build`
- `python3 scripts/release-governance-gate.py`
- `python3 scripts/validate-documentation-coverage.py`
- Local app load returned HTTP 200 at `http://localhost:3000/`

## Production Readback Before PR
- target invalid row IDs remaining: 0
- empty or non-http(s) `source_url` rows scanned: 0
- `/`, `/signals`, `/briefing/2026-05-06`: HTTP 200
- `/api/cron/fetch-news`: HTTP 401 unauthenticated
- deployed Vercel cron list: `crons: []`
