### PR TITLE
docs: close out PR 203 and PR 208 production merges

### DIFF
--- a/docs/engineering/bug-fixes/source-url-prewrite-guard-2026-05-10.md
+++ b/docs/engineering/bug-fixes/source-url-prewrite-guard-2026-05-10.md
@@ -8,14 +8,15 @@
 ## Fix
 - Exact change: Delete the three invalid non-live rows, skip missing-source candidates before draft insertion, report skipped candidates with `missing_public_source_url`, block approval/final-slate assignment/final-slate readiness/publish readiness for missing public URLs, and add a database constraint preventing empty or non-http(s) `signal_posts.source_url`.
 - Related PRD: Not required. This is bug-fix / data remediation aligned to the existing Boot Up MVP editorial source-of-truth.
-- PR: Pending.
+- PR: `https://github.com/brandonma25/daily-intelligence-aggregator/pull/208`.
 - Branch: `bugfix/source-url-prewrite-guard-20260510`
-- Head SHA: This commit.
-- Merge SHA: Pending.
+- Head SHA: `0349988e60ce0d860c18fd26ca4b07d92ec2f6d5`.
+- Merge SHA: `24cf07e3b8f4f4394c3dd3667eec663de1f0782b`.
+- Production deploy: `dpl_5CDb9wxaBU54pnRw3ujF6podY3Hh`.
 - GitHub source-of-truth status: This record is the repo-side bug-fix record for the remediation.
 - External references reviewed, if any: None.
 - Google Sheet / Work Log reference, if historically relevant: None.
-- Branch cleanup status: Pending PR lifecycle.
+- Branch cleanup status: Merged remote branch deleted. Local worktree retained for follow-up cleanup.
 
 ## Terminology Requirement
 - Before implementation, read `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`.
@@ -38,6 +39,7 @@
   - Production public routes `/`, `/signals`, and `/briefing/2026-05-06` returned HTTP 200.
   - Production cron endpoint `/api/cron/fetch-news` returned HTTP 401 without credentials.
   - Vercel deployed cron list returned `crons: []`.
+  - Post-merge production deployment `dpl_5CDb9wxaBU54pnRw3ujF6podY3Hh` reached `Ready`.
 
 ## Remaining Risks / Follow-up
 - The database constraint is present as a repo migration and should be applied through the normal migration/deploy path for production enforcement. Application-level guards already prevent draft insertion, approval, final-slate assignment, and publish readiness for missing public URLs after this code is deployed.

--- a/docs/engineering/change-records/source-url-prewrite-guard-remediation-2026-05-10.md
+++ b/docs/engineering/change-records/source-url-prewrite-guard-remediation-2026-05-10.md
@@ -20,6 +20,9 @@
 
 ## Supporting Record
 - Bug-fix record: `docs/engineering/bug-fixes/source-url-prewrite-guard-2026-05-10.md`
+- PR: `https://github.com/brandonma25/daily-intelligence-aggregator/pull/208`
+- Merge SHA: `24cf07e3b8f4f4394c3dd3667eec663de1f0782b`
+- Production deploy: `dpl_5CDb9wxaBU54pnRw3ujF6podY3Hh`
 
 ## Validation Summary
 - Production source-empty inventory after cleanup: 0 rows.
@@ -27,3 +30,4 @@
 - Public routes checked: `/`, `/signals`, `/briefing/2026-05-06`.
 - Cron state checked: deployed cron list empty; unauthenticated cron endpoint returned HTTP 401.
 - Local validation checked: targeted tests, full test suite, lint, build, release governance gate, documentation coverage, and local HTTP 200 load.
+- Post-merge production deploy reached `Ready`; subsequent PR #203 documentation closeout deploy `dpl_6ueScqM69hWQbvkZNCkdnvvkDMbX` also reached `Ready` with the same public route and cron safety checks passing.

--- a/docs/engineering/testing/2026-05-10-pr203-pr208-production-closeout.md
+++ b/docs/engineering/testing/2026-05-10-pr203-pr208-production-closeout.md
@@ -1,0 +1,55 @@
+# PR #203 and PR #208 Production Closeout - Testing Report
+
+## Release Metadata
+- Date: 2026-05-10.
+- Branch: `docs/pr203-pr208-production-closeout-20260510`.
+- Scope: documentation closeout after production merges for PR #208 and PR #203.
+- Canonical PRD required: No. PR #208 was bug-fix / data remediation aligned to existing Boot Up MVP source-backed editorial standards; PR #203 was documentation closeout for the already-merged PR #202 public-surface remediation.
+
+## Merged Pull Requests
+- PR #208: `https://github.com/brandonma25/daily-intelligence-aggregator/pull/208`
+  - Title: `Guard signal posts against missing source URLs`.
+  - Head SHA: `0349988e60ce0d860c18fd26ca4b07d92ec2f6d5`.
+  - Merge SHA: `24cf07e3b8f4f4394c3dd3667eec663de1f0782b`.
+  - Production deploy: `dpl_5CDb9wxaBU54pnRw3ujF6podY3Hh`.
+- PR #203: `https://github.com/brandonma25/daily-intelligence-aggregator/pull/203`
+  - Title: `docs: close out PR 202 public surface remediation evidence`.
+  - Head SHA after branch update: `9a07db0ae45d16b9b38fb2aadb0833ed649eaf97`.
+  - Merge SHA: `96ff29cbd75406f77088d8b0c27f26b78e4d7950`.
+  - Production deploy: `dpl_6ueScqM69hWQbvkZNCkdnvvkDMbX`.
+
+## PR Gate Results
+- PR #208: passed `feature-system-csv-validation`, `release-governance-gate`, `pr-lint`, `pr-unit-tests`, `pr-build`, `pr-e2e-chromium`, `pr-e2e-webkit`, `pr-summary`, Vercel, and Vercel Preview Comments.
+- PR #203: GitHub initially blocked merge because the branch was behind `main`; the PR branch was updated, then the refreshed gate passed `feature-system-csv-validation`, `release-governance-gate`, `pr-lint`, `pr-unit-tests`, `pr-build`, `pr-e2e-chromium`, `pr-e2e-webkit`, `pr-summary`, Vercel, and Vercel Preview Comments.
+
+## Production Verification
+- Production alias: `https://daily-intelligence-aggregator-ybs9.vercel.app`.
+- Final production deploy after both merges: `dpl_6ueScqM69hWQbvkZNCkdnvvkDMbX`.
+- Production route checks after PR #203 deployment reached `Ready`:
+  - `/`: HTTP 200.
+  - `/signals`: HTTP 200.
+  - `/briefing/2026-05-06`: HTTP 200.
+  - `/api/cron/fetch-news`: HTTP 401 unauthenticated.
+- Vercel cron state after both merges:
+  - deployed `crons`: `[]`.
+  - undeployed cron entry remained listed for `/api/cron/fetch-news` with schedule `0 10 * * *`.
+
+## Data Safety Notes
+- No replacement rows were inserted during the merge closeout.
+- No rows were published during the merge closeout.
+- Cron was not re-enabled.
+- PR #208 production readback before PR #203 confirmed:
+  - target invalid smoke-test rows remaining: `0`.
+  - source-empty or non-http(s) `signal_posts.source_url` rows in the scanned set: `0`.
+  - eligible invalid source URL rows: `0`.
+  - live rows: `3`.
+  - latest live `published_at`: `2026-05-06T05:19:08.978+00:00`.
+
+## Documentation Closeout
+- Updated bug-fix record: `docs/engineering/bug-fixes/source-url-prewrite-guard-2026-05-10.md`.
+- Existing PR #202 validation report remains the source for the public-surface remediation evidence closed by PR #203: `docs/engineering/testing/pr-202-public-surface-copy-remediation-validation.md`.
+- Tracker-sync fallback created because direct live tracker verification was not performed in this documentation pass: `docs/operations/tracker-sync/2026-05-10-pr203-pr208-production-closeout.md`.
+
+## Remaining Risks
+- The PR #208 database constraint migration is merged in the repo. This closeout did not manually run a Supabase migration command.
+- The stale local `main` worktree at `/Users/bm/dev/worktrees/bootup-editorial-history-ordering` remains locally divergent and was intentionally not used for edits.

--- a/docs/operations/tracker-sync/2026-05-10-pr203-pr208-production-closeout.md
+++ b/docs/operations/tracker-sync/2026-05-10-pr203-pr208-production-closeout.md
@@ -1,0 +1,40 @@
+# Tracker Sync Fallback - PR #203 and PR #208 Production Closeout
+
+## Reason
+- Direct live Google Sheets tracker verification was not performed during this documentation closeout.
+- Per release protocol, this fallback records the exact manual tracker payload needed for review.
+
+## Manual Update Payload
+- Work item: PR #208 source URL pre-write guard.
+  - Change type: bug-fix / data remediation.
+  - Suggested tracker lane: existing bug-fix / remediation row if present; otherwise Intake Queue.
+  - Suggested status: `Built`.
+  - PR: `https://github.com/brandonma25/daily-intelligence-aggregator/pull/208`.
+  - Merge SHA: `24cf07e3b8f4f4394c3dd3667eec663de1f0782b`.
+  - Production deploy: `dpl_5CDb9wxaBU54pnRw3ujF6podY3Hh`.
+  - Repo docs:
+    - `docs/engineering/bug-fixes/source-url-prewrite-guard-2026-05-10.md`
+    - `docs/engineering/change-records/source-url-prewrite-guard-remediation-2026-05-10.md`
+    - `docs/engineering/testing/2026-05-10-pr203-pr208-production-closeout.md`
+  - PRD file: none.
+  - Canonical PRD required: No.
+  - Production verification: public routes `/`, `/signals`, and `/briefing/2026-05-06` returned HTTP 200; `/api/cron/fetch-news` returned HTTP 401; deployed Vercel `crons` remained `[]`.
+
+- Work item: PR #203 PR #202 public-surface remediation documentation closeout.
+  - Change type: documentation closeout.
+  - Suggested tracker lane: existing PR #202 public-surface remediation row if present; otherwise Intake Queue.
+  - Suggested status: `Built`.
+  - PR: `https://github.com/brandonma25/daily-intelligence-aggregator/pull/203`.
+  - Merge SHA: `96ff29cbd75406f77088d8b0c27f26b78e4d7950`.
+  - Production deploy: `dpl_6ueScqM69hWQbvkZNCkdnvvkDMbX`.
+  - Repo docs:
+    - `docs/engineering/testing/pr-202-public-surface-copy-remediation-validation.md`
+    - `docs/engineering/testing/2026-05-10-pr203-pr208-production-closeout.md`
+  - PRD file: none.
+  - Canonical PRD required: No.
+  - Production verification: public routes `/`, `/signals`, and `/briefing/2026-05-06` returned HTTP 200; `/api/cron/fetch-news` returned HTTP 401; deployed Vercel `crons` remained `[]`.
+
+## Notes
+- Do not create duplicate governed rows in `Sheet1`.
+- Use an existing governed row only by exact `Record ID` if one exists.
+- If no governed row exists, route the update to `Intake Queue`.


### PR DESCRIPTION
## Summary
- record production closeout evidence for merged PR #208 and PR #203
- update the source URL pre-write guard bug-fix/change records with PR, merge, deploy, and cleanup state
- add a tracker-sync fallback payload because live Google Sheets tracker verification was not performed in this docs pass

## Validation
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name docs/pr203-pr208-production-closeout-20260510 --pr-title "docs: close out PR 203 and PR 208 production merges"`
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name docs/pr203-pr208-production-closeout-20260510 --pr-title "docs: close out PR 203 and PR 208 production merges"`
- `git diff --check`

## Notes
- Docs-only closeout; no code, schema, cron, source manifest, pipeline, publish, or data changes.
- Canonical PRD required: no.
