### PR TITLE
fix: align production URL metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,4 +21,4 @@ SENTRY_PROJECT=your_sentry_project_slug
 SENTRY_AUTH_TOKEN=
 RSS_CRON_MONITOR_SLUG=rss-feed-refresh
 RSS_STALE_THRESHOLD_MS=108000000
-PUBLIC_SITE_URL=https://your-production-domain.example
+PUBLIC_SITE_URL=https://bootupnews.vercel.app

--- a/docs/engineering/bug-fixes/briefing-detail-public-debug-artifacts.md
+++ b/docs/engineering/bug-fixes/briefing-detail-public-debug-artifacts.md
@@ -7,7 +7,7 @@
 
 ## Source Of Truth
 - Cowork frontend UX analysis 2026-05-06, prioritized shortlist Fix 1 and Fix 2.
-- Production URL observed before fix: `https://daily-intelligence-aggregator-ybs9.vercel.app/briefing/2026-05-06`.
+- Production URL observed before fix: `https://bootupnews.vercel.app/briefing/2026-05-06`.
 - BOOT_UP_WORK_LOG Decision D3 historical reference: no false freshness; trust matters more than daily automation optics.
 - Canonical PRD required: no.
 

--- a/docs/engineering/bug-fixes/public-card-cleanup-remediation-2026-05-02.md
+++ b/docs/engineering/bug-fixes/public-card-cleanup-remediation-2026-05-02.md
@@ -6,7 +6,7 @@
 - Affected object level: Card and Surface Placement.
 
 ## Source Of Truth
-- Live production audit of `daily-intelligence-aggregator-ybs9.vercel.app` on 2026-05-02.
+- Live production audit of `bootupnews.vercel.app` on 2026-05-02.
 - PR #180, #181, #187, and #189 metadata and PR bodies.
 - Prior Phase 1 change record: `docs/engineering/change-records/2026-05-02-public-card-cleanup-phase-1.md`.
 - GitHub source-of-truth status: canonical consolidated remediation record created on 2026-05-04.

--- a/docs/engineering/bug-fixes/public-card-tabs-remediation-2026-05-08.md
+++ b/docs/engineering/bug-fixes/public-card-tabs-remediation-2026-05-08.md
@@ -8,7 +8,7 @@
 ## Source Of Truth
 - Cowork eliminate-only analysis 2026-05-08 subtraction-lens shortlist.
 - Cowork frontend UX analysis 2026-05-06 taxonomy mismatch diagnosis.
-- Production homepage HTML/RSC payload fetched 2026-05-08 from `https://daily-intelligence-aggregator-ybs9.vercel.app/`.
+- Production homepage HTML/RSC payload fetched 2026-05-08 from `https://bootupnews.vercel.app/`.
 - Product Position fail-closed empty-state principle, no false freshness, and Signal Card structure guidance supplied by PM.
 - PR #202 and PR #204 GitHub diffs.
 - Canonical PRD required: No.

--- a/docs/engineering/bug-fixes/public-surface-copy-remediation-2026-05-07.md
+++ b/docs/engineering/bug-fixes/public-surface-copy-remediation-2026-05-07.md
@@ -55,7 +55,7 @@
   - Local browser `/briefing/2026-05-06` did not have production snapshot data available, but confirmed `Why this ranks here` and `confirmed-event rail` were absent from the rendered page.
   - Vercel preview verification passed for `/`, `/signals`, and `/briefing/2026-05-06`; removed internal strings were absent and unchanged public content remained visible.
   - Production deployment: `dpl_5vYVQSc3ak8Wi39B6E42xUsDSsva`, `https://bootup-l9r4iysw2-brandonma25s-projects.vercel.app`, created `2026-05-07T04:58:31Z`, target `production`, status `Ready`.
-  - Production alias checked: `https://daily-intelligence-aggregator-ybs9.vercel.app`.
+  - Production alias checked: `https://bootupnews.vercel.app`.
   - Production HTTP checks passed: `/` 200, `/signals` 200, `/briefing/2026-05-06` 200.
   - Production Chrome incognito click-level QA passed: homepage category tabs, category gates, login routing, briefing detail navigation, detail tabs, `/signals`, and `/signals` to homepage navigation all worked.
   - Fix-specific production QA passed: `/briefing/2026-05-06` no longer rendered `Why this ranks here` or `confirmed-event rail`; `/signals` no longer rendered `watch`, `High`, or `Published editorial layer`; `/signals` still rendered category tags such as `Finance` and `Tech`.

--- a/docs/engineering/change-records/2026-05-02-public-card-cleanup-phase-1.md
+++ b/docs/engineering/change-records/2026-05-02-public-card-cleanup-phase-1.md
@@ -3,7 +3,7 @@
 Date: 2026-05-02
 Branch: `feature/public-card-cleanup-phase-1`
 Change type: remediation / display-layer cleanup
-Source of truth: live production audit of `daily-intelligence-aggregator-ybs9.vercel.app` on 2026-05-02
+Source of truth: live production audit of `bootupnews.vercel.app` on 2026-05-02
 
 ## Problem
 

--- a/docs/engineering/change-records/2026-05-10-production-url-alignment-remediation.md
+++ b/docs/engineering/change-records/2026-05-10-production-url-alignment-remediation.md
@@ -1,0 +1,31 @@
+# Production URL Alignment Remediation
+
+Date: 2026-05-10
+
+Change type: remediation
+
+Canonical PRD required: no
+
+## Source of Truth
+
+User-declared production URL migration from the legacy Vercel production host
+and invalid interim host to:
+
+- Canonical production origin: `bootupnews.vercel.app`
+- Canonical full production URL: `https://bootupnews.vercel.app`
+
+## Scope
+
+This remediation updates repo-controlled production URL references only. It does
+not change routing, auth logic, deployment architecture, editorial workflow,
+content model, cron behavior, or public publishing behavior.
+
+## Implementation Notes
+
+- Repo-controlled full production URLs now use `https://bootupnews.vercel.app`.
+- Host-only production references now use `bootupnews.vercel.app`.
+- Public metadata uses the centralized app-origin helper in `src/lib/env.ts` for
+  homepage canonical metadata, Open Graph URL, Twitter URL, `robots.txt` sitemap
+  reference, and `sitemap.xml` homepage URL.
+- External Vercel, auth-provider, monitoring, analytics, Search Console, and
+  social preview settings remain outside repo scope.

--- a/docs/engineering/testing/2026-05-10-pr203-pr208-production-closeout.md
+++ b/docs/engineering/testing/2026-05-10-pr203-pr208-production-closeout.md
@@ -23,7 +23,7 @@
 - PR #203: GitHub initially blocked merge because the branch was behind `main`; the PR branch was updated, then the refreshed gate passed `feature-system-csv-validation`, `release-governance-gate`, `pr-lint`, `pr-unit-tests`, `pr-build`, `pr-e2e-chromium`, `pr-e2e-webkit`, `pr-summary`, Vercel, and Vercel Preview Comments.
 
 ## Production Verification
-- Production alias: `https://daily-intelligence-aggregator-ybs9.vercel.app`.
+- Production alias: `https://bootupnews.vercel.app`.
 - Final production deploy after both merges: `dpl_6ueScqM69hWQbvkZNCkdnvvkDMbX`.
 - Production route checks after PR #203 deployment reached `Ready`:
   - `/`: HTTP 200.

--- a/docs/engineering/testing/admin-review-limited-core-context-drafts-20260429.md
+++ b/docs/engineering/testing/admin-review-limited-core-context-drafts-20260429.md
@@ -50,7 +50,7 @@ This is remediation / controlled validation under the existing Boot Up product s
 - Production deployment status: READY.
 - Deployment URL: `https://bootup-jcwesbvxp-brandonma25s-projects.vercel.app`
 - Deployment ID: `dpl_7uz2kZftfvWrERV4jRBkfp5ybKMX`
-- Production alias checked: `https://daily-intelligence-aggregator-ybs9.vercel.app`
+- Production alias checked: `https://bootupnews.vercel.app`
 - `/` returned HTTP `200`.
 - `/signals` returned HTTP `200`.
 - `/dashboard/signals/editorial-review` returned HTTP `200` when unauthenticated, but did not render private draft rows.

--- a/docs/engineering/testing/editorial-rewrite-packet-core-context-drafts-20260429.md
+++ b/docs/engineering/testing/editorial-rewrite-packet-core-context-drafts-20260429.md
@@ -55,7 +55,7 @@ This is remediation / editorial validation against the existing Boot Up product 
 - Production deployment status: READY.
 - Deployment URL: `https://bootup-8f9iazuke-brandonma25s-projects.vercel.app`
 - Deployment ID: `dpl_3qNVyAnzTo9Eerx7zBF68YxB41WR`
-- Production alias checked: `https://daily-intelligence-aggregator-ybs9.vercel.app`
+- Production alias checked: `https://bootupnews.vercel.app`
 - `/` returned HTTP `200`.
 - `/signals` returned HTTP `200`.
 - Public live briefing date remained `2026-04-26` by live-row readback from the prior validation state.

--- a/docs/engineering/testing/limited-core-context-draft-only-validation-20260429.md
+++ b/docs/engineering/testing/limited-core-context-draft-only-validation-20260429.md
@@ -24,7 +24,7 @@ block_admin_review_due_to_missing_witm_failure_metadata
 - PR #141: `chore(validation): align controlled draft cap with Core/Context slate`
 - PR #141 merge commit: `efb1eea94d0452863b487c5e5b796635380597b8`
 - Production deployment URL: `https://bootup-d58ldcsvq-brandonma25s-projects.vercel.app`
-- Production alias checked: `https://daily-intelligence-aggregator-ybs9.vercel.app`
+- Production alias checked: `https://bootupnews.vercel.app`
 - Prior post-PR139 dry-run run ID: `post-pr139-context-witm-remediation-dryrun-20260429T0546Z`
 - Prior artifact:
   `/Users/bm/dev/worktrees/daily-intelligence-aggregator-post-pr139-context-witm-post-deploy-validation/.pipeline-runs/controlled-pipeline-dry_run-post-pr139-context-witm-remediation-dryrun-20260429T0546Z-2026-04-29T05-47-11-859Z.json`

--- a/docs/engineering/testing/post-pr139-context-witm-post-deploy-validation.md
+++ b/docs/engineering/testing/post-pr139-context-witm-post-deploy-validation.md
@@ -35,7 +35,7 @@ PR #139 was retitled from a `fix(...)` prefix to a remediation prefix before mer
 | Deployment target | production |
 | Deployment status | READY |
 | Deployment commit | `f0251f02743640a073535c288093496c05bc0908` |
-| Production alias checked | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production alias checked | `https://bootupnews.vercel.app` |
 | Homepage HTTP status | 200 |
 | `/signals` HTTP status | 200 |
 

--- a/docs/engineering/testing/pr-202-public-surface-copy-remediation-validation.md
+++ b/docs/engineering/testing/pr-202-public-surface-copy-remediation-validation.md
@@ -41,7 +41,7 @@
 - Result: preview routes loaded, removed internal strings were absent, and unchanged public content remained visible.
 
 ## Production Deployment
-- Production alias: `https://daily-intelligence-aggregator-ybs9.vercel.app`.
+- Production alias: `https://bootupnews.vercel.app`.
 - Immutable deploy URL: `https://bootup-l9r4iysw2-brandonma25s-projects.vercel.app`.
 - Deploy ID: `dpl_5vYVQSc3ak8Wi39B6E42xUsDSsva`.
 - Deploy timestamp: `2026-05-07T04:58:31Z`.
@@ -53,7 +53,7 @@
 
 ## Chrome Incognito Click-Level QA
 - Tool: Codex Computer Use in Google Chrome incognito.
-- Target: `https://daily-intelligence-aggregator-ybs9.vercel.app`.
+- Target: `https://bootupnews.vercel.app`.
 - Session state: logged out; no signed-in account UI or Vercel toolbar observed.
 - Click path verified:
   - Homepage loaded.

--- a/docs/engineering/testing/signed-in-home-dashboard-production-qa-2026-04-22.md
+++ b/docs/engineering/testing/signed-in-home-dashboard-production-qa-2026-04-22.md
@@ -5,7 +5,7 @@
 - Change type: remediation QA follow-up / alignment evidence.
 - Canonical PRD required: no.
 - Branch: `fix/signed-out-homepage-qa-remediation`.
-- Production target: `https://daily-intelligence-aggregator-ybs9.vercel.app/`.
+- Production target: `https://bootupnews.vercel.app/`.
 - Account: dummy QA account provided by the PM; password and session details are intentionally omitted.
 
 ## Source Of Truth

--- a/docs/engineering/testing/witm-metadata-targeted-repair-validation-20260429.md
+++ b/docs/engineering/testing/witm-metadata-targeted-repair-validation-20260429.md
@@ -41,7 +41,7 @@ This was remediation / controlled validation. It repaired existing review metada
 - Merge commit: `a25328a8378f73082e0e10cc35989c11c1c7c0c8`
 - Production deployment status: READY.
 - Deployment URL: `https://bootup-3edo9xd4n-brandonma25s-projects.vercel.app`
-- Production alias checked: `https://daily-intelligence-aggregator-ybs9.vercel.app`
+- Production alias checked: `https://bootupnews.vercel.app`
 - Deployment ID: `dpl_GcfxvqMioen2pjVra3hpB2k5kb4A`
 - The PR #143 source branch was not deleted because the local branch is still attached to a worktree.
 

--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-applied-schema-alignment-and-cycle-rerun.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-applied-schema-alignment-and-cycle-rerun.md
@@ -54,7 +54,7 @@ The production schema migration was not applied because the dry-run pending set 
 | Commit description | `Merge pull request #156 from brandonma25/codex/prd-53-authorized-production-schema-alignment` |
 | UTC capture time | `2026-04-30T06:05:46Z` |
 | Local capture time | `2026-04-30 14:05:46 CST` |
-| Production URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production URL | `https://bootupnews.vercel.app` |
 
 ## Baseline production schema preflight
 
@@ -225,11 +225,11 @@ sed -n '360,530p' src/lib/signals-editorial.ts
 date -u '+%Y-%m-%dT%H:%M:%SZ'
 date '+%Y-%m-%d %H:%M:%S %Z'
 gh variable list --repo brandonma25/daily-intelligence-aggregator
-curl -L -sS -o /tmp/bootup-apply-schema-home-before.html -w '%{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/
-curl -L -sS -o /tmp/bootup-apply-schema-signals-before.html -w '%{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/signals
-curl -L -sS -o /tmp/bootup-apply-schema-cron-before.txt -w '%{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/api/cron/fetch-news
+curl -L -sS -o /tmp/bootup-apply-schema-home-before.html -w '%{http_code} %{url_effective}\n' https://bootupnews.vercel.app/
+curl -L -sS -o /tmp/bootup-apply-schema-signals-before.html -w '%{http_code} %{url_effective}\n' https://bootupnews.vercel.app/signals
+curl -L -sS -o /tmp/bootup-apply-schema-cron-before.txt -w '%{http_code} %{url_effective}\n' https://bootupnews.vercel.app/api/cron/fetch-news
 rg -o 'sentry-release=[^,&"]+|signal_posts schema preflight failed\.[^<"]+|published_slate audit schema preflight failed\.[^<"]+|Missing expected columns: [^<"]+|0 signals|Published Signals are not available yet|Daily Executive Briefing|Today • [^<]+' /tmp/bootup-apply-schema-home-before.html /tmp/bootup-apply-schema-signals-before.html /tmp/bootup-apply-schema-cron-before.txt
-node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+node scripts/prod-check.js https://bootupnews.vercel.app
 supabase --version
 find supabase -maxdepth 3 -type f | sort
 find supabase/.temp -maxdepth 1 -type f -print 2>/dev/null | sort || true

--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-controlled-draft-only-rerun.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-controlled-draft-only-rerun.md
@@ -45,7 +45,7 @@ This rerun was authorized only for controlled production `draft_only` / non-live
 | Branch | `codex/prd-53-authorized-controlled-draft-only-rerun` |
 | Starting commit | `548ffdfb6e5845d0a0a2e3dccaa01d50ac0cba2c` |
 | Commit description | `Merge pull request #170 from brandonma25/codex/prd-53-authorized-controlled-draft-only` |
-| Production app URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production app URL | `https://bootupnews.vercel.app` |
 | Production deployment | `dpl_ESSRCej2jGfgNdjKFUCwtfY72iCz`, status Ready |
 
 The canonical checkout at `/Users/bm/dev/daily-intelligence-aggregator` remained on its existing branch and was not disturbed. This validation used the dedicated worktree above.
@@ -110,8 +110,8 @@ Setup and baseline checks:
 ```bash
 npm install
 vercel link --yes --project bootup --scope brandonma25s-projects --no-color
-node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app/
-vercel inspect https://daily-intelligence-aggregator-ybs9.vercel.app --no-color
+node scripts/prod-check.js https://bootupnews.vercel.app/
+vercel inspect https://bootupnews.vercel.app --no-color
 node <public route baseline check>
 node <read-only Supabase aggregate baseline check>
 ```
@@ -148,7 +148,7 @@ Post-run verification:
 
 ```bash
 node <read-only Supabase verification for inserted review row IDs>
-node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app/
+node scripts/prod-check.js https://bootupnews.vercel.app/
 node <public route post-check>
 node <read-only live row ID overlap check>
 npx tsx -e "<final-slate readiness validation against created rows>"
@@ -306,7 +306,7 @@ Public page text contains two article/source-title strings that also belong to p
 Chrome Computer Use inspected:
 
 ```text
-https://daily-intelligence-aggregator-ybs9.vercel.app/dashboard/signals/editorial-review
+https://bootupnews.vercel.app/dashboard/signals/editorial-review
 ```
 
 Observed admin state:

--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-controlled-draft-only.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-controlled-draft-only.md
@@ -47,7 +47,7 @@ This run was authorized only for controlled production `draft_only` / non-live c
 | UTC capture time | `2026-05-01T04:13:20Z` |
 | Local capture time | `2026-05-01 12:13:20 CST` |
 | Production deployment SHA | `37a0d4cf8de98a5171e38a8486618a48e0ca7916` |
-| Production app URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production app URL | `https://bootupnews.vercel.app` |
 | Supabase project ref | `fwkqjeumreaznfhnlzev` |
 
 The canonical checkout at `/Users/bm/dev/daily-intelligence-aggregator` remained on its existing branch and was not disturbed. This validation used the dedicated worktree above.
@@ -115,7 +115,7 @@ Baseline read-only checks:
 
 ```bash
 python3 <public route baseline smoke script>
-node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+node scripts/prod-check.js https://bootupnews.vercel.app
 supabase projects list --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-authorized-controlled-draft-only
 supabase link --project-ref fwkqjeumreaznfhnlzev --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-authorized-controlled-draft-only
 supabase db query "<read-only live/audit/count select>" --linked --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-authorized-controlled-draft-only --output table

--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-migration-history-repair.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-migration-history-repair.md
@@ -43,7 +43,7 @@ The approved next action was therefore to repair migration history for only the 
 | UTC capture time | `2026-05-01T02:36:17Z` |
 | Local capture time | `2026-05-01 10:36:17 CST` |
 | Production project ref | `fwkqjeumreaznfhnlzev` |
-| Production app URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production app URL | `https://bootupnews.vercel.app` |
 
 The canonical checkout at `/Users/bm/dev/daily-intelligence-aggregator` remained on its existing branch and was not disturbed. This repair used the dedicated worktree above.
 
@@ -146,7 +146,7 @@ Public safety verification:
 python3 - <<'PY'
 from urllib.request import Request, urlopen
 routes = ['/', '/signals']
-base = 'https://daily-intelligence-aggregator-ybs9.vercel.app'
+base = 'https://bootupnews.vercel.app'
 for route in routes:
     req = Request(base + route, headers={'User-Agent': 'codex-public-safety-smoke/1.0'})
     with urlopen(req, timeout=20) as resp:
@@ -251,7 +251,7 @@ The earlier DML/backfill migrations no longer appear in dry-run output. No unexp
 
 ## Public Safety Verification
 
-Production app URL: `https://daily-intelligence-aggregator-ybs9.vercel.app`
+Production app URL: `https://bootupnews.vercel.app`
 
 | Route | HTTP status | Public raw schema error exposed | Missing PRD-53 column names exposed | Public expected markers |
 | --- | --- | --- | --- | --- |

--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-schema-alignment-and-cycle-rerun.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-schema-alignment-and-cycle-rerun.md
@@ -52,7 +52,7 @@ The prompt was not treated as migration authorization because it did not include
 | Commit description | `Merge pull request #155 from brandonma25/codex/prd-53-production-schema-migration-alignment` |
 | UTC capture time | `2026-04-30T05:19:46Z` |
 | Local capture time | `2026-04-30 13:19:46 CST` |
-| Production URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production URL | `https://bootupnews.vercel.app` |
 
 ## Baseline production schema preflight
 
@@ -259,11 +259,11 @@ sed -n '1,260p' supabase/migrations/20260430110000_signal_posts_editorial_card_c
 sed -n '1,300p' supabase/migrations/20260430120000_published_slates_minimal_audit_history.sql
 printenv | rg 'CONTROLLED_PRODUCTION_SCHEMA_MIGRATION_APPROVED|CONTROLLED_PRODUCTION_PUBLISH_APPROVED|SUPABASE|VERCEL|PRODUCTION_BASE_URL|PIPELINE'
 gh variable list --repo brandonma25/daily-intelligence-aggregator
-curl -L -sS -o /tmp/bootup-authorized-align-home.html -w '%{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/
-curl -L -sS -o /tmp/bootup-authorized-align-signals.html -w '%{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/signals
-curl -L -sS -o /tmp/bootup-authorized-align-cron.txt -w '%{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/api/cron/fetch-news
+curl -L -sS -o /tmp/bootup-authorized-align-home.html -w '%{http_code} %{url_effective}\n' https://bootupnews.vercel.app/
+curl -L -sS -o /tmp/bootup-authorized-align-signals.html -w '%{http_code} %{url_effective}\n' https://bootupnews.vercel.app/signals
+curl -L -sS -o /tmp/bootup-authorized-align-cron.txt -w '%{http_code} %{url_effective}\n' https://bootupnews.vercel.app/api/cron/fetch-news
 rg -o 'sentry-release=[^,&"]+|signal_posts schema preflight failed\.[^<"]+|Missing expected columns: [^<"]+|0 signals|Published Signals are not available yet|Daily Executive Briefing|Today • [^<]+' /tmp/bootup-authorized-align-home.html /tmp/bootup-authorized-align-signals.html /tmp/bootup-authorized-align-cron.txt
-node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+node scripts/prod-check.js https://bootupnews.vercel.app
 supabase --version
 supabase migration list --linked --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-authorized-production-schema-alignment
 supabase db push --dry-run --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-authorized-production-schema-alignment

--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-schema-apply.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-authorized-schema-apply.md
@@ -51,7 +51,7 @@ After that repair, `supabase db push --dry-run --linked` showed only the three e
 | UTC capture time | `2026-05-01T03:10:19Z` |
 | Local capture time | `2026-05-01 11:10:19 CST` |
 | Production project ref | `fwkqjeumreaznfhnlzev` |
-| Production app URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production app URL | `https://bootupnews.vercel.app` |
 | Supabase CLI version | `2.90.0` |
 
 The canonical checkout at `/Users/bm/dev/daily-intelligence-aggregator` remained on its existing branch and was not disturbed. This apply used the dedicated worktree above.
@@ -158,7 +158,7 @@ Public and admin safety checks:
 ```bash
 python3 - <<'PY'
 from urllib.request import Request, urlopen
-base = 'https://daily-intelligence-aggregator-ybs9.vercel.app'
+base = 'https://bootupnews.vercel.app'
 routes = ['/', '/signals', '/dashboard/signals/editorial-review']
 needles = ['signal_posts schema preflight failed', 'published_slate audit schema preflight failed', 'final_slate_rank', 'final_slate_tier', 'editorial_decision', 'reviewed_at']
 for route in routes:
@@ -180,7 +180,7 @@ PY
 python3 - <<'PY'
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError
-url = 'https://daily-intelligence-aggregator-ybs9.vercel.app/api/cron/fetch-news'
+url = 'https://bootupnews.vercel.app/api/cron/fetch-news'
 req = Request(url, headers={'User-Agent': 'codex-cron-disabled-smoke/1.0'})
 try:
     with urlopen(req, timeout=20) as resp:
@@ -288,7 +288,7 @@ This establishes schema-layer readiness for the PRD-53 final-slate/admin workflo
 
 ## Public Safety Verification
 
-Production app URL: `https://daily-intelligence-aggregator-ybs9.vercel.app`
+Production app URL: `https://bootupnews.vercel.app`
 
 | Route | HTTP status | Public raw schema error exposed | Missing PRD-53 column names exposed | Expected public markers |
 | --- | --- | --- | --- | --- |

--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-catalog-access-confirmed-inspection.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-catalog-access-confirmed-inspection.md
@@ -57,7 +57,7 @@ The run used only read-only/dry-run Supabase commands and read-only catalog quer
 | Local capture time | `2026-05-01 09:56:40 CST` |
 | Production project ref | `fwkqjeumreaznfhnlzev` |
 | Production project URL | `https://fwkqjeumreaznfhnlzev.supabase.co` |
-| Production app URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production app URL | `https://bootupnews.vercel.app` |
 
 The canonical checkout at `/Users/bm/dev/daily-intelligence-aggregator` remained on its existing branch and was not disturbed. This inspection used the dedicated worktree above.
 

--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-catalog-level-database-owner-review.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-catalog-level-database-owner-review.md
@@ -55,7 +55,7 @@ This run attempted catalog-level production inspection under read-only authoriza
 | Commit description | `Merge pull request #159 from brandonma25/codex/prd-53-database-owner-migration-history-review` |
 | UTC capture time | `2026-04-30T18:32:01Z` |
 | Local capture time | `2026-05-01 02:32:01 CST` |
-| Production URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production URL | `https://bootupnews.vercel.app` |
 
 The stale `/Users/bm/Documents/daily-intelligence-aggregator-main` checkout was not used for repo work because `git status --short --branch` failed with `error: bad tree object HEAD`.
 
@@ -324,12 +324,12 @@ supabase migration list --linked --workdir /Users/bm/dev/worktrees/daily-intelli
 supabase db push --dry-run --linked --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-catalog-level-database-owner-review
 supabase db query --linked --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-catalog-level-database-owner-review --output json "select version from supabase_migrations.schema_migrations order by version;"
 supabase db query --linked --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-catalog-level-database-owner-review --output json "<combined read-only catalog query>"
-curl -sS -I https://daily-intelligence-aggregator-ybs9.vercel.app/
-curl -sS -I https://daily-intelligence-aggregator-ybs9.vercel.app/signals
-curl -sS -I https://daily-intelligence-aggregator-ybs9.vercel.app/api/cron/fetch-news
-curl -L -sS -o /tmp/bootup-catalog-review-home.html -w 'home %{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/
-curl -L -sS -o /tmp/bootup-catalog-review-signals.html -w 'signals %{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/signals
-node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+curl -sS -I https://bootupnews.vercel.app/
+curl -sS -I https://bootupnews.vercel.app/signals
+curl -sS -I https://bootupnews.vercel.app/api/cron/fetch-news
+curl -L -sS -o /tmp/bootup-catalog-review-home.html -w 'home %{http_code} %{url_effective}\n' https://bootupnews.vercel.app/
+curl -L -sS -o /tmp/bootup-catalog-review-signals.html -w 'signals %{http_code} %{url_effective}\n' https://bootupnews.vercel.app/signals
+node scripts/prod-check.js https://bootupnews.vercel.app
 rg -o 'sentry-release=[^,&"]+|signal_posts schema preflight failed\.[^<"]+|published_slate audit schema preflight failed\.[^<"]+|Missing expected columns: [^<"]+|0 signals|Published Signals are not available yet|Daily Executive Briefing|Today • [^<]+' /tmp/bootup-catalog-review-home.html /tmp/bootup-catalog-review-signals.html
 git diff --check
 npm run lint
@@ -354,7 +354,7 @@ python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex
 | Combined read-only catalog query | Blocked by `ECIRCUITBREAKER` on Supabase temp-login role. No mutation occurred. |
 | Homepage and `/signals` HEAD checks | Both HTTP 200. |
 | Cron endpoint HEAD check | HTTP 401 unauthorized. |
-| `node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app` | Failed because `/` was HTTP 200 but missing expected public briefing markers. |
+| `node scripts/prod-check.js https://bootupnews.vercel.app` | Failed because `/` was HTTP 200 but missing expected public briefing markers. |
 | `git diff --check` | Passed. |
 | `npm run lint` | Passed using a matching dependency tree symlinked from a sibling worktree with identical `package.json` and `package-lock.json`. |
 | `npm run test` | Passed: 73 test files and 572 tests. |

--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-database-owner-migration-history-review.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-database-owner-migration-history-review.md
@@ -54,7 +54,7 @@ This run adds authorized read-only schema evidence. It confirms the same broad s
 | Commit description | `Merge pull request #158 from brandonma25/codex/prd-53-migration-history-drift-diagnosis` |
 | UTC capture time | `2026-04-30T18:01:23Z` |
 | Local capture time | `2026-05-01 02:01:23 CST` |
-| Production URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production URL | `https://bootupnews.vercel.app` |
 
 The stale `/Users/bm/Documents/daily-intelligence-aggregator-main` checkout was not used for repo work because `git status --short --branch` failed with `error: bad tree object HEAD`.
 
@@ -341,9 +341,9 @@ supabase migration list --linked --workdir /Users/bm/dev/worktrees/daily-intelli
 supabase db push --dry-run --linked --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-database-owner-migration-history-review
 supabase projects api-keys --project-ref fwkqjeumreaznfhnlzev --output json
 node - <<'NODE' ...sanitized read-only REST schema probe...
-curl -L -sS -o /tmp/bootup-db-owner-home.html -w 'home %{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/
-curl -L -sS -o /tmp/bootup-db-owner-signals.html -w 'signals %{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/signals
-curl -L -sS -o /tmp/bootup-db-owner-cron.txt -w 'cron %{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/api/cron/fetch-news
+curl -L -sS -o /tmp/bootup-db-owner-home.html -w 'home %{http_code} %{url_effective}\n' https://bootupnews.vercel.app/
+curl -L -sS -o /tmp/bootup-db-owner-signals.html -w 'signals %{http_code} %{url_effective}\n' https://bootupnews.vercel.app/signals
+curl -L -sS -o /tmp/bootup-db-owner-cron.txt -w 'cron %{http_code} %{url_effective}\n' https://bootupnews.vercel.app/api/cron/fetch-news
 node - <<'NODE' ...sanitized route marker extraction...
 date -u '+%Y-%m-%dT%H:%M:%SZ'
 date '+%Y-%m-%d %H:%M:%S %Z'

--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-migration-history-drift-diagnosis.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-migration-history-drift-diagnosis.md
@@ -55,7 +55,7 @@ This diagnostic separates:
 | Commit description | `Merge pull request #157 from brandonma25/codex/prd-53-apply-production-schema-alignment` |
 | UTC capture time | `2026-04-30T06:53:42Z` |
 | Local capture time | `2026-04-30 14:53:42 CST` |
-| Production URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production URL | `https://bootupnews.vercel.app` |
 
 ## Linked Supabase project confirmation
 
@@ -352,11 +352,11 @@ supabase projects list --output json
 supabase link --project-ref fwkqjeumreaznfhnlzev --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-migration-history-drift-diagnosis
 supabase migration list --linked --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-migration-history-drift-diagnosis
 supabase db push --dry-run --linked --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-migration-history-drift-diagnosis
-curl -L -sS -o /tmp/bootup-drift-home.html -w '%{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/
-curl -L -sS -o /tmp/bootup-drift-signals.html -w '%{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/signals
-curl -L -sS -o /tmp/bootup-drift-cron.txt -w '%{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/api/cron/fetch-news
+curl -L -sS -o /tmp/bootup-drift-home.html -w '%{http_code} %{url_effective}\n' https://bootupnews.vercel.app/
+curl -L -sS -o /tmp/bootup-drift-signals.html -w '%{http_code} %{url_effective}\n' https://bootupnews.vercel.app/signals
+curl -L -sS -o /tmp/bootup-drift-cron.txt -w '%{http_code} %{url_effective}\n' https://bootupnews.vercel.app/api/cron/fetch-news
 rg -o 'sentry-release=[^,&"]+|signal_posts schema preflight failed\.[^<"]+|published_slate audit schema preflight failed\.[^<"]+|Missing expected columns: [^<"]+|0 signals|Published Signals are not available yet|Daily Executive Briefing|Today • [^<]+' /tmp/bootup-drift-home.html /tmp/bootup-drift-signals.html /tmp/bootup-drift-cron.txt
-node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+node scripts/prod-check.js https://bootupnews.vercel.app
 sed -n '1,140p' src/lib/signals-editorial.ts
 sed -n '340,570p' src/lib/signals-editorial.ts
 sed -n '1,220p' docs/engineering/change-records/2026-04-27-signal-posts-schema-preflight-remediation.md

--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-schema-alignment-and-second-cycle-rerun.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-schema-alignment-and-second-cycle-rerun.md
@@ -50,7 +50,7 @@ The prompt alone was not treated as migration or publish authorization.
 | Commit description | `Merge pull request #154 from brandonma25/codex/prd-53-second-controlled-cycle-validation` |
 | UTC capture time | `2026-04-30T04:52:10Z` |
 | Local capture time | `2026-04-30 12:52:10 CST` |
-| Production URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production URL | `https://bootupnews.vercel.app` |
 
 ## Baseline production schema preflight
 
@@ -263,10 +263,10 @@ sed -n '1,240p' supabase/migrations/20260430110000_signal_posts_editorial_card_c
 sed -n '1,260p' supabase/migrations/20260430120000_published_slates_minimal_audit_history.sql
 printenv | rg 'CONTROLLED_PRODUCTION_SCHEMA_MIGRATION_APPROVED|CONTROLLED_PRODUCTION_PUBLISH_APPROVED|SUPABASE|VERCEL|PRODUCTION_BASE_URL|PIPELINE' || true
 gh variable list --repo brandonma25/daily-intelligence-aggregator
-curl -L -sS -o /tmp/bootup-schema-align-home.html -w '%{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/
-curl -L -sS -o /tmp/bootup-schema-align-signals.html -w '%{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/signals
-curl -L -sS -o /tmp/bootup-schema-align-cron.txt -w '%{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/api/cron/fetch-news
-node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+curl -L -sS -o /tmp/bootup-schema-align-home.html -w '%{http_code} %{url_effective}\n' https://bootupnews.vercel.app/
+curl -L -sS -o /tmp/bootup-schema-align-signals.html -w '%{http_code} %{url_effective}\n' https://bootupnews.vercel.app/signals
+curl -L -sS -o /tmp/bootup-schema-align-cron.txt -w '%{http_code} %{url_effective}\n' https://bootupnews.vercel.app/api/cron/fetch-news
+node scripts/prod-check.js https://bootupnews.vercel.app
 supabase migration list --linked --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-production-schema-migration-alignment
 supabase db push --dry-run --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-production-schema-migration-alignment
 supabase migration list --help

--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-second-controlled-cycle-rerun.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-second-controlled-cycle-rerun.md
@@ -49,7 +49,7 @@ This run was authorized for dry-run and read-only validation only. It was not au
 | UTC capture time | `2026-05-01T03:45:34Z` |
 | Local capture time | `2026-05-01 11:45:34 CST` |
 | Production project ref | `fwkqjeumreaznfhnlzev` |
-| Production app URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production app URL | `https://bootupnews.vercel.app` |
 | Production deployment SHA | `b7c20594b0fea70870146e0c3d184ad9ed0df94c` |
 | Supabase CLI version | `2.90.0` |
 
@@ -110,7 +110,7 @@ supabase db push --dry-run --linked --workdir /Users/bm/dev/worktrees/daily-inte
 supabase db query "<read-only PRD-53 catalog verification select>" --linked --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-second-controlled-cycle-rerun --output table
 supabase db query "<read-only aggregate public/audit count select>" --linked --workdir /Users/bm/dev/worktrees/daily-intelligence-aggregator-prd-53-second-controlled-cycle-rerun --output table
 python3 <public route smoke script>
-node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+node scripts/prod-check.js https://bootupnews.vercel.app
 gh api repos/brandonma25/daily-intelligence-aggregator/deployments --jq "<latest production deployment jq>"
 ```
 

--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-second-controlled-cycle.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-second-controlled-cycle.md
@@ -52,7 +52,7 @@ Production publish was not authorized.
 | Commit description | `Merge pull request #153 from brandonma25/codex/prd-53-minimal-published-slate-audit-history` |
 | UTC capture time | `2026-04-30T04:25:28Z` |
 | Local capture time | `2026-04-30 12:25:28 CST` |
-| Production URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production URL | `https://bootupnews.vercel.app` |
 
 ## Baseline production checks
 
@@ -290,10 +290,10 @@ sed -n '1,220p' docs/engineering/protocols/release-automation-operating-guide.md
 sed -n '1,180p' docs/product/prd/prd-53-signals-admin-editorial-layer.md
 rg -n "dry_run|draft_only|pipeline:controlled|CONTROLLED_PRODUCTION_PUBLISH_APPROVED|publish|cron" .
 gh variable list --repo brandonma25/daily-intelligence-aggregator
-curl -L -sS -o /tmp/bootup-home.html -w '%{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/
-curl -L -sS -o /tmp/bootup-signals.html -w '%{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/signals
-curl -L -sS -o /tmp/bootup-cron.txt -w '%{http_code} %{url_effective}\n' https://daily-intelligence-aggregator-ybs9.vercel.app/api/cron/fetch-news
-node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+curl -L -sS -o /tmp/bootup-home.html -w '%{http_code} %{url_effective}\n' https://bootupnews.vercel.app/
+curl -L -sS -o /tmp/bootup-signals.html -w '%{http_code} %{url_effective}\n' https://bootupnews.vercel.app/signals
+curl -L -sS -o /tmp/bootup-cron.txt -w '%{http_code} %{url_effective}\n' https://bootupnews.vercel.app/api/cron/fetch-news
+node scripts/prod-check.js https://bootupnews.vercel.app
 npm install
 PIPELINE_RUN_MODE=dry_run PIPELINE_TARGET_ENV=production PIPELINE_CRON_DISABLED_CONFIRMED=true BRIEFING_DATE_OVERRIDE=2026-04-30 PIPELINE_TEST_RUN_ID=prd53-second-controlled-cycle-dryrun-20260430T0429Z npm run pipeline:controlled-test
 npx tsx -e "<local dry-run artifact parser and final-slate readiness validator invocation>"

--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-stable-catalog-access-inspection.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-stable-catalog-access-inspection.md
@@ -54,7 +54,7 @@ The inspection is still blocked. The fresh worktree does not have linked Supabas
 | PR #164 merged at | `2026-04-30T21:26:21Z` |
 | UTC capture time | `2026-04-30T21:29:16Z` |
 | Local capture time | `2026-05-01 05:29:16 CST` |
-| Production URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production URL | `https://bootupnews.vercel.app` |
 
 The canonical checkout at `/Users/bm/dev/daily-intelligence-aggregator` remained on `feature/tldr-url-ingestion` and was not disturbed. A dedicated worktree was created from `origin/main` for this branch after PR #164 merged.
 

--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-stable-catalog-readonly-access-rerun.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-stable-catalog-readonly-access-rerun.md
@@ -58,7 +58,7 @@ The access still is not visible to this process, so this run stopped before:
 | PR #163 merged at | `2026-04-30T20:59:38Z` |
 | UTC capture time | `2026-04-30T21:01:05Z` |
 | Local capture time | `2026-05-01 05:01:05 CST` |
-| Production URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production URL | `https://bootupnews.vercel.app` |
 
 The canonical checkout at `/Users/bm/dev/daily-intelligence-aggregator` remained on `feature/tldr-url-ingestion` and was not disturbed. A dedicated worktree was created from `origin/main` for this branch after PR #163 merged.
 

--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-stable-catalog-readonly-rerun.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-stable-catalog-readonly-rerun.md
@@ -59,7 +59,7 @@ PR #160 and PR #161 narrowed the blocker to stable read-only production catalog 
 | Commit description | `Merge pull request #162 from brandonma25/codex/hotfix-public-schema-preflight-fallback` |
 | UTC capture time | `2026-04-30T20:47:27Z` |
 | Local capture time | `2026-05-01 04:47:27 CST` |
-| Production URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production URL | `https://bootupnews.vercel.app` |
 
 The canonical checkout at `/Users/bm/dev/daily-intelligence-aggregator` remained on `feature/tldr-url-ingestion` and was not disturbed. A dedicated worktree was created from `origin/main` for this branch.
 

--- a/docs/operations/controlled-cycles/2026-04-30-prd-53-stable-catalog-readonly-review.md
+++ b/docs/operations/controlled-cycles/2026-04-30-prd-53-stable-catalog-readonly-review.md
@@ -56,7 +56,7 @@ This run checked that prerequisite before running any Supabase read or dry-run c
 | Commit description | `Merge pull request #160 from brandonma25/codex/prd-53-catalog-level-database-owner-review` |
 | UTC capture time | `2026-04-30T18:59:32Z` |
 | Local capture time | `2026-05-01 02:59:32 CST` |
-| Production URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production URL | `https://bootupnews.vercel.app` |
 
 The stale `/Users/bm/Documents/daily-intelligence-aggregator-main` checkout was not used for repo work because prior and current workspace checks showed it is not the safe canonical repo path for this lane. The branch was created in the canonical `/Users/bm/dev/worktrees` workspace family.
 

--- a/docs/operations/controlled-cycles/2026-05-01-final-launch-readiness-qa-rerun.md
+++ b/docs/operations/controlled-cycles/2026-05-01-final-launch-readiness-qa-rerun.md
@@ -49,7 +49,7 @@ Secondary:
 
 | Field | Result |
 | --- | --- |
-| Production URL checked | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production URL checked | `https://bootupnews.vercel.app` |
 | Starting commit | `a212dd552daea72e2416bb64ce8b1b2e4b700880` |
 | Starting commit summary | `Merge pull request #177 from brandonma25/codex/mvp-measurement-storage-alignment` |
 | Vercel deployment ID | `dpl_6GEaxxLVp4DZpLMHqEdzDTiYYFVU` |
@@ -93,9 +93,9 @@ sed -n '1,160p' scripts/mvp-measurement-summary.ts
 Production deployment and route checks:
 
 ```bash
-vercel inspect https://daily-intelligence-aggregator-ybs9.vercel.app --no-color
+vercel inspect https://bootupnews.vercel.app --no-color
 gh run list --branch main --limit 5 --json databaseId,displayTitle,headSha,status,conclusion,createdAt,url
-node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+node scripts/prod-check.js https://bootupnews.vercel.app
 node <production route and content marker probe>
 node <production Playwright browser QA probe>
 ```

--- a/docs/operations/controlled-cycles/2026-05-01-final-launch-readiness-qa.md
+++ b/docs/operations/controlled-cycles/2026-05-01-final-launch-readiness-qa.md
@@ -41,7 +41,7 @@ Secondary:
 
 | Field | Result |
 | --- | --- |
-| Production URL checked | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production URL checked | `https://bootupnews.vercel.app` |
 | Merge commit checked | `bde841ca941940665e62fe1a368d883e85e7f035` |
 | Vercel deployment ID | `dpl_51jU2mfosJsksFLHAw1pn9McNsTd` |
 | Production deployment URL | `https://bootup-69yreqc91-brandonma25s-projects.vercel.app` |
@@ -63,21 +63,21 @@ git worktree list
 gh pr merge 175 --merge --delete-branch
 gh pr view 175 --json number,state,mergedAt,mergeCommit,url
 git fetch origin main
-vercel inspect https://daily-intelligence-aggregator-ybs9.vercel.app --no-color
+vercel inspect https://bootupnews.vercel.app --no-color
 gh run view 25209406044 --json status,conclusion,jobs
-node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+node scripts/prod-check.js https://bootupnews.vercel.app
 ```
 
 Production route, content, browser, and measurement probes:
 
 ```bash
-curl -sS -o /tmp/bootup-home.html -w "%{http_code}\n" https://daily-intelligence-aggregator-ybs9.vercel.app/
-curl -sS -o /tmp/bootup-signals.html -w "%{http_code}\n" https://daily-intelligence-aggregator-ybs9.vercel.app/signals
-curl -sS -o /tmp/bootup-admin.html -w "%{http_code}\n" https://daily-intelligence-aggregator-ybs9.vercel.app/dashboard/signals/editorial-review
-curl -sS -o /tmp/bootup-cron.json -w "%{http_code}\n" https://daily-intelligence-aggregator-ybs9.vercel.app/api/cron/fetch-news
+curl -sS -o /tmp/bootup-home.html -w "%{http_code}\n" https://bootupnews.vercel.app/
+curl -sS -o /tmp/bootup-signals.html -w "%{http_code}\n" https://bootupnews.vercel.app/signals
+curl -sS -o /tmp/bootup-admin.html -w "%{http_code}\n" https://bootupnews.vercel.app/dashboard/signals/editorial-review
+curl -sS -o /tmp/bootup-cron.json -w "%{http_code}\n" https://bootupnews.vercel.app/api/cron/fetch-news
 node <production-content-marker-check>
 node <production-browser-qa-script>
-curl -sS -X POST https://daily-intelligence-aggregator-ybs9.vercel.app/api/mvp-measurement/events \
+curl -sS -X POST https://bootupnews.vercel.app/api/mvp-measurement/events \
   -H "content-type: application/json" \
   --data '<bounded QA homepage_view payload without secrets>'
 npx tsx scripts/mvp-measurement-summary.ts --days 1

--- a/docs/operations/controlled-cycles/2026-05-01-mvp-measurement-storage-alignment.md
+++ b/docs/operations/controlled-cycles/2026-05-01-mvp-measurement-storage-alignment.md
@@ -96,7 +96,7 @@ Production target:
 
 | Field | Result |
 | --- | --- |
-| Production URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production URL | `https://bootupnews.vercel.app` |
 | Production deployment ID | `dpl_Ckb4UwAuaH1njCxEByXDhDgwXxoE` |
 | Production deployment URL | `https://bootup-ns1plzgq0-brandonma25s-projects.vercel.app` |
 | Production deploy status | Ready |
@@ -166,8 +166,8 @@ supabase db push --dry-run --linked --workdir <worktree>
 Production verification:
 
 ```bash
-vercel inspect https://daily-intelligence-aggregator-ybs9.vercel.app --no-color
-node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+vercel inspect https://bootupnews.vercel.app --no-color
+node scripts/prod-check.js https://bootupnews.vercel.app
 node <baseline measurement event API probe>
 node <post-apply measurement event API probe>
 node <public route and cron safety probe>

--- a/docs/operations/controlled-cycles/2026-05-01-mvp-measurement-summary-readiness.md
+++ b/docs/operations/controlled-cycles/2026-05-01-mvp-measurement-summary-readiness.md
@@ -222,7 +222,7 @@ Production summary readback was not run in this branch because the internal path
 Production URL:
 
 ```text
-https://daily-intelligence-aggregator-ybs9.vercel.app
+https://bootupnews.vercel.app
 ```
 
 Read-only checks run before code changes:
@@ -293,7 +293,7 @@ Commands run:
 npm install
 npx vitest run src/lib/mvp-measurement-summary.test.ts src/app/api/internal/mvp-measurement/summary/route.test.ts
 npx tsx scripts/mvp-measurement-summary.ts --days 1
-node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+node scripts/prod-check.js https://bootupnews.vercel.app
 node <read-only public route and cron probe>
 git diff --check
 python3 scripts/validate-feature-system-csv.py

--- a/docs/operations/controlled-cycles/2026-05-01-prd-53-admin-review-final-slate-validation.md
+++ b/docs/operations/controlled-cycles/2026-05-01-prd-53-admin-review-final-slate-validation.md
@@ -54,7 +54,7 @@ It was not authorized to publish, set `is_live=true`, set `published_at`, archiv
 | Branch | `codex/prd-53-admin-review-final-slate-validation` |
 | Starting commit | `e2db691` |
 | Commit description | `Merge pull request #171 from brandonma25/codex/prd-53-authorized-controlled-draft-only-rerun` |
-| Production app URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production app URL | `https://bootupnews.vercel.app` |
 | Admin route | `/dashboard/signals/editorial-review` |
 | Current set shown in admin | `2026-05-01` |
 | Current candidate count | `7` |
@@ -126,16 +126,16 @@ Production public and cron safety verification:
 
 ```bash
 git rev-parse --short HEAD
-curl -sS -I https://daily-intelligence-aggregator-ybs9.vercel.app/ | sed -n '1,12p'
-curl -sS https://daily-intelligence-aggregator-ybs9.vercel.app/ | rg -n "signal_posts schema preflight failed|final_slate_rank|Today's briefing is being prepared|being prepared|Wednesday, April 29|April 29|Top 5 Core|Next 2 Context"
-curl -sS -I https://daily-intelligence-aggregator-ybs9.vercel.app/signals | sed -n '1,12p'
-curl -sS https://daily-intelligence-aggregator-ybs9.vercel.app/signals | rg -n "Published Signals|7 signals|Top 5 Core Signals|Next 2 Context Signals|signal_posts schema preflight failed|final_slate_rank|final_slate_tier|editorial_decision"
-curl -sS -i https://daily-intelligence-aggregator-ybs9.vercel.app/api/cron/fetch-news | sed -n '1,20p'
+curl -sS -I https://bootupnews.vercel.app/ | sed -n '1,12p'
+curl -sS https://bootupnews.vercel.app/ | rg -n "signal_posts schema preflight failed|final_slate_rank|Today's briefing is being prepared|being prepared|Wednesday, April 29|April 29|Top 5 Core|Next 2 Context"
+curl -sS -I https://bootupnews.vercel.app/signals | sed -n '1,12p'
+curl -sS https://bootupnews.vercel.app/signals | rg -n "Published Signals|7 signals|Top 5 Core Signals|Next 2 Context Signals|signal_posts schema preflight failed|final_slate_rank|final_slate_tier|editorial_decision"
+curl -sS -i https://bootupnews.vercel.app/api/cron/fetch-news | sed -n '1,20p'
 ```
 
 Browser actions through authenticated Chrome session:
 
-- Opened `https://daily-intelligence-aggregator-ybs9.vercel.app/dashboard/signals/editorial-review?scope=current`.
+- Opened `https://bootupnews.vercel.app/dashboard/signals/editorial-review?scope=current`.
 - Confirmed admin route loaded as `newsweb2026@gmail.com`.
 - Confirmed current set `2026-05-01`, seven current candidates, and zero selected final-slate rows.
 - Approved five WITM-passed current candidates through the supported `Approve` buttons.

--- a/docs/operations/controlled-cycles/2026-05-01-prd-53-admin-rewrite-replacement-pass.md
+++ b/docs/operations/controlled-cycles/2026-05-01-prd-53-admin-rewrite-replacement-pass.md
@@ -54,7 +54,7 @@ It was not authorized to publish, set `is_live=true`, set `published_at`, archiv
 | Branch | `codex/prd-53-admin-rewrite-replacement-pass` |
 | Starting commit | `17be23b` |
 | Commit description | `Merge pull request #172 from brandonma25/codex/prd-53-admin-review-final-slate-validation` |
-| Production app URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production app URL | `https://bootupnews.vercel.app` |
 | Admin route | `/dashboard/signals/editorial-review` |
 | Current set shown in admin | `2026-05-01` |
 | Current candidate count | `7` |
@@ -143,7 +143,7 @@ Production public and cron safety verification after admin actions:
 
 ```bash
 node <<'NODE'
-const base = 'https://daily-intelligence-aggregator-ybs9.vercel.app';
+const base = 'https://bootupnews.vercel.app';
 const checks = [
   ['/', ['Today\\'s briefing is being prepared', 'Wednesday, April 29', 'signal_posts schema preflight failed', 'final_slate_rank', '2026-05-01']],
   ['/signals', ['Published Signals', 'Top 5 Core Signals', 'Next 2 Context Signals', 'signal_posts schema preflight failed', 'final_slate_rank', '2026-05-01']],
@@ -160,7 +160,7 @@ NODE
 
 Browser actions through authenticated Chrome session:
 
-- Opened `https://daily-intelligence-aggregator-ybs9.vercel.app/dashboard/signals/editorial-review`.
+- Opened `https://bootupnews.vercel.app/dashboard/signals/editorial-review`.
 - Confirmed admin route loaded as `newsweb2026@gmail.com`.
 - Confirmed current set `2026-05-01`, seven current candidates, and the PR #172 review state.
 - Rewrote the two WITM-blocked rows through the supported admin edit controls.

--- a/docs/operations/controlled-cycles/2026-05-01-prd-53-authorized-second-controlled-publish.md
+++ b/docs/operations/controlled-cycles/2026-05-01-prd-53-authorized-second-controlled-publish.md
@@ -53,7 +53,7 @@ This run was authorized only for the supported PRD-53 production publish action 
 | Branch | `codex/prd-53-authorized-second-controlled-publish` |
 | Starting commit | `ae67225` |
 | Commit description | `Merge pull request #173 from brandonma25/codex/prd-53-admin-rewrite-replacement-pass` |
-| Production app URL | `https://daily-intelligence-aggregator-ybs9.vercel.app` |
+| Production app URL | `https://bootupnews.vercel.app` |
 | Admin route | `/dashboard/signals/editorial-review` |
 | Current set shown in admin | `2026-05-01` |
 | Current candidate count before publish | `7` |
@@ -137,7 +137,7 @@ Production public, admin, and cron verification:
 
 ```bash
 node <<'NODE'
-const base = 'https://daily-intelligence-aggregator-ybs9.vercel.app';
+const base = 'https://bootupnews.vercel.app';
 const titles = [
   'Trump signs DHS legislation, ending record-breaking shutdown',
   'Economic Letter Countdown: Most Read Topics from 2025',
@@ -170,12 +170,12 @@ for (const path of ['/', '/signals', '/api/cron/fetch-news']) {
   for (const title of titles) console.log(`${path} title ${JSON.stringify(title)}=${text.includes(title)}`);
 }
 NODE
-node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+node scripts/prod-check.js https://bootupnews.vercel.app
 ```
 
 Browser actions through authenticated Chrome session:
 
-- Opened `https://daily-intelligence-aggregator-ybs9.vercel.app/dashboard/signals/editorial-review?scope=current`.
+- Opened `https://bootupnews.vercel.app/dashboard/signals/editorial-review?scope=current`.
 - Confirmed admin route loaded as `newsweb2026@gmail.com`.
 - Revalidated current set `2026-05-01`, seven current candidates, `7/7 selected`, `5/5 Core`, `2/2 Context`, and `Slate ready`.
 - Confirmed `Publish Final Slate` was enabled.
@@ -387,7 +387,7 @@ git diff --check
 python3 scripts/validate-feature-system-csv.py
 python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-authorized-second-controlled-publish --pr-title "PRD-53 authorized second controlled publish"
 python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-authorized-second-controlled-publish --pr-title "PRD-53 authorized second controlled publish"
-node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app
+node scripts/prod-check.js https://bootupnews.vercel.app
 npm run lint
 npm run test
 npm run build
@@ -399,7 +399,7 @@ Results:
 - `python3 scripts/validate-feature-system-csv.py`: passed with pre-existing PRD slug warnings for PRD-32, PRD-37, and PRD-38.
 - `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name codex/prd-53-authorized-second-controlled-publish --pr-title "PRD-53 authorized second controlled publish"`: passed.
 - `python3 scripts/release-governance-gate.py --diff-mode local --branch-name codex/prd-53-authorized-second-controlled-publish --pr-title "PRD-53 authorized second controlled publish"`: passed.
-- `node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app`: passed; `/` and `/dashboard` returned HTTP 200.
+- `node scripts/prod-check.js https://bootupnews.vercel.app`: passed; `/` and `/dashboard` returned HTTP 200.
 - Initial `npm run lint`: blocked because dependencies were not installed in the fresh worktree.
 - `npm install`: completed; reported two npm audit findings.
 - Post-install `npm run lint`: passed.

--- a/docs/operations/launch-readiness/2026-05-02-controlled-user-exposure-active-day-0-readback.md
+++ b/docs/operations/launch-readiness/2026-05-02-controlled-user-exposure-active-day-0-readback.md
@@ -51,7 +51,7 @@ Current state:
 
 Production URL:
 
-- `https://daily-intelligence-aggregator-ybs9.vercel.app`
+- `https://bootupnews.vercel.app`
 
 Current branch and commit:
 
@@ -65,12 +65,12 @@ Deployment:
 - target: production
 - status: Ready
 - deployment URL: `https://bootup-dka9lij8m-brandonma25s-projects.vercel.app`
-- production alias: `https://daily-intelligence-aggregator-ybs9.vercel.app`
+- production alias: `https://bootupnews.vercel.app`
 
 Production verification:
 
 - GitHub Production Verification passed for `9fec0c7a6889b8a419a34ce2252c856acf954263`.
-- `vercel inspect https://daily-intelligence-aggregator-ybs9.vercel.app` showed production Ready.
+- `vercel inspect https://bootupnews.vercel.app` showed production Ready.
 
 Route checks:
 

--- a/docs/operations/launch-readiness/2026-05-02-controlled-user-exposure-active-day-0.md
+++ b/docs/operations/launch-readiness/2026-05-02-controlled-user-exposure-active-day-0.md
@@ -51,7 +51,7 @@ Current execution state:
 
 Production URL:
 
-- `https://daily-intelligence-aggregator-ybs9.vercel.app`
+- `https://bootupnews.vercel.app`
 
 Current branch and commit:
 
@@ -65,12 +65,12 @@ Deployment:
 - target: production
 - status: Ready
 - deployment URL: `https://bootup-d9qcqdq2j-brandonma25s-projects.vercel.app`
-- production alias: `https://daily-intelligence-aggregator-ybs9.vercel.app`
+- production alias: `https://bootupnews.vercel.app`
 
 Production verification:
 
 - GitHub Production Verification passed for `c3fab6fc3d0e1a0c0e9ba8d9d0ac5896f2ce6322`.
-- `node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app` passed for `/` and `/dashboard`.
+- `node scripts/prod-check.js https://bootupnews.vercel.app` passed for `/` and `/dashboard`.
 
 Route checks:
 
@@ -176,7 +176,7 @@ Would you try it for a week? Use it like a morning briefing: scan what matters, 
 
 It is early, so I am mainly looking for whether it feels useful, clear, and worth coming back to. No need to use it in any artificial way.
 
-Link: https://daily-intelligence-aggregator-ybs9.vercel.app
+Link: https://bootupnews.vercel.app
 ```
 
 Longer email:
@@ -194,7 +194,7 @@ Would you try it for one week? The ideal use is simple: open it the way you migh
 
 It is still early, so I am mostly looking for whether it feels useful, clear, and worth returning to. Please use it naturally. If something feels confusing, stale, too shallow, or surprisingly useful, I would appreciate hearing that.
 
-Link: https://daily-intelligence-aggregator-ybs9.vercel.app
+Link: https://bootupnews.vercel.app
 
 Thanks.
 ```
@@ -425,7 +425,7 @@ Additional validation evidence captured before packet creation:
 - `npm run test` passed: 78 test files and 591 tests.
 - `npm run build` passed.
 - GitHub Production Verification passed for `c3fab6fc3d0e1a0c0e9ba8d9d0ac5896f2ce6322`.
-- `node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app` passed.
+- `node scripts/prod-check.js https://bootupnews.vercel.app` passed.
 - Production route probes for `/`, `/signals`, `/briefing/2026-05-01`, `/api/cron/fetch-news`, `/api/internal/mvp-measurement/summary?days=7`, and `/dashboard/signals/editorial-review` matched expected public/protected behavior.
 - Authenticated browser summary readback returned `ok:true` with aggregate production event counts.
 - Vercel error-log and HTTP 500-log checks returned no logs in the checked 30-minute window.

--- a/docs/operations/launch-readiness/2026-05-02-controlled-user-exposure-day-0.md
+++ b/docs/operations/launch-readiness/2026-05-02-controlled-user-exposure-day-0.md
@@ -58,7 +58,7 @@ Known merged baseline:
 
 Production URL:
 
-- `https://daily-intelligence-aggregator-ybs9.vercel.app`
+- `https://bootupnews.vercel.app`
 
 Current branch and commit:
 
@@ -70,7 +70,7 @@ Deployment:
 - Vercel deployment ID: `dpl_AWqcyHeHAa4ie3E43dBZuiLx8P4b`
 - target: production
 - status: Ready
-- production alias: `https://daily-intelligence-aggregator-ybs9.vercel.app`
+- production alias: `https://bootupnews.vercel.app`
 
 Production route checks:
 
@@ -81,7 +81,7 @@ Production route checks:
 | `/briefing/2026-05-01` | HTTP 200 |
 | `/api/cron/fetch-news` without auth | HTTP 401 |
 | `/api/internal/mvp-measurement/summary?days=7` without auth | HTTP 401 |
-| `node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app` | PASS: `/` and `/dashboard` returned HTTP 200 |
+| `node scripts/prod-check.js https://bootupnews.vercel.app` | PASS: `/` and `/dashboard` returned HTTP 200 |
 
 Public safety:
 
@@ -199,7 +199,7 @@ Would you try it for a week? Use it like a morning briefing: scan what matters, 
 
 It is early, so I am mainly looking for whether it feels useful, clear, and worth coming back to. No need to use it in any artificial way.
 
-Link: https://daily-intelligence-aggregator-ybs9.vercel.app
+Link: https://bootupnews.vercel.app
 ```
 
 Longer email:
@@ -217,7 +217,7 @@ Would you try it for one week? The ideal use is simple: open it the way you migh
 
 It is still early, so I am mostly looking for whether it feels useful, clear, and worth returning to. Please use it naturally. If something feels confusing, stale, too shallow, or surprisingly useful, I would appreciate hearing that.
 
-Link: https://daily-intelligence-aggregator-ybs9.vercel.app
+Link: https://bootupnews.vercel.app
 
 Thanks.
 ```
@@ -553,7 +553,7 @@ Results:
 
 Additional validation and evidence:
 
-- `node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app` passed for `/` and `/dashboard`.
+- `node scripts/prod-check.js https://bootupnews.vercel.app` passed for `/` and `/dashboard`.
 - Production route probes for `/`, `/signals`, `/briefing/2026-05-01`, `/api/cron/fetch-news`, and `/api/internal/mvp-measurement/summary?days=7` matched expected status codes.
 - Authenticated browser summary readback returned `ok:true` with aggregate production event counts.
 - Vercel error-log and HTTP 500-log checks for deployment `dpl_AWqcyHeHAa4ie3E43dBZuiLx8P4b` returned no logs in the checked 30-minute window.

--- a/docs/operations/launch-readiness/2026-05-03-controlled-user-exposure-day-1-monitoring.md
+++ b/docs/operations/launch-readiness/2026-05-03-controlled-user-exposure-day-1-monitoring.md
@@ -33,7 +33,7 @@ Secondary:
 
 Production URL:
 
-- `https://daily-intelligence-aggregator-ybs9.vercel.app`
+- `https://bootupnews.vercel.app`
 
 Current branch and commit:
 
@@ -53,7 +53,7 @@ Deployment:
 - target: production
 - status: Ready
 - deployment URL: `https://bootup-dyk4n8a4t-brandonma25s-projects.vercel.app`
-- production alias: `https://daily-intelligence-aggregator-ybs9.vercel.app`
+- production alias: `https://bootupnews.vercel.app`
 
 Route checks:
 

--- a/docs/operations/launch-readiness/2026-05-05-controlled-user-exposure-day-3-qualitative-check.md
+++ b/docs/operations/launch-readiness/2026-05-05-controlled-user-exposure-day-3-qualitative-check.md
@@ -34,7 +34,7 @@ Secondary:
 
 Production URL:
 
-- `https://daily-intelligence-aggregator-ybs9.vercel.app`
+- `https://bootupnews.vercel.app`
 
 Current branch and commit:
 
@@ -54,7 +54,7 @@ Deployment:
 - target: production
 - status: Ready
 - deployment URL: `https://bootup-bpp47bhus-brandonma25s-projects.vercel.app`
-- production alias: `https://daily-intelligence-aggregator-ybs9.vercel.app`
+- production alias: `https://bootupnews.vercel.app`
 - deployment created: 2026-05-02 16:18:03 CST
 
 Route checks:

--- a/docs/operations/tracker-sync/2026-05-02-controlled-user-exposure-day-0.md
+++ b/docs/operations/tracker-sync/2026-05-02-controlled-user-exposure-day-0.md
@@ -57,7 +57,7 @@ Results:
 
 Additional validation:
 
-- `node scripts/prod-check.js https://daily-intelligence-aggregator-ybs9.vercel.app` passed for `/` and `/dashboard`.
+- `node scripts/prod-check.js https://bootupnews.vercel.app` passed for `/` and `/dashboard`.
 - Production route probes for `/`, `/signals`, `/briefing/2026-05-01`, `/api/cron/fetch-news`, and `/api/internal/mvp-measurement/summary?days=7` matched expected status codes.
 - Authenticated browser summary readback returned `ok:true` with aggregate production event counts.
 - Vercel error-log and HTTP 500-log checks for deployment `dpl_AWqcyHeHAa4ie3E43dBZuiLx8P4b` returned no logs in the checked 30-minute window.

--- a/src/app/metadata.test.ts
+++ b/src/app/metadata.test.ts
@@ -15,6 +15,21 @@ describe("public page metadata", () => {
     expect(String(metadata.description).length).toBeLessThanOrEqual(160);
   });
 
+  it("exposes canonical and social URL metadata for the public homepage", async () => {
+    const { metadata } = await import("@/app/page");
+
+    expect(metadata.metadataBase?.toString()).toBe("https://bootupnews.vercel.app/");
+    expect(metadata.alternates).toEqual({
+      canonical: "https://bootupnews.vercel.app/",
+    });
+    expect(metadata.openGraph).toEqual({
+      url: "https://bootupnews.vercel.app/",
+    });
+    expect(metadata.other).toEqual({
+      "twitter:url": "https://bootupnews.vercel.app/",
+    });
+  });
+
   it("uses reader-facing public signals metadata", async () => {
     const { metadata } = await import("@/app/signals/page");
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
+import type { Metadata } from "next";
+
 import LandingHomepage from "@/components/landing/homepage";
 import { getHomepagePageState } from "@/lib/data";
-import { isHomepageDebugConfigured } from "@/lib/env";
+import { buildPublicAppUrl, getPublicAppOrigin, isHomepageDebugConfigured } from "@/lib/env";
 import { applyHomepageEditorialOverridesToDashboardData } from "@/lib/homepage-editorial-overrides";
 import { buildHomepageViewModel } from "@/lib/homepage-model";
 import { formatHomeBriefingDateLabel } from "@/lib/utils";
@@ -12,6 +14,21 @@ type PageProps = {
 function readSingleParam(value: string | string[] | undefined) {
   return Array.isArray(value) ? value[0] : value;
 }
+
+const homepageUrl = buildPublicAppUrl("/");
+
+export const metadata: Metadata = {
+  metadataBase: new URL(getPublicAppOrigin()),
+  alternates: {
+    canonical: homepageUrl,
+  },
+  openGraph: {
+    url: homepageUrl,
+  },
+  other: {
+    "twitter:url": homepageUrl,
+  },
+};
 
 export default async function Page({ searchParams }: PageProps) {
   // Keep homepage SSR on persisted read models only. Do not route this page

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+
+import { buildPublicAppUrl } from "@/lib/env";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: buildPublicAppUrl("/sitemap.xml"),
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+
+import { buildPublicAppUrl } from "@/lib/env";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: buildPublicAppUrl("/"),
+      changeFrequency: "daily",
+      priority: 1,
+    },
+  ];
+}

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { getSupabasePublicEnvDiagnostics, resolvePublicSupabaseConfig } from "@/lib/env";
+import {
+  buildPublicAppUrl,
+  getSupabasePublicEnvDiagnostics,
+  resolvePublicSupabaseConfig,
+} from "@/lib/env";
 
 describe("public Supabase env resolution", () => {
   it("prefers the anon key when both supported public key names are present", () => {
@@ -37,5 +41,9 @@ describe("public Supabase env resolution", () => {
           name === "NEXT_PUBLIC_SUPABASE_ANON_KEY or NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
       ),
     ).toBe(true);
+  });
+
+  it("builds public URLs from the canonical production origin by default", () => {
+    expect(buildPublicAppUrl("/sitemap.xml")).toBe("https://bootupnews.vercel.app/sitemap.xml");
   });
 });

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -12,6 +12,33 @@ function normalizePositiveIntegerEnv(value: string | undefined) {
   return Number.isFinite(parsed) && parsed > 0 ? String(parsed) : "";
 }
 
+export const CANONICAL_PRODUCTION_APP_URL = "https://bootupnews.vercel.app";
+
+function normalizeUrlOrigin(value: string | undefined) {
+  const normalized = normalizeEnv(value);
+  if (!normalized) {
+    return "";
+  }
+
+  try {
+    const url = new URL(normalized);
+    url.pathname = "";
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return "";
+  }
+}
+
+export function getPublicAppOrigin() {
+  return normalizeUrlOrigin(process.env.NEXT_PUBLIC_APP_URL) || CANONICAL_PRODUCTION_APP_URL;
+}
+
+export function buildPublicAppUrl(path = "/") {
+  return new URL(path, `${getPublicAppOrigin()}/`).toString();
+}
+
 export function resolvePublicSupabaseConfig({
   supabaseUrl,
   supabaseAnonKey,


### PR DESCRIPTION
## Effective change type

remediation

## Source of truth

- Production URL migration to `https://bootupnews.vercel.app`
- Branch cleanup report proving unrelated dirty work from `feature/tldr-url-ingestion` was isolated
- Clean deploy branch: `clean/production-url-remediation-20260510`
- Deployment base: `origin/main` at `9463523`

## Canonical PRD requirement

No new canonical PRD required.

## Scope

- Align repo-controlled production URL references from the old production host to `bootupnews.vercel.app`.
- Add centralized public app URL helpers for canonical public metadata.
- Add homepage canonical, Open Graph URL, and Twitter URL metadata.
- Add App Router metadata routes for `/robots.txt` and `/sitemap.xml`.
- Add/update metadata and env tests.
- Add a production URL remediation change record.

## Explicit exclusions

- No cron re-enable.
- No uncontrolled writes.
- No `draft_only` run.
- No publish flow.
- No source expansion.
- No editorial authority changes.
- No schema or snapshot redesign.
- No unrelated dirty branch changes from `feature/tldr-url-ingestion`.

## Validation

- `git status --short`: pass, clean.
- `git diff --stat origin/main...HEAD`: pass, remediation-only diff reviewed.
- `git diff --name-status origin/main...HEAD`: pass, remediation-only file set reviewed.
- `git diff --check origin/main...HEAD`: pass.
- URL safety search for `daily-intelligence-aggregator-ybs9.vercel.app` and `bootupnews.vercel.com`: pass, zero deploy-branch references.
- Malformed URL search for `https://https://bootupnews.vercel.app` and `http://bootupnews.vercel.app`: pass, zero references.
- `npm ls @sentry/nextjs`: pass, `@sentry/nextjs@10.50.0`.
- `npm run lint`: pass.
- `NEXT_PUBLIC_APP_URL=https://bootupnews.vercel.app npm run build`: pass.
- `NEXT_PUBLIC_APP_URL=https://bootupnews.vercel.app npm run test`: pass, 80 files / 613 tests.
- Local runtime probe from built app:
  - `/robots.txt`: 200, sitemap points to `https://bootupnews.vercel.app/sitemap.xml`.
  - `/sitemap.xml`: 200, includes `https://bootupnews.vercel.app/`.
  - `/`: 200, canonical/og:url/twitter:url point to `https://bootupnews.vercel.app`.
  - Served local HTML contained no old or invalid production URL.

## Cron/write posture

Cron remains disabled by this PR. No write, publish, uncontrolled cron, or full `draft_only` flow was run.
