### PR TITLE
chore: add Search Console verification

### DIFF
--- a/docs/engineering/change-records/2026-05-11-analytics-mvp-gap-bridge.md
+++ b/docs/engineering/change-records/2026-05-11-analytics-mvp-gap-bridge.md
@@ -1,0 +1,22 @@
+# Analytics MVP Gap Bridge
+
+## Summary
+- Added Google Search Console URL-prefix verification support for the production Boot Up URL.
+- Confirmed the analytics stack target remains minimal for MVP: Vercel Analytics and Speed Insights, Sentry, PostHog, Supabase dashboard logs, and Google Search Console.
+- No secrets, DSNs, API keys, cookies, or raw environment values are recorded here.
+
+## Scope
+- Public verification artifact for Google Search Console ownership.
+- External configuration follow-up: ensure browser-side Sentry DSN is configured through Vercel environment variables so client-side errors initialize in production and preview.
+
+## Non-Goals
+- No new analytics provider.
+- No PostHog session replay enablement.
+- No paid experimentation, revenue analytics, or custom BI layer.
+- No changes to product behavior, ingestion, ranking, Signal Cards, or Surface Placement.
+
+## Validation Plan
+- Verify the Search Console property after production deploy.
+- Confirm the verification artifact returns HTTP 200 at the production root.
+- Confirm Sentry RSS monitoring remains server-side and that client Sentry initializes only when the public DSN env var is present.
+- Confirm PostHog still receives MVP behavior events without query strings, full article bodies, or full Why It Matters copy.

--- a/public/googlec2cd2dfec41cc36b.html
+++ b/public/googlec2cd2dfec41cc36b.html
@@ -1,0 +1,1 @@
+google-site-verification: googlec2cd2dfec41cc36b.html


### PR DESCRIPTION
## Summary
- Add Google Search Console URL-prefix verification artifact for the production Boot Up URL.
- Add a concise engineering change record for the MVP analytics gap bridge.

## Notes
- No secrets, DSNs, raw env values, cookies, tokens, or private logs are included.
- Browser-side Sentry DSN remains a manual Vercel env follow-up because the existing sensitive DSN value is not readable from local env pulls.

## Validation
- npm install
- npm run lint
- npm test
- npm run build
- local dev smoke at http://localhost:3000/
- local verification artifact returned HTTP 200