### PR TITLE
Complete PRD-61 newsletter editorial-cycle validation

### DIFF
--- a/docs/engineering/bug-fixes/prd-61-newsletter-dry-run-label-preflight.md
+++ b/docs/engineering/bug-fixes/prd-61-newsletter-dry-run-label-preflight.md
@@ -1,0 +1,53 @@
+# PRD-61 Newsletter Dry-Run Label Preflight — Bug-Fix Record
+
+## Summary
+
+- Problem addressed: Gmail OAuth could succeed while the runner searched an account that did not expose the expected `boot-up-benchmark` label, making an account/token mismatch look like an empty newsletter inventory.
+- Root cause: The controlled path searched Gmail messages directly and did not first prove exact label visibility for the same REST OAuth token.
+- Affected object level: Article ingestion and Surface Placement candidate preview only.
+
+## Fix
+
+- Exact change: Add an exact Gmail label preflight before message search, fail closed with a sanitized label missing/account mismatch message, add a dedicated zero-write dry-run report script, and add read-only promotion preview logic that mirrors production source URL, dedup, and rank rules without writing.
+- Related PRD: PRD-61.
+- PR: Not opened at time of record.
+- Branch: `fix/prd-61-newsletter-dry-run-validation`
+- Head SHA at record time: `c9b1bb002a0c76b39b1081d83763d458440bc0b5`
+- Production writes: One BM-authorized controlled newsletter write validation completed after zero-write dry-run passed.
+- Cron changes: None.
+- Tracker sync files: None.
+- GitHub source-of-truth status: Repo docs and branch-local validation record updated; no Google Sheet / Work Log tracker update.
+
+## Terminology Requirement
+
+- [x] Confirmed object level before coding: Article and Surface Placement.
+- [x] No new naming expands canonical Signal identity or Card terminology.
+- [x] Legacy table name `signal_posts` is used only for the existing Surface Placement persistence model.
+
+## Validation
+
+Automated checks completed:
+- `npm install` completed.
+- `npx vitest run src/lib/newsletter-ingestion/gmail.test.ts src/lib/newsletter-ingestion/runner.test.ts src/lib/newsletter-ingestion/storage-promotion.test.ts src/lib/newsletter-ingestion/parser.test.ts src/lib/newsletter-ingestion/dry-run-report.test.ts` passed.
+- `npm run lint` passed.
+- `npm run test` passed.
+- `npm run build` passed.
+- `npm run governance:coverage` passed.
+- `python3 scripts/release-governance-gate.py` passed.
+- `git diff --check` passed.
+
+Controlled operations validation completed:
+- Gmail REST OAuth refresh-token exchange succeeded with the Web application client named `Boot Up Newsletter Ingestion OAuth Playground`.
+- Exact Gmail label `boot-up-benchmark` was visible to the same token used by the runner.
+- Zero-write dry-run fetched `3` labeled emails, extracted `24` Article candidates, identified `5` eligible Surface Placement promotion candidates, and left counts unchanged at `newsletter_emails = 0`, `newsletter_story_extractions = 0`, `signal_posts = 68`.
+- BM then authorized controlled write-mode validation.
+- Controlled write stored `3` `newsletter_emails` rows, stored `24` `newsletter_story_extractions` rows, and created `5` non-live `signal_posts` review candidates.
+- Post-write counts were `newsletter_emails = 3`, `newsletter_story_extractions = 24`, `signal_posts = 73`.
+- `/` returned HTTP `200` with the May 6 slate; `/signals` returned HTTP `200`; latest public renderable Signal count remained `3`.
+- No raw email content, snippets, Gmail message IDs, thread IDs, credentials, refresh tokens, or client secrets were printed or written into repo docs.
+
+## Remaining Risks / Follow-Up
+
+- Remove temporary local OAuth redirect URI `http://127.0.0.1:53682/oauth2callback` from the `Boot Up Newsletter Ingestion OAuth Playground` Web client after confirming no more local token generation is needed.
+- Production cron remains disabled and still requires separate BM approval before scheduling.
+- If label preflight fails in future runs, regenerate the refresh token from the Gmail account that actually contains `boot-up-benchmark`.

--- a/docs/engineering/testing/2026-05-11-prd-61-newsletter-dry-run-validation.md
+++ b/docs/engineering/testing/2026-05-11-prd-61-newsletter-dry-run-validation.md
@@ -1,0 +1,135 @@
+# PRD-61 Newsletter Editorial-Cycle Validation
+
+- Date: `2026-05-11`
+- Record updated: `2026-05-12`
+- Branch: `fix/prd-61-newsletter-dry-run-validation`
+- PRD: `docs/product/prd/prd-61-newsletter-ingestion-story-clusters-and-historical-signal-snapshot-foundation.md`
+- Object levels: Article and Surface Placement. No canonical Signal identity or Card copy model changes.
+
+## Scope
+
+- Added a REST OAuth label preflight for the exact Gmail label `boot-up-benchmark`.
+- Added a dedicated zero-write report command: `npx tsx scripts/newsletter-ingestion-dry-run-report.ts`.
+- Added read-only promotion preview logic that mirrors source URL validity, title/source dedup, and rank availability rules without insert or update helpers.
+- Updated the newsletter ingestion runbook with the label-verified dry-run report procedure.
+- Completed controlled operational validation against the Gmail account that can see `boot-up-benchmark`.
+- Completed one BM-authorized production write validation through the controlled newsletter runner only.
+
+## Safety Boundaries
+
+- Gmail MCP, Chrome, and browser state remain diagnostics only, not backend dependencies.
+- `NEWSLETTER_INGESTION_DRY_RUN=true` remains the expected validation mode.
+- The report excludes Gmail message IDs, thread IDs, raw content, snippets, credentials, refresh tokens, and client secrets.
+- The report does not write `newsletter_emails`, `newsletter_story_extractions`, or `signal_posts`.
+- The authorized write validation did not run RSS, cron, `draft_only`, publish, or public-surface publication paths.
+- No production cron schedule was enabled by this change.
+- No credentials, refresh tokens, raw newsletter content, snippets, Gmail message IDs, or thread IDs were written into repo docs.
+
+## Automated Validation
+
+Focused newsletter suite:
+
+```bash
+npx vitest run src/lib/newsletter-ingestion/gmail.test.ts src/lib/newsletter-ingestion/runner.test.ts src/lib/newsletter-ingestion/storage-promotion.test.ts src/lib/newsletter-ingestion/parser.test.ts src/lib/newsletter-ingestion/dry-run-report.test.ts
+```
+
+Result:
+- `5` test files passed.
+- `31` tests passed.
+
+Repo checks completed on this branch before operational validation:
+- `npm install`
+- `npm run lint`
+- `npm run test`
+- `npm run build`
+- `npm run governance:coverage`
+- `python3 scripts/release-governance-gate.py`
+- `git diff --check`
+
+Coverage added:
+- Exact Gmail label preflight success and missing-label/account-mismatch failure.
+- Runner fail-closed behavior before message search when the label is not visible.
+- Dry-run report privacy checks for raw content, snippets, credentials, and message IDs.
+- Read-only promotion preview for eligible creation, existing non-live candidate linkage, duplicate public row skip, and exhausted-rank skip.
+- Existing parser fixture coverage remains in the focused suite.
+
+## Controlled Dry-Run Validation
+
+Completed after BM recreated local credentials through a hidden prompt and authorized Gmail read-only OAuth for the Gmail account that contains the `boot-up-benchmark` label.
+
+Pre-flight:
+
+| Check | Result |
+| --- | --- |
+| `newsletter_emails` | `0` |
+| `newsletter_story_extractions` | `0` |
+| `signal_posts` | `68` |
+| Gmail OAuth env vars | Present, values not printed |
+| `NEWSLETTER_INGESTION_DRY_RUN` | `true` for dry-run |
+| Gmail label preflight | Exact `boot-up-benchmark` label visible |
+
+Dry-run result:
+
+| Result | Value |
+| --- | --- |
+| Emails fetched | `3` |
+| Source breakdown | `1440 Daily Digest: 2`, `Morning Brew: 1` |
+| Story extractions | `24` |
+| Failed emails | `0` |
+| Source URL quality | `5` primary URLs, `19` newsletter-only |
+| Category distribution | `Finance: 7`, `Tech: 1`, `Politics: 1`, `Uncategorized: 15` |
+| Eligible promotion candidates | `5` |
+| Duplicate public-row overlaps | `0` |
+| Database writes | `0` |
+
+Post dry-run counts remained unchanged:
+- `newsletter_emails = 0`
+- `newsletter_story_extractions = 0`
+- `signal_posts = 68`
+
+## Authorized Write Validation
+
+BM authorized the controlled newsletter write after the dry-run passed. The write used only `scripts/newsletter-ingestion-controlled-run.ts` with:
+
+- `NEWSLETTER_INGESTION_ENABLED=true`
+- `NEWSLETTER_INGESTION_DRY_RUN=false`
+- `NEWSLETTER_INGESTION_SINCE_HOURS=48`
+- `GMAIL_NEWSLETTER_LABEL=boot-up-benchmark`
+- `NEWSLETTER_INGESTION_TARGET_ENV=production`
+- `ALLOW_PRODUCTION_NEWSLETTER_INGESTION=true`
+
+Write result:
+
+| Result | Value |
+| --- | --- |
+| Runner success | `true` |
+| Emails fetched | `3` |
+| Existing email count | `0` |
+| Stored emails | `3` |
+| Story extractions stored | `24` |
+| Promoted candidates | `5` |
+| Linked existing candidates | `0` |
+| Skipped promotions | `19` |
+| Failed emails | `0` |
+| Candidate live state | Non-live review candidates only |
+| Publish path | Not run |
+
+Post-write table counts:
+
+| Table | Count |
+| --- | --- |
+| `newsletter_emails` | `3` |
+| `newsletter_story_extractions` | `24` |
+| `signal_posts` | `73` |
+
+Public-surface verification:
+- `/` returned HTTP `200` and still showed the May 6 slate.
+- `/signals` returned HTTP `200`.
+- Latest public renderable Signal count remained `3`.
+- Non-live newsletter candidates did not become public.
+
+Cleanup:
+- `.env.newsletter.local` was deleted.
+- `/tmp/gmail_oauth_code_53682.json` was deleted.
+- No local OAuth callback listener remained on port `53682`.
+- Manual Google Cloud cleanup remains: remove temporary redirect URI `http://127.0.0.1:53682/oauth2callback` from the `Boot Up Newsletter Ingestion OAuth Playground` Web client after confirming no further local OAuth token generation is needed.

--- a/docs/operations/newsletter-ingestion-cron-runbook.md
+++ b/docs/operations/newsletter-ingestion-cron-runbook.md
@@ -41,6 +41,8 @@ npx tsx scripts/newsletter-ingestion-controlled-run.ts
 ```
 
 Expected:
+- Gmail OAuth refresh succeeds.
+- Exact Gmail label `boot-up-benchmark` is visible to the same token used by the runner.
 - Gmail messages are fetched from the label.
 - Candidate story count is reported.
 - No `newsletter_emails` rows are inserted.
@@ -48,6 +50,34 @@ Expected:
 - No `signal_posts` rows are inserted.
 - No WITM is generated.
 - Nothing is published.
+
+## Run Label-Verified Dry-Run Report Locally
+
+Use this report before authorizing writes. It reuses the PRD-61 REST OAuth backend path and does not depend on Gmail MCP, Chrome, or browser state.
+
+If credentials are stored in a local env file, load them without printing values:
+
+```bash
+set -a
+source .env.newsletter.local
+set +a
+NEWSLETTER_INGESTION_ENABLED=true \
+NEWSLETTER_INGESTION_DRY_RUN=true \
+NEWSLETTER_INGESTION_SINCE_HOURS=48 \
+GMAIL_NEWSLETTER_LABEL=boot-up-benchmark \
+npx tsx scripts/newsletter-ingestion-dry-run-report.ts
+```
+
+Expected report sections:
+- Gmail OAuth and exact-label preflight status.
+- Sanitized email inventory: sender, subject, and received timestamp only.
+- Story extraction totals and 3-5 sample headlines per newsletter.
+- Source URL quality counts.
+- Finance / Tech / Politics category distribution.
+- Read-only promotion preview with eligible candidate titles and source URLs.
+- Dedup skips for invalid URLs, duplicate public rows, and exhausted candidate ranks.
+
+The report must not include Gmail message IDs, thread IDs, raw email content, snippets, credentials, refresh tokens, or client secrets. It must not insert or update `newsletter_emails`, `newsletter_story_extractions`, or `signal_posts`.
 
 ## Run Controlled Non-Production Ingestion
 
@@ -73,6 +103,60 @@ Expected candidate state:
 - `final_slate_rank is null`
 - `final_slate_tier is null`
 - WITM fields remain blank or human-required
+
+## Run Controlled Production Write Validation After Approval
+
+Use only after BM explicitly approves a controlled write validation. This is not the cron path and must not run RSS, `draft_only`, publish, or public-surface publication workflows.
+
+Required pre-flight:
+- Confirm `NEWSLETTER_INGESTION_DRY_RUN=false` is intentional for this one run.
+- Confirm `NEWSLETTER_INGESTION_ENABLED=true`.
+- Confirm `ALLOW_PRODUCTION_NEWSLETTER_INGESTION=true`.
+- Confirm Gmail env vars are present without printing values.
+- Confirm pre-counts for `newsletter_emails`, `newsletter_story_extractions`, and `signal_posts`.
+- Confirm the exact Gmail label `boot-up-benchmark` is visible in dry-run mode first.
+
+Command shape:
+
+```bash
+set -a
+source .env.newsletter.local
+set +a
+NEWSLETTER_INGESTION_ENABLED=true \
+NEWSLETTER_INGESTION_DRY_RUN=false \
+NEWSLETTER_INGESTION_TARGET_ENV=production \
+ALLOW_PRODUCTION_NEWSLETTER_INGESTION=true \
+NEWSLETTER_INGESTION_SINCE_HOURS=48 \
+GMAIL_NEWSLETTER_LABEL=boot-up-benchmark \
+npx tsx scripts/newsletter-ingestion-controlled-run.ts
+```
+
+Expected write behavior:
+- Stores new `newsletter_emails` rows idempotently by Gmail message id.
+- Stores conservative `newsletter_story_extractions` Article candidates.
+- Creates only non-live `signal_posts` review candidates.
+- Leaves `editorial_status = 'needs_review'`.
+- Leaves `is_live = false`.
+- Leaves `published_at is null`.
+- Does not assign final slate placement.
+- Does not publish anything.
+
+Required post-flight:
+- Confirm row-count changes match the runner summary.
+- Confirm `/` still returns HTTP 200 and shows the existing public slate.
+- Confirm `/signals` still returns HTTP 200 and excludes non-live newsletter candidates.
+- Delete `.env.newsletter.local`.
+- Delete any local OAuth capture file.
+- Stop any local OAuth callback listener.
+- Remove temporary local OAuth redirect URIs from the Google Cloud OAuth client when no longer needed.
+
+2026-05-11 controlled validation result:
+- Dry-run pre-counts: `newsletter_emails = 0`, `newsletter_story_extractions = 0`, `signal_posts = 68`.
+- Dry-run fetched `3` labeled emails, extracted `24` Article candidates, identified `5` eligible promotion candidates, and performed zero writes.
+- BM-authorized controlled write stored `3` newsletter emails, stored `24` story extractions, and created `5` non-live review candidates.
+- Post-write counts: `newsletter_emails = 3`, `newsletter_story_extractions = 24`, `signal_posts = 73`.
+- Public surface remained gated: `/` HTTP 200 with the May 6 slate, `/signals` HTTP 200, latest public renderable Signal count `3`.
+- Local secret files and OAuth capture files were deleted after validation.
 
 ## Enable Production Cron After Approval
 
@@ -144,6 +228,11 @@ Runtime checks:
 Gmail auth failure:
 - Expected response: fail closed before writes.
 - Check Gmail OAuth env values in deployment secrets.
+
+Gmail label missing/account mismatch:
+- Expected response: fail closed before message search and before writes.
+- Regenerate the refresh token from the Gmail account that contains the exact `boot-up-benchmark` label.
+- Do not diagnose by printing account email, tokens, message IDs, raw content, or snippets.
 
 Gmail rate limit:
 - Expected response: retry safely, then fail closed if still rate-limited.

--- a/docs/product/prd/prd-61-newsletter-ingestion-story-clusters-and-historical-signal-snapshot-foundation.md
+++ b/docs/product/prd/prd-61-newsletter-ingestion-story-clusters-and-historical-signal-snapshot-foundation.md
@@ -41,6 +41,8 @@ This amendment supersedes the original runtime non-goals only for the controlled
 - Known newsletter sources in that label: Morning Brew, Semafor Flagship, TLDR, AP Wire, and 1440.
 - Backend integration uses the server-side Gmail API directly with OAuth2 refresh-token credentials supplied by environment variables.
 - Gmail MCP, Chrome, and personal browser state are not backend dependencies.
+- The controlled path must verify the exact Gmail label `boot-up-benchmark` is visible to the same REST OAuth token before message search.
+- If the label is missing, the runtime must fail closed with a sanitized label missing/account mismatch message before searching messages or writing records.
 - Newsletters are discovery and context sources, not final editorial judgment.
 - Newsletter-derived items are internal Article evidence candidates.
 - BM remains the editorial layer and writes all WITM manually.
@@ -50,6 +52,8 @@ This amendment supersedes the original runtime non-goals only for the controlled
 - `signal_posts.context_material` stores internal newsletter excerpt or framing for editorial grounding only.
 - `newsletter_emails.raw_content` is internal-only raw source material.
 - Dry-run mode is required and defaults on. Dry-run fetches and parses only in memory and performs no database writes.
+- A dedicated dry-run report command must produce sanitized inventory, extraction, source URL quality, category distribution, dedup, and promotion-preview output without writing newsletter or `signal_posts` records.
+- Promotion preview must reuse the same source URL, title/source dedup, and rank-availability rules as write-mode promotion while returning only read-only statuses: `eligible`, `invalid_source_url`, `duplicate_public_row`, or `no_available_candidate_rank`.
 - Runtime writes are fail-closed. Missing Gmail credentials, disabled ingestion, dry-run mode, production guard failure, Gmail auth failure, Gmail rate limits, or database errors must not publish or create live rows.
 - Production writes require all three runtime write gates: `NEWSLETTER_INGESTION_ENABLED=true`, `NEWSLETTER_INGESTION_DRY_RUN=false`, and `ALLOW_PRODUCTION_NEWSLETTER_INGESTION=true`.
 - The Phase 1 parser is heuristic and conservative. It should prefer fewer higher-confidence newsletter Article candidates over noisy over-extraction.
@@ -71,7 +75,7 @@ This amendment supersedes the original runtime non-goals only for the controlled
 - No ranking threshold change.
 - No WITM threshold change.
 - No production migration execution.
-- No production newsletter ingestion write-mode execution during implementation.
+- No production newsletter ingestion write-mode execution without explicit BM authorization.
 - No production cron execution during implementation.
 
 ## Implementation Shape / System Impact
@@ -82,6 +86,8 @@ This amendment supersedes the original runtime non-goals only for the controlled
   - internal MIME/newsletter parser
   - storage/extraction helpers
   - controlled runner
+  - zero-write dry-run report script
+  - read-only promotion preview helper
   - guarded cron route, disabled by default through environment gates
 - RLS v1: service-role-only access for all new internal Phase 2 tables. No anon or authenticated policies are created for newsletter, Story Cluster, Signal evolution, or cross-event connection tables.
 - `published_slates` and `published_slate_items` remain internal service-role tables and become the historical snapshot foundation.
@@ -119,13 +125,40 @@ This amendment supersedes the original runtime non-goals only for the controlled
 - Existing public homepage and `/signals` query shapes remain unchanged and still require live published rows through app-controlled service-role queries.
 - Local validation passes or any failure is documented with exact scope.
 - Gmail search query uses `label:boot-up-benchmark` plus the configured since date.
+- Gmail label preflight proves exact `boot-up-benchmark` visibility before message search and fails closed on label missing/account mismatch.
 - Gmail credentials come only from environment variables and are never logged.
+- Dry-run report output excludes credentials, raw content, snippets, Gmail message IDs, and thread IDs.
+- Dry-run report lists sanitized email inventory, extraction counts, sample headlines, source URL quality, category distribution, read-only dedup analysis, and eligible promotion candidate title/source URL pairs.
 - Newsletter ingestion is idempotent by `newsletter_emails.gmail_message_id`; `gmail_thread_id` may repeat.
 - Newsletter parsing covers representative Morning Brew, Semafor Flagship, TLDR, AP Wire, 1440, malformed, and empty fixtures.
 - Promotion creates only non-live `needs_review` rows with WITM blank or human-required.
 - Promotion links `newsletter_story_extractions.signal_post_id` to created or safe existing non-live rows.
+- Promotion preview matches write-mode promotion skip/link/create rules without calling insert or update helpers.
 - Runtime dry-run and disabled modes perform no writes.
 - Public leakage tests prove `newsletter_emails.raw_content` and `signal_posts.context_material` are not selected or rendered publicly.
+
+## Editorial-Cycle Validation Closeout
+
+Controlled validation completed on `2026-05-11` in branch `fix/prd-61-newsletter-dry-run-validation`.
+
+Dry-run validation:
+- Gmail REST OAuth succeeded with the Web application client named `Boot Up Newsletter Ingestion OAuth Playground`.
+- The same token used by the controlled runner saw the exact Gmail label `boot-up-benchmark`.
+- Pre-counts were `newsletter_emails = 0`, `newsletter_story_extractions = 0`, and `signal_posts = 68`.
+- Dry-run fetched `3` labeled emails, extracted `24` newsletter-derived Article candidates, identified `5` eligible non-live Surface Placement promotion candidates, and recorded `0` failed emails.
+- Dry-run performed zero database writes, and post-counts remained unchanged.
+
+BM-authorized write validation:
+- The controlled newsletter runner was executed once with production write gates explicitly enabled.
+- The run stored `3` `newsletter_emails` rows, stored `24` `newsletter_story_extractions` rows, and created `5` non-live `signal_posts` review candidates.
+- Post-write counts were `newsletter_emails = 3`, `newsletter_story_extractions = 24`, and `signal_posts = 73`.
+- Candidate rows remained non-live review candidates; no publish path, cron path, RSS path, or `draft_only` path was run.
+- Public checks confirmed `/` HTTP `200` with the existing May 6 slate, `/signals` HTTP `200`, and latest public renderable Signal count `3`.
+- Local credential and OAuth capture files were deleted after the run.
+
+Remaining operational follow-up:
+- Remove temporary local OAuth redirect URI `http://127.0.0.1:53682/oauth2callback` from the `Boot Up Newsletter Ingestion OAuth Playground` Web client after no further local token generation is needed.
+- Production cron remains out of scope until separate BM approval.
 
 ## Evidence and Confidence
 

--- a/scripts/newsletter-ingestion-dry-run-report.ts
+++ b/scripts/newsletter-ingestion-dry-run-report.ts
@@ -1,0 +1,19 @@
+import { buildNewsletterDryRunReport } from "@/lib/newsletter-ingestion/dry-run-report";
+
+async function main() {
+  const report = await buildNewsletterDryRunReport();
+
+  console.log(JSON.stringify(report, null, 2));
+
+  if (!report.success) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(JSON.stringify({
+    success: false,
+    message: error instanceof Error ? error.message : String(error),
+  }));
+  process.exitCode = 1;
+});

--- a/src/lib/newsletter-ingestion/dry-run-report.test.ts
+++ b/src/lib/newsletter-ingestion/dry-run-report.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveNewsletterIngestionConfig } from "@/lib/newsletter-ingestion/config";
+import { buildNewsletterDryRunReport } from "@/lib/newsletter-ingestion/dry-run-report";
+import type { GmailApiClient } from "@/lib/newsletter-ingestion/gmail";
+import type { NewsletterDbClient } from "@/lib/newsletter-ingestion/storage";
+
+type Row = Record<string, unknown>;
+type TableName = "newsletter_emails" | "newsletter_story_extractions" | "signal_posts";
+
+function encodeRawEmail(raw: string) {
+  return Buffer.from(raw, "utf8").toString("base64url");
+}
+
+function createDb(initial: Partial<Record<TableName, Row[]>> = {}) {
+  const tables: Record<TableName, Row[]> = {
+    newsletter_emails: [...(initial.newsletter_emails ?? [])],
+    newsletter_story_extractions: [...(initial.newsletter_story_extractions ?? [])],
+    signal_posts: [...(initial.signal_posts ?? [])],
+  };
+
+  function createBuilder(tableName: TableName) {
+    const filters: Array<{ column: string; value: unknown }> = [];
+    const inFilters: Array<{ column: string; values: unknown[] }> = [];
+    let limitCount: number | null = null;
+
+    function applyFilters(rows: Row[]) {
+      return rows.filter((row) =>
+        filters.every((filter) => row[filter.column] === filter.value) &&
+        inFilters.every((filter) => filter.values.includes(row[filter.column])),
+      );
+    }
+
+    function execute() {
+      const selected = applyFilters(tables[tableName]);
+      return { data: limitCount === null ? selected : selected.slice(0, limitCount), error: null };
+    }
+
+    const builder = {
+      select() {
+        return builder;
+      },
+      eq(column: string, value: unknown) {
+        filters.push({ column, value });
+        return builder;
+      },
+      in(column: string, values: unknown[]) {
+        inFilters.push({ column, values });
+        return builder;
+      },
+      limit(count: number) {
+        limitCount = count;
+        return builder;
+      },
+      then(resolve: (value: { data: Row[]; error: null }) => void) {
+        resolve(execute());
+      },
+    };
+
+    return builder;
+  }
+
+  return {
+    tables,
+    db: {
+      from(tableName: TableName) {
+        return createBuilder(tableName);
+      },
+    } as unknown as NewsletterDbClient,
+  };
+}
+
+function createConfig() {
+  return resolveNewsletterIngestionConfig({
+    NEWSLETTER_INGESTION_ENABLED: "true",
+    NEWSLETTER_INGESTION_DRY_RUN: "true",
+    NEWSLETTER_INGESTION_SINCE_HOURS: "48",
+    GMAIL_CLIENT_ID: "client-id",
+    GMAIL_CLIENT_SECRET: "client-secret",
+    GMAIL_REFRESH_TOKEN: "refresh-token",
+  });
+}
+
+function createRawNewsletter() {
+  return [
+    "From: TLDR <newsletter@tldr.tech>",
+    "Subject: TLDR Daily",
+    "Date: Sun, 10 May 2026 07:00:00 +0000",
+    "Content-Type: text/plain",
+    "",
+    "Microsoft expands data center capacity",
+    "PRIVATE_BODY_SNIPPET Microsoft is adding AI infrastructure capacity as cloud demand shifts procurement timelines. https://example.com/cloud",
+    "",
+    "Senate tariff vote pressures chip imports",
+    "PRIVATE_BODY_SNIPPET Lawmakers are weighing tariff changes that could affect chip supply chains and public company guidance. https://example.com/tariffs",
+  ].join("\r\n");
+}
+
+function createGmailClient(input: {
+  labelVisible?: boolean;
+  raw?: string;
+} = {}) {
+  return {
+    getLabelByName: vi.fn(async () =>
+      input.labelVisible === false
+        ? null
+        : {
+            id: "Label_1",
+            name: "boot-up-benchmark",
+            messagesTotal: 1,
+            messagesUnread: 0,
+          }),
+    listNewsletterMessages: vi.fn(async () => [{ id: "gmail-private-message-id", threadId: "thread-private-id" }]),
+    getRawMessage: vi.fn(async () => ({
+      id: "gmail-private-message-id",
+      threadId: "thread-private-id",
+      raw: encodeRawEmail(input.raw ?? createRawNewsletter()),
+      internalDate: "1778400000000",
+    })),
+  } satisfies GmailApiClient;
+}
+
+describe("newsletter dry-run report", () => {
+  it("reports inventory, extraction, and promotion candidates without leaking private material", async () => {
+    const { db, tables } = createDb();
+    const gmailClient = createGmailClient();
+
+    const report = await buildNewsletterDryRunReport({
+      now: new Date("2026-05-10T10:00:00.000Z"),
+      briefingDate: "2026-05-10",
+      sinceDate: new Date("2026-05-08T10:00:00.000Z"),
+    }, {
+      config: createConfig(),
+      db,
+      gmailClient,
+    });
+
+    expect(report.success).toBe(true);
+    expect(report.gmail).toMatchObject({
+      oauth: "ok",
+      labelVisible: true,
+      labelMessageTotal: 1,
+    });
+    expect(report.emailInventory.total).toBe(1);
+    expect(report.storyExtraction).toMatchObject({
+      total: 2,
+      failedEmailCount: 0,
+    });
+    expect(report.sourceUrlQuality).toEqual({
+      withPrimarySourceUrl: 2,
+      newsletterOnly: 0,
+    });
+    expect(report.categoryDistribution.Tech).toBeGreaterThanOrEqual(1);
+    expect(report.promotionPreview.candidates).toHaveLength(2);
+    expect(report.promotionPreview.candidates[0]).toMatchObject({
+      title: "Microsoft expands data center capacity",
+      sourceUrl: "https://example.com/cloud",
+      previewAction: "create_candidate",
+      rank: 1,
+    });
+    expect(report.privacy).toEqual({
+      rawContentIncluded: false,
+      snippetsIncluded: false,
+      messageIdsIncluded: false,
+    });
+    expect(report.dedup).toMatchObject({
+      duplicatePublicRowCount: 0,
+      linkedExistingCandidateCount: 0,
+      sourceUrlOverlapCount: 0,
+      titleOverlapCount: 0,
+      overlaps: [],
+    });
+    expect(tables.newsletter_emails).toHaveLength(0);
+    expect(tables.newsletter_story_extractions).toHaveLength(0);
+    expect(tables.signal_posts).toHaveLength(0);
+
+    const serialized = JSON.stringify(report);
+    expect(serialized).not.toContain("PRIVATE_BODY_SNIPPET");
+    expect(serialized).not.toContain("gmail-private-message-id");
+    expect(serialized).not.toContain("thread-private-id");
+    expect(serialized).not.toContain("client-secret");
+    expect(serialized).not.toContain("refresh-token");
+  });
+
+  it("stops before message search when the Gmail label preflight fails", async () => {
+    const { db, tables } = createDb();
+    const gmailClient = createGmailClient({ labelVisible: false });
+
+    const report = await buildNewsletterDryRunReport({
+      now: new Date("2026-05-10T10:00:00.000Z"),
+      briefingDate: "2026-05-10",
+      sinceDate: new Date("2026-05-08T10:00:00.000Z"),
+    }, {
+      config: createConfig(),
+      db,
+      gmailClient,
+    });
+
+    expect(report.success).toBe(false);
+    expect(report.message).toMatch(/label missing\/account mismatch/i);
+    expect(report.emailInventory.total).toBe(0);
+    expect(gmailClient.listNewsletterMessages).not.toHaveBeenCalled();
+    expect(gmailClient.getRawMessage).not.toHaveBeenCalled();
+    expect(tables.newsletter_emails).toHaveLength(0);
+    expect(tables.newsletter_story_extractions).toHaveLength(0);
+    expect(tables.signal_posts).toHaveLength(0);
+  });
+});

--- a/src/lib/newsletter-ingestion/dry-run-report.ts
+++ b/src/lib/newsletter-ingestion/dry-run-report.ts
@@ -1,0 +1,479 @@
+import {
+  getNewsletterSinceDate,
+  resolveNewsletterIngestionConfig,
+  validateNewsletterGmailEnv,
+  type NewsletterIngestionConfig,
+} from "@/lib/newsletter-ingestion/config";
+import { parseRawNewsletterEmail } from "@/lib/newsletter-ingestion/email-content";
+import {
+  createGmailApiClient,
+  fetchBootUpBenchmarkEmails,
+  verifyGmailNewsletterLabelVisible,
+  type GmailApiClient,
+} from "@/lib/newsletter-ingestion/gmail";
+import { parseNewsletterStories, type ParsedNewsletterStory } from "@/lib/newsletter-ingestion/parser";
+import {
+  previewNewsletterStoryPromotions,
+  type NewsletterPromotionPreviewResult,
+} from "@/lib/newsletter-ingestion/promotion";
+import type { NewsletterDbClient } from "@/lib/newsletter-ingestion/storage";
+import { createSupabaseServiceRoleClient } from "@/lib/supabase/server";
+
+type EmailInventoryItem = {
+  sender: string;
+  subject: string | null;
+  receivedAt: string | null;
+};
+
+type NewsletterGroup<T> = {
+  sender: string;
+  count: number;
+  items: T[];
+};
+
+type ParsedEmailReport = EmailInventoryItem & {
+  stories: ParsedNewsletterStory[];
+};
+
+export type NewsletterDryRunReport = {
+  success: boolean;
+  message: string;
+  timestamp: string;
+  label: string;
+  sinceDate: string;
+  briefingDate: string;
+  dryRun: true;
+  enabled: boolean;
+  targetEnvironment: string;
+  gmail: {
+    oauth: "ok" | "not_checked";
+    labelVisible: boolean;
+    labelMessageTotal: number | null;
+  };
+  emailInventory: {
+    total: number;
+    newsletters: Array<NewsletterGroup<EmailInventoryItem>>;
+  };
+  storyExtraction: {
+    total: number;
+    failedEmailCount: number;
+    newsletters: Array<{
+      sender: string;
+      count: number;
+      sampleHeadlines: string[];
+    }>;
+  };
+  sourceUrlQuality: {
+    withPrimarySourceUrl: number;
+    newsletterOnly: number;
+  };
+  categoryDistribution: Record<"Finance" | "Tech" | "Politics" | "Uncategorized", number>;
+  promotionPreview: {
+    eligibleCount: number;
+    createCandidateCount: number;
+    linkExistingCandidateCount: number;
+    skippedCount: number;
+    candidates: Array<{
+      title: string;
+      sourceUrl: string;
+      sourceDomain: string | null;
+      category: string | null;
+      previewAction: "create_candidate" | "link_existing_candidate";
+      rank: number | null;
+    }>;
+    skipped: Array<{
+      title: string;
+      sourceUrl: string | null;
+      reason: string;
+    }>;
+  };
+  dedup: {
+    duplicatePublicRowCount: number;
+    linkedExistingCandidateCount: number;
+    sourceUrlOverlapCount: number;
+    titleOverlapCount: number;
+    overlaps: Array<{
+      title: string;
+      sourceUrl: string | null;
+      status: "eligible" | "duplicate_public_row";
+      previewAction: "link_existing_candidate" | "skip";
+      matchedBy: "source_url" | "title";
+    }>;
+  };
+  privacy: {
+    rawContentIncluded: false;
+    snippetsIncluded: false;
+    messageIdsIncluded: false;
+  };
+};
+
+export type NewsletterDryRunReportDependencies = {
+  config?: NewsletterIngestionConfig;
+  gmailClient?: GmailApiClient;
+  db?: NewsletterDbClient | null;
+};
+
+function todayTaipei(now: Date) {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Taipei",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+}
+
+function emptyReport(input: {
+  success: boolean;
+  message: string;
+  timestamp: string;
+  config: NewsletterIngestionConfig;
+  sinceDate: Date;
+  briefingDate: string;
+  gmail?: Partial<NewsletterDryRunReport["gmail"]>;
+}): NewsletterDryRunReport {
+  return {
+    success: input.success,
+    message: input.message,
+    timestamp: input.timestamp,
+    label: input.config.label,
+    sinceDate: input.sinceDate.toISOString(),
+    briefingDate: input.briefingDate,
+    dryRun: true,
+    enabled: input.config.enabled,
+    targetEnvironment: input.config.targetEnvironment,
+    gmail: {
+      oauth: input.gmail?.oauth ?? "not_checked",
+      labelVisible: input.gmail?.labelVisible ?? false,
+      labelMessageTotal: input.gmail?.labelMessageTotal ?? null,
+    },
+    emailInventory: {
+      total: 0,
+      newsletters: [],
+    },
+    storyExtraction: {
+      total: 0,
+      failedEmailCount: 0,
+      newsletters: [],
+    },
+    sourceUrlQuality: {
+      withPrimarySourceUrl: 0,
+      newsletterOnly: 0,
+    },
+    categoryDistribution: {
+      Finance: 0,
+      Tech: 0,
+      Politics: 0,
+      Uncategorized: 0,
+    },
+    promotionPreview: {
+      eligibleCount: 0,
+      createCandidateCount: 0,
+      linkExistingCandidateCount: 0,
+      skippedCount: 0,
+      candidates: [],
+      skipped: [],
+    },
+    dedup: {
+      duplicatePublicRowCount: 0,
+      linkedExistingCandidateCount: 0,
+      sourceUrlOverlapCount: 0,
+      titleOverlapCount: 0,
+      overlaps: [],
+    },
+    privacy: {
+      rawContentIncluded: false,
+      snippetsIncluded: false,
+      messageIdsIncluded: false,
+    },
+  };
+}
+
+function groupBySender<T extends { sender: string }>(items: T[]) {
+  const groups = new Map<string, T[]>();
+
+  for (const item of items) {
+    const sender = item.sender.trim() || "Unknown sender";
+    groups.set(sender, [...(groups.get(sender) ?? []), item]);
+  }
+
+  return [...groups.entries()].map(([sender, groupedItems]) => ({
+    sender,
+    count: groupedItems.length,
+    items: groupedItems,
+  }));
+}
+
+function summarizeStories(parsedEmails: ParsedEmailReport[]) {
+  const bySender = new Map<string, ParsedNewsletterStory[]>();
+  const categoryDistribution = {
+    Finance: 0,
+    Tech: 0,
+    Politics: 0,
+    Uncategorized: 0,
+  };
+  let withPrimarySourceUrl = 0;
+  let newsletterOnly = 0;
+
+  for (const email of parsedEmails) {
+    const sender = email.sender.trim() || "Unknown sender";
+    bySender.set(sender, [...(bySender.get(sender) ?? []), ...email.stories]);
+
+    for (const story of email.stories) {
+      if (story.sourceUrl) {
+        withPrimarySourceUrl += 1;
+      } else {
+        newsletterOnly += 1;
+      }
+
+      if (story.category) {
+        categoryDistribution[story.category] += 1;
+      } else {
+        categoryDistribution.Uncategorized += 1;
+      }
+    }
+  }
+
+  return {
+    withPrimarySourceUrl,
+    newsletterOnly,
+    categoryDistribution,
+    newsletters: [...bySender.entries()].map(([sender, stories]) => ({
+      sender,
+      count: stories.length,
+      sampleHeadlines: stories.slice(0, 5).map((story) => story.headline),
+    })),
+  };
+}
+
+function summarizePromotionPreview(previews: NewsletterPromotionPreviewResult[]) {
+  const eligible = previews.filter((preview) => preview.status === "eligible");
+  const createCandidates = eligible.filter((preview) => preview.previewAction === "create_candidate");
+  const linkExistingCandidates = eligible.filter((preview) => preview.previewAction === "link_existing_candidate");
+  const skipped = previews.filter((preview) => preview.previewAction === "skip");
+
+  return {
+    eligibleCount: eligible.length,
+    createCandidateCount: createCandidates.length,
+    linkExistingCandidateCount: linkExistingCandidates.length,
+    skippedCount: skipped.length,
+    candidates: eligible
+      .filter((preview) => preview.sourceUrl)
+      .map((preview) => ({
+        title: preview.title,
+        sourceUrl: preview.sourceUrl as string,
+        sourceDomain: preview.sourceDomain,
+        category: preview.category,
+        previewAction: preview.previewAction as "create_candidate" | "link_existing_candidate",
+        rank: preview.rank,
+      })),
+    skipped: skipped.map((preview) => ({
+      title: preview.title,
+      sourceUrl: preview.sourceUrl,
+      reason: preview.reason ?? preview.status,
+    })),
+    duplicatePublicRowCount: previews.filter((preview) => preview.status === "duplicate_public_row").length,
+    linkedExistingCandidateCount: linkExistingCandidates.length,
+    sourceUrlOverlapCount: previews.filter((preview) => preview.matchedBy === "source_url").length,
+    titleOverlapCount: previews.filter((preview) => preview.matchedBy === "title").length,
+    overlaps: previews
+      .filter((preview): preview is NewsletterPromotionPreviewResult & {
+        matchedBy: "source_url" | "title";
+        status: "eligible" | "duplicate_public_row";
+        previewAction: "link_existing_candidate" | "skip";
+      } =>
+        Boolean(preview.matchedBy) &&
+        (preview.previewAction === "link_existing_candidate" || preview.status === "duplicate_public_row"),
+      )
+      .map((preview) => ({
+        title: preview.title,
+        sourceUrl: preview.sourceUrl,
+        status: preview.status,
+        previewAction: preview.previewAction,
+        matchedBy: preview.matchedBy,
+      })),
+  };
+}
+
+export async function buildNewsletterDryRunReport(
+  input: {
+    now?: Date;
+    briefingDate?: string;
+    sinceDate?: Date;
+  } = {},
+  dependencies: NewsletterDryRunReportDependencies = {},
+): Promise<NewsletterDryRunReport> {
+  const now = input.now ?? new Date();
+  const timestamp = now.toISOString();
+  const config = dependencies.config ??
+    resolveNewsletterIngestionConfig(process.env, {
+      dryRun: true,
+    });
+  const sinceDate = input.sinceDate ?? getNewsletterSinceDate(config, now);
+  const briefingDate = input.briefingDate ?? todayTaipei(now);
+
+  if (!config.enabled) {
+    return emptyReport({
+      success: false,
+      message: "NEWSLETTER_INGESTION_ENABLED is not true.",
+      timestamp,
+      config,
+      sinceDate,
+      briefingDate,
+    });
+  }
+
+  const gmailEnv = validateNewsletterGmailEnv(config);
+
+  if (!gmailEnv.ok) {
+    return emptyReport({
+      success: false,
+      message: gmailEnv.message ?? "Newsletter Gmail configuration is incomplete.",
+      timestamp,
+      config,
+      sinceDate,
+      briefingDate,
+    });
+  }
+
+  const gmailClient = dependencies.gmailClient ?? createGmailApiClient({
+    credentials: {
+      clientId: config.gmailClientId,
+      clientSecret: config.gmailClientSecret,
+      refreshToken: config.gmailRefreshToken,
+    },
+  });
+  const labelPreflight = await verifyGmailNewsletterLabelVisible(gmailClient, config.label);
+
+  if (!labelPreflight.ok) {
+    return emptyReport({
+      success: false,
+      message: labelPreflight.message,
+      timestamp,
+      config,
+      sinceDate,
+      briefingDate,
+      gmail: {
+        oauth: "ok",
+        labelVisible: false,
+      },
+    });
+  }
+
+  const db = dependencies.db ?? createSupabaseServiceRoleClient();
+
+  if (!db) {
+    return emptyReport({
+      success: false,
+      message: "Dry-run report cannot preview promotion candidates because Supabase service-role env is not configured.",
+      timestamp,
+      config,
+      sinceDate,
+      briefingDate,
+      gmail: {
+        oauth: "ok",
+        labelVisible: true,
+        labelMessageTotal: labelPreflight.label.messagesTotal,
+      },
+    });
+  }
+
+  const refs = await fetchBootUpBenchmarkEmails(sinceDate, {
+    gmailClient,
+    label: config.label,
+    maxResults: config.maxEmailsPerRun,
+  });
+  const parsedEmails: ParsedEmailReport[] = [];
+  let failedEmailCount = 0;
+
+  for (const ref of refs) {
+    try {
+      const rawMessage = await gmailClient.getRawMessage(ref.id);
+      const email = parseRawNewsletterEmail(rawMessage.raw, {
+        internalDate: rawMessage.internalDate,
+      });
+      const stories = parseNewsletterStories({
+        sender: email.sender,
+        subject: email.subject,
+        rawContent: email.contentText,
+      });
+
+      parsedEmails.push({
+        sender: email.sender || "Unknown sender",
+        subject: email.subject || null,
+        receivedAt: email.receivedAt,
+        stories,
+      });
+    } catch {
+      failedEmailCount += 1;
+    }
+  }
+
+  const stories = parsedEmails.flatMap((email) => email.stories);
+  const storySummary = summarizeStories(parsedEmails);
+  const promotionPreviews = await previewNewsletterStoryPromotions({
+    db,
+    briefingDate,
+    stories: stories.map((story) => ({
+      headline: story.headline,
+      sourceUrl: story.sourceUrl,
+      sourceDomain: story.sourceDomain,
+      category: story.category,
+    })),
+  });
+  const promotionSummary = summarizePromotionPreview(promotionPreviews);
+
+  return {
+    success: failedEmailCount === 0,
+    message: "Newsletter ingestion dry-run report fetched Gmail messages and previewed promotion candidates without database writes.",
+    timestamp,
+    label: config.label,
+    sinceDate: sinceDate.toISOString(),
+    briefingDate,
+    dryRun: true,
+    enabled: config.enabled,
+    targetEnvironment: config.targetEnvironment,
+    gmail: {
+      oauth: "ok",
+      labelVisible: true,
+      labelMessageTotal: labelPreflight.label.messagesTotal,
+    },
+    emailInventory: {
+      total: parsedEmails.length,
+      newsletters: groupBySender(parsedEmails.map((email) => ({
+        sender: email.sender,
+        subject: email.subject,
+        receivedAt: email.receivedAt,
+      }))),
+    },
+    storyExtraction: {
+      total: stories.length,
+      failedEmailCount,
+      newsletters: storySummary.newsletters,
+    },
+    sourceUrlQuality: {
+      withPrimarySourceUrl: storySummary.withPrimarySourceUrl,
+      newsletterOnly: storySummary.newsletterOnly,
+    },
+    categoryDistribution: storySummary.categoryDistribution,
+    promotionPreview: {
+      eligibleCount: promotionSummary.eligibleCount,
+      createCandidateCount: promotionSummary.createCandidateCount,
+      linkExistingCandidateCount: promotionSummary.linkExistingCandidateCount,
+      skippedCount: promotionSummary.skippedCount,
+      candidates: promotionSummary.candidates,
+      skipped: promotionSummary.skipped,
+    },
+    dedup: {
+      duplicatePublicRowCount: promotionSummary.duplicatePublicRowCount,
+      linkedExistingCandidateCount: promotionSummary.linkedExistingCandidateCount,
+      sourceUrlOverlapCount: promotionSummary.sourceUrlOverlapCount,
+      titleOverlapCount: promotionSummary.titleOverlapCount,
+      overlaps: promotionSummary.overlaps,
+    },
+    privacy: {
+      rawContentIncluded: false,
+      snippetsIncluded: false,
+      messageIdsIncluded: false,
+    },
+  };
+}

--- a/src/lib/newsletter-ingestion/gmail.test.ts
+++ b/src/lib/newsletter-ingestion/gmail.test.ts
@@ -5,6 +5,7 @@ import {
   createGmailApiClient,
   fetchBootUpBenchmarkEmails,
   GmailApiError,
+  verifyGmailNewsletterLabelVisible,
 } from "@/lib/newsletter-ingestion/gmail";
 
 describe("Gmail newsletter API client", () => {
@@ -81,5 +82,81 @@ describe("Gmail newsletter API client", () => {
       status: 429,
       retryable: true,
     } satisfies Partial<GmailApiError>);
+  });
+
+  it("confirms the exact newsletter label is visible without exposing secrets", async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url === "https://oauth2.googleapis.com/token") {
+        return Response.json({ access_token: "access-token" });
+      }
+
+      expect(url).toBe("https://gmail.googleapis.com/gmail/v1/users/me/labels");
+      return Response.json({
+        labels: [
+          { id: "Label_1", name: "boot-up-benchmark", messagesTotal: 7, messagesUnread: 2 },
+          { id: "Label_2", name: "Boot Up Benchmark", messagesTotal: 1, messagesUnread: 0 },
+        ],
+      });
+    });
+    const gmailClient = createGmailApiClient({
+      credentials: {
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        refreshToken: "refresh-token",
+      },
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    const result = await verifyGmailNewsletterLabelVisible(gmailClient, "boot-up-benchmark");
+
+    expect(result).toEqual({
+      ok: true,
+      label: {
+        id: "Label_1",
+        name: "boot-up-benchmark",
+        messagesTotal: 7,
+        messagesUnread: 2,
+      },
+    });
+    expect(JSON.stringify(fetchImpl.mock.calls)).not.toContain("refresh-token");
+    expect(JSON.stringify(fetchImpl.mock.calls)).not.toContain("client-secret");
+  });
+
+  it("fails closed with a sanitized account mismatch message when the label is missing", async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url === "https://oauth2.googleapis.com/token") {
+        return Response.json({ access_token: "access-token" });
+      }
+
+      return Response.json({
+        labels: [
+          { id: "Label_1", name: "other-label", messagesTotal: 7, messagesUnread: 2 },
+        ],
+      });
+    });
+    const gmailClient = createGmailApiClient({
+      credentials: {
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        refreshToken: "refresh-token",
+      },
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    const result = await verifyGmailNewsletterLabelVisible(gmailClient, "boot-up-benchmark");
+
+    expect(result).toEqual({
+      ok: false,
+      label: "boot-up-benchmark",
+      message: expect.stringMatching(/label missing\/account mismatch/i),
+    });
+    if (!result.ok) {
+      expect(result.message).not.toContain("refresh-token");
+      expect(result.message).not.toContain("client-secret");
+    }
   });
 });

--- a/src/lib/newsletter-ingestion/gmail.ts
+++ b/src/lib/newsletter-ingestion/gmail.ts
@@ -13,12 +13,20 @@ export type GmailMessageRef = {
   threadId: string;
 };
 
+export type GmailLabel = {
+  id: string;
+  name: string;
+  messagesTotal: number | null;
+  messagesUnread: number | null;
+};
+
 export type GmailRawMessage = GmailMessageRef & {
   raw: string;
   internalDate: string | null;
 };
 
 export type GmailApiClient = {
+  getLabelByName(label: string): Promise<GmailLabel | null>;
   listNewsletterMessages(input: {
     label?: string;
     sinceDate: Date;
@@ -39,6 +47,15 @@ type GmailRawMessageResponse = {
   threadId?: string;
   raw?: string;
   internalDate?: string;
+};
+
+type GmailLabelsResponse = {
+  labels?: Array<{
+    id?: string;
+    name?: string;
+    messagesTotal?: number;
+    messagesUnread?: number;
+  }>;
 };
 
 type GmailTokenResponse = {
@@ -180,6 +197,30 @@ export function createGmailApiClient(input: {
   }
 
   return {
+    async getLabelByName(label) {
+      const normalizedLabel = normalizeLabel(label);
+      const accessToken = await getAccessToken();
+      const url = new URL("https://gmail.googleapis.com/gmail/v1/users/me/labels");
+      const body = await gmailFetchJson<GmailLabelsResponse>({
+        url,
+        accessToken,
+        fetchImpl,
+        failureLabel: "Gmail label preflight",
+      });
+      const labelMatch = (body.labels ?? []).find((entry) => entry.name === normalizedLabel);
+
+      if (!labelMatch?.id || !labelMatch.name) {
+        return null;
+      }
+
+      return {
+        id: labelMatch.id,
+        name: labelMatch.name,
+        messagesTotal: typeof labelMatch.messagesTotal === "number" ? labelMatch.messagesTotal : null,
+        messagesUnread: typeof labelMatch.messagesUnread === "number" ? labelMatch.messagesUnread : null,
+      };
+    },
+
     async listNewsletterMessages({ label = DEFAULT_NEWSLETTER_LABEL, sinceDate, maxResults }) {
       const accessToken = await getAccessToken();
       const url = new URL("https://gmail.googleapis.com/gmail/v1/users/me/messages");
@@ -244,4 +285,39 @@ export async function fetchBootUpBenchmarkEmails(
     sinceDate,
     maxResults: input.maxResults,
   });
+}
+
+export type GmailLabelPreflightResult =
+  | {
+      ok: true;
+      label: GmailLabel;
+    }
+  | {
+      ok: false;
+      label: string;
+      message: string;
+    };
+
+export async function verifyGmailNewsletterLabelVisible(
+  gmailClient: GmailApiClient,
+  label = DEFAULT_NEWSLETTER_LABEL,
+): Promise<GmailLabelPreflightResult> {
+  const normalizedLabel = normalizeLabel(label);
+  const visibleLabel = await gmailClient.getLabelByName(normalizedLabel);
+
+  if (!visibleLabel) {
+    return {
+      ok: false,
+      label: normalizedLabel,
+      message:
+        `Gmail label "${normalizedLabel}" is not visible to the authorized account ` +
+        "(label missing/account mismatch). " +
+        "Regenerate the refresh token from the Gmail account that contains that label.",
+    };
+  }
+
+  return {
+    ok: true,
+    label: visibleLabel,
+  };
 }

--- a/src/lib/newsletter-ingestion/promotion.ts
+++ b/src/lib/newsletter-ingestion/promotion.ts
@@ -4,6 +4,7 @@ import type { NewsletterDbClient, NewsletterStoryExtractionRow } from "@/lib/new
 type ExistingSignalPostCandidate = {
   id: string;
   title: string | null;
+  source_url: string | null;
   rank: number | null;
   editorial_status: string | null;
   is_live: boolean | null;
@@ -33,6 +34,26 @@ export type NewsletterPromotionResult =
         | "storage_error";
       message: string;
     };
+
+export type NewsletterPromotionPreviewStory = {
+  headline: string;
+  sourceUrl: string | null;
+  sourceDomain: string | null;
+  category: "Finance" | "Tech" | "Politics" | null;
+};
+
+export type NewsletterPromotionPreviewResult = {
+  status: "eligible" | "invalid_source_url" | "duplicate_public_row" | "no_available_candidate_rank";
+  previewAction: "create_candidate" | "link_existing_candidate" | "skip";
+  title: string;
+  sourceUrl: string | null;
+  sourceDomain: string | null;
+  category: "Finance" | "Tech" | "Politics" | null;
+  rank: number | null;
+  existingSignalPostId: string | null;
+  matchedBy: "source_url" | "title" | null;
+  reason: string | null;
+};
 
 function normalizeDateValue(value: string) {
   if (!/^\d{4}-\d{2}-\d{2}$/u.test(value)) {
@@ -85,7 +106,7 @@ async function findExistingBySourceUrl(input: {
 }) {
   const result = await input.db
     .from("signal_posts")
-    .select("id, title, rank, editorial_status, is_live, published_at")
+    .select("id, title, source_url, rank, editorial_status, is_live, published_at")
     .eq("briefing_date", input.briefingDate)
     .eq("source_url", input.sourceUrl)
     .limit(1);
@@ -105,7 +126,7 @@ async function findExistingByTitle(input: {
   const normalizedTitle = normalizeTitle(input.title);
   const result = await input.db
     .from("signal_posts")
-    .select("id, title, rank, editorial_status, is_live, published_at")
+    .select("id, title, source_url, rank, editorial_status, is_live, published_at")
     .eq("briefing_date", input.briefingDate)
     .limit(100);
 
@@ -143,6 +164,136 @@ async function getNextCandidateRank(input: {
   }
 
   return null;
+}
+
+async function getExistingSignalPostCandidates(input: {
+  db: NewsletterDbClient;
+  briefingDate: string;
+}) {
+  const result = await input.db
+    .from("signal_posts")
+    .select("id, title, source_url, rank, editorial_status, is_live, published_at")
+    .eq("briefing_date", input.briefingDate)
+    .limit(200);
+
+  if (result.error) {
+    throw new Error(`signal_posts preview check failed: ${result.error.message}`);
+  }
+
+  return (result.data ?? []) as ExistingSignalPostCandidate[];
+}
+
+function nextAvailablePreviewRank(
+  existingRows: ExistingSignalPostCandidate[],
+  allocatedRanks: Set<number>,
+) {
+  const usedRanks = new Set(
+    existingRows
+      .map((row) => row.rank)
+      .filter((rank): rank is number => typeof rank === "number"),
+  );
+
+  for (const rank of allocatedRanks) {
+    usedRanks.add(rank);
+  }
+
+  for (let rank = 1; rank <= 20; rank += 1) {
+    if (!usedRanks.has(rank)) {
+      allocatedRanks.add(rank);
+      return rank;
+    }
+  }
+
+  return null;
+}
+
+export async function previewNewsletterStoryPromotions(input: {
+  db: NewsletterDbClient;
+  briefingDate: string;
+  stories: NewsletterPromotionPreviewStory[];
+}): Promise<NewsletterPromotionPreviewResult[]> {
+  const briefingDate = normalizeDateValue(input.briefingDate);
+  const existingRows = await getExistingSignalPostCandidates({
+    db: input.db,
+    briefingDate,
+  });
+  const allocatedRanks = new Set<number>();
+
+  return input.stories.map((story) => {
+    const title = story.headline;
+    const sourceUrl = story.sourceUrl?.trim() ?? null;
+    const base = {
+      title,
+      sourceUrl,
+      sourceDomain: story.sourceDomain,
+      category: story.category,
+    };
+
+    if (!isValidPublicSourceUrl(sourceUrl ?? "")) {
+      return {
+        ...base,
+        status: "invalid_source_url" as const,
+        previewAction: "skip" as const,
+        rank: null,
+        existingSignalPostId: null,
+        matchedBy: null,
+        reason: "Newsletter story lacks a valid public source URL.",
+      };
+    }
+
+    const existingByUrl = existingRows.find((row) => row.source_url === sourceUrl);
+    const existingByTitle = existingRows.find((row) => normalizeTitle(row.title) === normalizeTitle(title));
+    const existing = existingByUrl ?? existingByTitle ?? null;
+    const matchedBy = existingByUrl ? "source_url" : existingByTitle ? "title" : null;
+
+    if (existing) {
+      if (isPublishedOrLive(existing)) {
+        return {
+          ...base,
+          status: "duplicate_public_row" as const,
+          previewAction: "skip" as const,
+          rank: null,
+          existingSignalPostId: existing.id,
+          matchedBy,
+          reason: "Newsletter story matches an already live or published signal_posts row.",
+        };
+      }
+
+      return {
+        ...base,
+        status: "eligible" as const,
+        previewAction: "link_existing_candidate" as const,
+        rank: existing.rank,
+        existingSignalPostId: existing.id,
+        matchedBy,
+        reason: "Newsletter story would link to an existing non-live review candidate.",
+      };
+    }
+
+    const rank = nextAvailablePreviewRank(existingRows, allocatedRanks);
+
+    if (!rank) {
+      return {
+        ...base,
+        status: "no_available_candidate_rank" as const,
+        previewAction: "skip" as const,
+        rank: null,
+        existingSignalPostId: null,
+        matchedBy: null,
+        reason: "All 20 candidate ranks are already occupied for the briefing date.",
+      };
+    }
+
+    return {
+      ...base,
+      status: "eligible" as const,
+      previewAction: "create_candidate" as const,
+      rank,
+      existingSignalPostId: null,
+      matchedBy: null,
+      reason: "Newsletter story would create a non-live needs_review candidate.",
+    };
+  });
 }
 
 export async function promoteNewsletterStoryToCandidate(input: {

--- a/src/lib/newsletter-ingestion/runner.test.ts
+++ b/src/lib/newsletter-ingestion/runner.test.ts
@@ -120,6 +120,14 @@ function createGmailClient(): GmailApiClient {
   ].join("\r\n");
 
   return {
+    async getLabelByName() {
+      return {
+        id: "Label_1",
+        name: "boot-up-benchmark",
+        messagesTotal: 1,
+        messagesUnread: 0,
+      };
+    },
     async listNewsletterMessages() {
       return [{ id: "gmail-1", threadId: "thread-1" }];
     },
@@ -178,6 +186,38 @@ describe("controlled newsletter ingestion runner", () => {
     expect(result.success).toBe(true);
     expect(result.summary.fetchedMessageCount).toBe(1);
     expect(result.summary.extractedStoryCount).toBe(1);
+    expect(tables.newsletter_emails).toHaveLength(0);
+    expect(tables.newsletter_story_extractions).toHaveLength(0);
+    expect(tables.signal_posts).toHaveLength(0);
+  });
+
+  it("fails closed before message search when the configured label is not visible", async () => {
+    const { db, tables } = createDb();
+    const gmailClient = {
+      getLabelByName: vi.fn(async () => null),
+      listNewsletterMessages: vi.fn(),
+      getRawMessage: vi.fn(),
+    } as unknown as GmailApiClient;
+    const config = resolveNewsletterIngestionConfig({
+      NEWSLETTER_INGESTION_ENABLED: "true",
+      NEWSLETTER_INGESTION_DRY_RUN: "true",
+      GMAIL_CLIENT_ID: "client",
+      GMAIL_CLIENT_SECRET: "secret",
+      GMAIL_REFRESH_TOKEN: "refresh",
+    });
+
+    const result = await runNewsletterIngestion({
+      now: new Date("2026-05-10T00:00:00.000Z"),
+    }, {
+      config,
+      db,
+      gmailClient,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.summary.message).toMatch(/label missing\/account mismatch/i);
+    expect(gmailClient.listNewsletterMessages).not.toHaveBeenCalled();
+    expect(gmailClient.getRawMessage).not.toHaveBeenCalled();
     expect(tables.newsletter_emails).toHaveLength(0);
     expect(tables.newsletter_story_extractions).toHaveLength(0);
     expect(tables.signal_posts).toHaveLength(0);

--- a/src/lib/newsletter-ingestion/runner.ts
+++ b/src/lib/newsletter-ingestion/runner.ts
@@ -9,6 +9,7 @@ import {
 import {
   createGmailApiClient,
   fetchBootUpBenchmarkEmails,
+  verifyGmailNewsletterLabelVisible,
   type GmailApiClient,
   type GmailMessageRef,
 } from "@/lib/newsletter-ingestion/gmail";
@@ -347,6 +348,20 @@ export async function runNewsletterIngestion(
   });
 
   try {
+    const labelPreflight = await verifyGmailNewsletterLabelVisible(gmailClient, config.label);
+
+    if (!labelPreflight.ok) {
+      return buildResult({
+        success: false,
+        timestamp,
+        config,
+        sinceDate,
+        briefingDate,
+        testRunId,
+        message: labelPreflight.message,
+      });
+    }
+
     const refs = await fetchBootUpBenchmarkEmails(sinceDate, {
       gmailClient,
       label: config.label,

--- a/src/lib/newsletter-ingestion/storage-promotion.test.ts
+++ b/src/lib/newsletter-ingestion/storage-promotion.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import type { GmailApiClient } from "@/lib/newsletter-ingestion/gmail";
-import { promoteNewsletterStoryToCandidate } from "@/lib/newsletter-ingestion/promotion";
+import {
+  previewNewsletterStoryPromotions,
+  promoteNewsletterStoryToCandidate,
+} from "@/lib/newsletter-ingestion/promotion";
 import {
   createContentSha256,
   extractStoriesFromEmail,
@@ -114,6 +117,14 @@ function createDb(initial: Partial<Record<TableName, Row[]>> = {}) {
 
 function createGmailClient(raw: string): GmailApiClient {
   return {
+    async getLabelByName() {
+      return {
+        id: "Label_1",
+        name: "boot-up-benchmark",
+        messagesTotal: 1,
+        messagesUnread: 0,
+      };
+    },
     async listNewsletterMessages() {
       return [{ id: "gmail-1", threadId: "thread-1" }];
     },
@@ -346,5 +357,172 @@ describe("newsletter candidate promotion", () => {
     });
     expect(tables.signal_posts).toHaveLength(1);
     expect(tables.newsletter_story_extractions[0]?.signal_post_id).toBe("signal-existing");
+  });
+
+  it("previews eligible candidate creation without writing signal_posts rows", async () => {
+    const { db, tables } = createDb();
+
+    const result = await previewNewsletterStoryPromotions({
+      db,
+      briefingDate: "2026-05-10",
+      stories: [{
+        headline: "Microsoft expands data center capacity",
+        sourceUrl: "https://example.com/cloud",
+        sourceDomain: "example.com",
+        category: "Tech",
+      }],
+    });
+
+    expect(result).toEqual([{
+      status: "eligible",
+      previewAction: "create_candidate",
+      title: "Microsoft expands data center capacity",
+      sourceUrl: "https://example.com/cloud",
+      sourceDomain: "example.com",
+      category: "Tech",
+      rank: 1,
+      existingSignalPostId: null,
+      matchedBy: null,
+      reason: "Newsletter story would create a non-live needs_review candidate.",
+    }]);
+    expect(tables.signal_posts).toHaveLength(0);
+  });
+
+  it("previews duplicate public rows as skipped without writing", async () => {
+    const { db, tables } = createDb({
+      signal_posts: [{
+        id: "signal-live",
+        briefing_date: "2026-05-10",
+        rank: 4,
+        title: "Microsoft expands data center capacity",
+        source_url: "https://example.com/cloud",
+        editorial_status: "published",
+        is_live: true,
+        published_at: "2026-05-10T10:00:00.000Z",
+      }],
+    });
+
+    const result = await previewNewsletterStoryPromotions({
+      db,
+      briefingDate: "2026-05-10",
+      stories: [{
+        headline: "Microsoft expands data center capacity",
+        sourceUrl: "https://example.com/cloud",
+        sourceDomain: "example.com",
+        category: "Tech",
+      }],
+    });
+
+    expect(result[0]).toMatchObject({
+      status: "duplicate_public_row",
+      previewAction: "skip",
+      existingSignalPostId: "signal-live",
+      matchedBy: "source_url",
+      rank: null,
+    });
+    expect(tables.signal_posts).toHaveLength(1);
+  });
+
+  it("previews non-live duplicates as linkable review candidates", async () => {
+    const { db, tables } = createDb({
+      signal_posts: [{
+        id: "signal-existing",
+        briefing_date: "2026-05-10",
+        rank: 2,
+        title: "Existing cloud candidate",
+        source_url: "https://example.com/cloud",
+        editorial_status: "needs_review",
+        is_live: false,
+        published_at: null,
+      }],
+    });
+
+    const result = await previewNewsletterStoryPromotions({
+      db,
+      briefingDate: "2026-05-10",
+      stories: [{
+        headline: "Microsoft expands data center capacity",
+        sourceUrl: "https://example.com/cloud",
+        sourceDomain: "example.com",
+        category: "Tech",
+      }],
+    });
+
+    expect(result[0]).toMatchObject({
+      status: "eligible",
+      previewAction: "link_existing_candidate",
+      existingSignalPostId: "signal-existing",
+      matchedBy: "source_url",
+      rank: 2,
+    });
+    expect(tables.signal_posts).toHaveLength(1);
+  });
+
+  it("previews exhausted candidate ranks without writing", async () => {
+    const { db, tables } = createDb({
+      signal_posts: Array.from({ length: 20 }, (_value, index) => ({
+        id: `signal-${index + 1}`,
+        briefing_date: "2026-05-10",
+        rank: index + 1,
+        title: `Existing candidate ${index + 1}`,
+        source_url: `https://example.com/story-${index + 1}`,
+        editorial_status: "needs_review",
+        is_live: false,
+        published_at: null,
+      })),
+    });
+
+    const result = await previewNewsletterStoryPromotions({
+      db,
+      briefingDate: "2026-05-10",
+      stories: [{
+        headline: "New candidate without rank",
+        sourceUrl: "https://example.com/new-story",
+        sourceDomain: "example.com",
+        category: "Finance",
+      }],
+    });
+
+    expect(result[0]).toMatchObject({
+      status: "no_available_candidate_rank",
+      previewAction: "skip",
+      rank: null,
+      existingSignalPostId: null,
+      matchedBy: null,
+    });
+    expect(tables.signal_posts).toHaveLength(20);
+  });
+
+  it("previews title overlaps when source URLs differ", async () => {
+    const { db } = createDb({
+      signal_posts: [{
+        id: "signal-title-match",
+        briefing_date: "2026-05-10",
+        rank: 7,
+        title: "Microsoft expands data center capacity",
+        source_url: "https://example.com/original-cloud",
+        editorial_status: "published",
+        is_live: true,
+        published_at: "2026-05-10T10:00:00.000Z",
+      }],
+    });
+
+    const result = await previewNewsletterStoryPromotions({
+      db,
+      briefingDate: "2026-05-10",
+      stories: [{
+        headline: "Microsoft expands data center capacity",
+        sourceUrl: "https://example.com/alternate-cloud",
+        sourceDomain: "example.com",
+        category: "Tech",
+      }],
+    });
+
+    expect(result[0]).toMatchObject({
+      status: "duplicate_public_row",
+      previewAction: "skip",
+      existingSignalPostId: "signal-title-match",
+      matchedBy: "title",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add exact Gmail label preflight for `boot-up-benchmark` before newsletter message search
- add a sanitized zero-write dry-run report script and read-only promotion preview logic
- record completed dry-run plus BM-authorized controlled write validation in PRD/runbook/bug-fix/testing docs

## Safety
- no secrets, refresh tokens, raw Gmail content, snippets, message IDs, or thread IDs are committed
- no cron, RSS, `draft_only`, publish path, or public publication path is enabled
- newsletter candidates remain non-live `needs_review` rows

## Validation
- `npm install`
- `npm run lint`
- `npm run test`
- `npm run build`
- `npm run governance:coverage`
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name fix/prd-61-newsletter-dry-run-validation --pr-title "Complete PRD-61 newsletter editorial-cycle validation"`
- `git diff --check`

## Operational validation recorded
- dry-run: 3 labeled emails, 24 Article candidates, 5 eligible promotion candidates, zero writes
- authorized controlled write: 3 newsletter emails, 24 story extractions, 5 non-live review candidates
- public surface remained gated: `/` 200 with May 6 slate, `/signals` 200, latest public renderable Signal count 3

## Follow-up
- remove temporary local OAuth redirect URI from the Google Cloud Web client when no further local token generation is needed
- production cron remains disabled pending separate BM approval