### PR TITLE
Fix RSS cron serverless TLDR packaging

### DIFF
--- a/docs/engineering/bug-fixes/rss-cron-jsdom-esm-packaging-2026-05-12.md
+++ b/docs/engineering/bug-fixes/rss-cron-jsdom-esm-packaging-2026-05-12.md
@@ -1,0 +1,40 @@
+# RSS Cron jsdom ESM Packaging — Bug-Fix Record
+
+## Summary
+- Problem addressed: Production RSS fetch cron failed before producing Articles, with a serverless runtime packaging error in `html-encoding-sniffer` / `@exodus/bytes`.
+- Root cause: `src/lib/tldr.ts` imported `jsdom` in the production RSS ingestion path. The deployed Node serverless bundle hit a CommonJS-to-ESM dependency edge before RSS ingestion could run.
+- Affected object level: Article ingestion.
+
+## Fix
+- Exact change: Replaced the TLDR digest DOM extraction dependency with a deterministic anchor/heading extractor so production cron code no longer imports `jsdom`.
+- Related PRD: `PRD-60`, `PRD-61`
+- PR: Pending
+- Branch: `fix/prd-60-rss-cron-esm-packaging`
+- Head SHA: Pending
+- Merge SHA: Pending
+- GitHub source-of-truth status: Local branch pending PR.
+- External references reviewed, if any: Sanitized production log evidence only; no secrets, raw email content, snippets, or message IDs recorded.
+- Google Sheet / Work Log reference, if historically relevant: Not used as canonical source of truth.
+- Branch cleanup status: Pending PR merge.
+
+## Terminology Requirement
+- Before implementation, read `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`.
+- [x] Confirmed object level before coding: Article.
+- [x] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [x] Legacy `rss` and `tldr` naming preserved only where already established.
+
+## Validation
+- Automated checks:
+  - `npm install` completed.
+  - `npx vitest run src/lib/tldr.test.ts src/lib/rss.test.ts src/lib/pipeline/ingestion/tldr.integration.test.ts` passed.
+  - `npm run lint` passed.
+  - `npx vitest run src/app/api/cron/fetch-news/route.test.ts src/app/api/cron/fetch-editorial-inputs/route.test.ts src/lib/newsletter-ingestion/gmail.test.ts src/lib/newsletter-ingestion/runner.test.ts src/lib/tldr.test.ts src/lib/rss.test.ts src/lib/pipeline/ingestion/tldr.integration.test.ts` passed.
+  - `npm run test` passed, 91 files and 670 tests.
+  - `npm run build` passed. Existing workspace-root and module-type warnings were observed.
+  - Built cron route artifacts under `.next/server/app/api/cron` no longer contain `html-encoding-sniffer`, `@exodus/bytes`, or direct `jsdom` imports.
+- Human checks:
+  - Production fetch retry requires merge, deployment, valid production env, and BM authorization.
+
+## Remaining Risks / Follow-up
+- Gmail newsletter ingestion remains blocked until the production REST OAuth refresh token belongs to the Gmail account that can see exact label `boot-up-benchmark`.
+- Vercel preview or production should be used to verify the cron route after this fix is merged and deployed.

--- a/docs/engineering/bug-fixes/rss-cron-jsdom-esm-packaging-2026-05-12.md
+++ b/docs/engineering/bug-fixes/rss-cron-jsdom-esm-packaging-2026-05-12.md
@@ -10,7 +10,7 @@
 - Related PRD: `PRD-60`, `PRD-61`
 - PR: `#222`
 - Branch: `fix/prd-60-rss-cron-esm-packaging`
-- Head SHA: `97d7df3c40dd3e5a650079b7aee67c2acef28542`
+- Head SHA: Tracked by PR `#222`; final merge details recorded by GitHub.
 - Merge SHA: Pending
 - GitHub source-of-truth status: PR open.
 - External references reviewed, if any: Sanitized production log evidence only; no secrets, raw email content, snippets, or message IDs recorded.

--- a/docs/engineering/bug-fixes/rss-cron-jsdom-esm-packaging-2026-05-12.md
+++ b/docs/engineering/bug-fixes/rss-cron-jsdom-esm-packaging-2026-05-12.md
@@ -8,11 +8,11 @@
 ## Fix
 - Exact change: Replaced the TLDR digest DOM extraction dependency with a deterministic anchor/heading extractor so production cron code no longer imports `jsdom`.
 - Related PRD: `PRD-60`, `PRD-61`
-- PR: Pending
+- PR: `#222`
 - Branch: `fix/prd-60-rss-cron-esm-packaging`
-- Head SHA: Pending
+- Head SHA: `97d7df3c40dd3e5a650079b7aee67c2acef28542`
 - Merge SHA: Pending
-- GitHub source-of-truth status: Local branch pending PR.
+- GitHub source-of-truth status: PR open.
 - External references reviewed, if any: Sanitized production log evidence only; no secrets, raw email content, snippets, or message IDs recorded.
 - Google Sheet / Work Log reference, if historically relevant: Not used as canonical source of truth.
 - Branch cleanup status: Pending PR merge.

--- a/src/lib/tldr.test.ts
+++ b/src/lib/tldr.test.ts
@@ -73,6 +73,23 @@ describe("TLDR discovery adapter", () => {
     ).toBe("https://example.com/story-a");
   });
 
+  it("extracts encoded headings and hrefs without loading a DOM runtime", () => {
+    expect(
+      extractLinksFromDigest(`
+        <a href="https://example.com/story?utm_source=tldrnewsletter&amp;ref=side">
+          <h3>AT&amp;T buys &quot;fiber&quot; startup</h3>
+        </a>
+      `),
+    ).toEqual([
+      {
+        title: "AT&T buys \"fiber\" startup",
+        originalUrl: "https://example.com/story?utm_source=tldrnewsletter&ref=side",
+        normalizedUrl: "https://example.com/story",
+        sourceDomain: "example.com",
+      },
+    ]);
+  });
+
   it("recognizes every validated official TLDR category feed as a discovery input", () => {
     expect(TLDR_FEED_KEYS).toEqual([
       "tech",

--- a/src/lib/tldr.ts
+++ b/src/lib/tldr.ts
@@ -1,4 +1,3 @@
-import { JSDOM } from "jsdom";
 import Parser from "rss-parser";
 
 import { env } from "@/lib/env";
@@ -193,14 +192,14 @@ export async function ingestTldrCandidates(
 // MIT attribution: this keeps the same high-level extraction shape as Bullrich/tldr-rss
 // (digest RSS -> digest HTML -> linked headlines) while using Boot Up's own pipeline contracts.
 export function extractLinksFromDigest(digestHtml: string): TldrDigestLink[] {
-  const document = new JSDOM(digestHtml).window.document;
   const seenNormalizedUrls = new Set<string>();
   const links: TldrDigestLink[] = [];
+  const anchorPattern = /<a\b([^>]*)>([\s\S]*?)<\/a>/gi;
 
-  for (const heading of Array.from(document.querySelectorAll("h3"))) {
-    const title = heading.textContent?.trim();
-    const anchor = heading.closest("a");
-    const href = anchor?.href?.trim();
+  for (const match of digestHtml.matchAll(anchorPattern)) {
+    const [, attributes, body] = match;
+    const title = extractFirstHeadingText(body);
+    const href = extractHref(attributes);
 
     if (!title || !href || shouldIgnoreTldrLink(href, title)) {
       continue;
@@ -226,6 +225,56 @@ export function extractLinksFromDigest(digestHtml: string): TldrDigestLink[] {
   }
 
   return links;
+}
+
+function extractHref(attributes: string) {
+  const hrefMatch = attributes.match(/\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i);
+  const rawHref = hrefMatch?.[1] ?? hrefMatch?.[2] ?? hrefMatch?.[3] ?? "";
+  return decodeHtmlEntities(rawHref.trim());
+}
+
+function extractFirstHeadingText(html: string) {
+  const headingMatch = html.match(/<h3\b[^>]*>([\s\S]*?)<\/h3>/i);
+  if (!headingMatch) {
+    return "";
+  }
+
+  return decodeHtmlEntities(stripHtmlTags(headingMatch[1])).replace(/\s+/g, " ").trim();
+}
+
+function stripHtmlTags(value: string) {
+  return value.replace(/<[^>]*>/g, " ");
+}
+
+function decodeHtmlEntities(value: string) {
+  const namedEntities: Record<string, string> = {
+    amp: "&",
+    apos: "'",
+    gt: ">",
+    lt: "<",
+    nbsp: " ",
+    quot: "\"",
+  };
+
+  return value.replace(/&(#x[0-9a-f]+|#\d+|[a-z]+);/gi, (entity, code: string) => {
+    const normalizedCode = code.toLowerCase();
+
+    if (normalizedCode.startsWith("#x")) {
+      const parsed = Number.parseInt(normalizedCode.slice(2), 16);
+      return isValidCodePoint(parsed) ? String.fromCodePoint(parsed) : entity;
+    }
+
+    if (normalizedCode.startsWith("#")) {
+      const parsed = Number.parseInt(normalizedCode.slice(1), 10);
+      return isValidCodePoint(parsed) ? String.fromCodePoint(parsed) : entity;
+    }
+
+    return namedEntities[normalizedCode] ?? entity;
+  });
+}
+
+function isValidCodePoint(value: number) {
+  return Number.isInteger(value) && value >= 0 && value <= 0x10ffff;
 }
 
 export function normalizeUrl(url: string) {


### PR DESCRIPTION
## Summary
- Removes the production `jsdom` import from the TLDR RSS discovery adapter.
- Replaces DOM parsing with a deterministic anchor/heading extractor for TLDR digest links.
- Records the RSS cron serverless packaging failure in the repo-safe bug-fix lane.

## Root Cause
The production RSS cron path imported `src/lib/tldr.ts`, which imported `jsdom`. The deployed serverless bundle then hit a CommonJS-to-ESM dependency edge in `html-encoding-sniffer` / `@exodus/bytes` before RSS ingestion could complete.

## Validation
- `npm install`
- `npx vitest run src/lib/tldr.test.ts src/lib/rss.test.ts src/lib/pipeline/ingestion/tldr.integration.test.ts`
- `npm run lint`
- `npx vitest run src/app/api/cron/fetch-news/route.test.ts src/app/api/cron/fetch-editorial-inputs/route.test.ts src/lib/newsletter-ingestion/gmail.test.ts src/lib/newsletter-ingestion/runner.test.ts src/lib/tldr.test.ts src/lib/rss.test.ts src/lib/pipeline/ingestion/tldr.integration.test.ts`
- `npm run build`
- `npm run test`
- `python3 scripts/validate-feature-system-csv.py`
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name fix/prd-60-rss-cron-esm-packaging --pr-title "Fix RSS cron serverless TLDR packaging"`
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name fix/prd-60-rss-cron-esm-packaging --pr-title "Fix RSS cron serverless TLDR packaging"`

## Notes
- Gmail newsletter ingestion remains separately dependent on the production REST OAuth refresh token belonging to the Gmail account that can see `boot-up-benchmark`.
- No credential values, email content, snippets, or message IDs are included.