### PR TITLE
Fix RSS snapshot separation from newsletter candidates

### DIFF
--- a/docs/engineering/bug-fixes/rss-newsletter-snapshot-rank-collision-2026-05-12.md
+++ b/docs/engineering/bug-fixes/rss-newsletter-snapshot-rank-collision-2026-05-12.md
@@ -1,0 +1,42 @@
+# RSS Newsletter Snapshot Rank Collision — Bug-Fix Record
+
+## Summary
+- Problem addressed: Newsletter discovery candidates could occupy ranks `1-5` in `signal_posts` for a briefing date before the RSS snapshot was persisted.
+- Root cause: RSS snapshot idempotency checked only `briefing_date` plus occupied `rank` values. It did not distinguish RSS-derived Signal review rows from newsletter discovery rows.
+- Affected object level: Surface Placement. The bug affected editorial-review placement rows in legacy `signal_posts`, not canonical Signal identity.
+
+## Fix
+- Exact change: RSS persistence now reserves existing unselected newsletter discovery rows into lower-priority rank slots before inserting the RSS snapshot, and newsletter promotion now allocates open ranks from `20` downward.
+- Related PRD: PRD-60 scheduled RSS fetch and PRD-61 newsletter ingestion runtime.
+- PR: Pending.
+- Branch: `fix/rss-newsletter-snapshot-separation`
+- Head SHA: Pending.
+- Merge SHA: Pending.
+- GitHub source-of-truth status: Pending PR.
+- External references reviewed, if any: None.
+- Google Sheet / Work Log reference, if historically relevant: Not updated directly; fallback tracker-sync record required if live tracker access is unavailable.
+- Branch cleanup status: Pending merge.
+
+## Terminology Requirement
+- Before implementation, read `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`.
+- [x] Confirmed object level before coding: Surface Placement.
+- [x] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [x] Legacy `signal_posts` naming remains documented as operational placement storage.
+
+## Validation
+- Automated checks:
+  - `npm install`
+  - `npm run test -- src/lib/signals-editorial.test.ts src/lib/newsletter-ingestion/storage-promotion.test.ts src/lib/newsletter-ingestion/dry-run-report.test.ts`
+  - `npm run lint`
+  - `npm run test`
+  - `npm run build`
+  - `python3 scripts/release-governance-gate.py`
+  - `python3 scripts/validate-documentation-coverage.py`
+  - `python3 scripts/pr-governance-audit.py`
+- Human checks:
+  - Confirm production Gmail OAuth refresh token belongs to the Gmail account with `boot-up-benchmark`.
+  - After deployment and env correction, run the combined fetch and confirm the current editorial set contains RSS candidates above newsletter discovery rows.
+
+## Remaining Risks / Follow-up
+- Existing production newsletter discovery rows still require one post-deploy fetch to rebalance their ranks and let RSS rows occupy the current top ranks.
+- Production newsletter fetching remains blocked until `GMAIL_REFRESH_TOKEN` is regenerated from the Gmail account that exposes `boot-up-benchmark`.

--- a/docs/operations/tracker-sync/2026-05-12-rss-newsletter-snapshot-separation.md
+++ b/docs/operations/tracker-sync/2026-05-12-rss-newsletter-snapshot-separation.md
@@ -1,0 +1,19 @@
+# Manual Tracker Sync — RSS Newsletter Snapshot Separation
+
+## Context
+- Branch: `fix/rss-newsletter-snapshot-separation`
+- Work type: Bug fix / production remediation
+- Related PRDs: PRD-60 scheduled RSS fetch, PRD-61 newsletter ingestion runtime
+- Repo record: `docs/engineering/bug-fixes/rss-newsletter-snapshot-rank-collision-2026-05-12.md`
+
+## Manual Update Payload
+- Status: `In Review` until PR checks pass and the PR is merged.
+- Owner: `BM`
+- Notes: RSS persistence no longer treats newsletter discovery candidates as an existing RSS snapshot. Newsletter discovery candidates are assigned lower-priority ranks so the current RSS candidate set can occupy the top editorial-review ranks after the next fetch.
+- Evidence: local lint, full unit suite, build, governance gate, documentation coverage, and PR governance audit passed.
+
+## Production Follow-Up
+- After merge/deploy, regenerate the production Gmail refresh token from the Gmail account that exposes `boot-up-benchmark`.
+- Rerun `/api/cron/fetch-editorial-inputs`.
+- Confirm the current editorial set has RSS candidates in ranks `1-5` and newsletter discovery rows below them.
+- Publish only after BM selects and approves the final slate.

--- a/src/lib/newsletter-ingestion/dry-run-report.test.ts
+++ b/src/lib/newsletter-ingestion/dry-run-report.test.ts
@@ -156,7 +156,7 @@ describe("newsletter dry-run report", () => {
       title: "Microsoft expands data center capacity",
       sourceUrl: "https://example.com/cloud",
       previewAction: "create_candidate",
-      rank: 1,
+      rank: 20,
     });
     expect(report.privacy).toEqual({
       rawContentIncluded: false,

--- a/src/lib/newsletter-ingestion/promotion.ts
+++ b/src/lib/newsletter-ingestion/promotion.ts
@@ -157,7 +157,7 @@ async function getNextCandidateRank(input: {
       .filter((rank): rank is number => typeof rank === "number"),
   );
 
-  for (let rank = 1; rank <= 20; rank += 1) {
+  for (let rank = 20; rank >= 1; rank -= 1) {
     if (!usedRanks.has(rank)) {
       return rank;
     }
@@ -197,7 +197,7 @@ function nextAvailablePreviewRank(
     usedRanks.add(rank);
   }
 
-  for (let rank = 1; rank <= 20; rank += 1) {
+  for (let rank = 20; rank >= 1; rank -= 1) {
     if (!usedRanks.has(rank)) {
       allocatedRanks.add(rank);
       return rank;

--- a/src/lib/newsletter-ingestion/storage-promotion.test.ts
+++ b/src/lib/newsletter-ingestion/storage-promotion.test.ts
@@ -274,7 +274,7 @@ describe("newsletter candidate promotion", () => {
     expect(result).toMatchObject({
       status: "created",
       signalPostId: expect.any(String),
-      rank: 1,
+      rank: 20,
     });
     expect(tables.signal_posts[0]).toMatchObject({
       editorial_status: "needs_review",
@@ -380,7 +380,7 @@ describe("newsletter candidate promotion", () => {
       sourceUrl: "https://example.com/cloud",
       sourceDomain: "example.com",
       category: "Tech",
-      rank: 1,
+      rank: 20,
       existingSignalPostId: null,
       matchedBy: null,
       reason: "Newsletter story would create a non-live needs_review candidate.",

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -1495,6 +1495,45 @@ describe("signals editorial workflow", () => {
     expect(insertedRows.map((row) => row.rank)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
   });
 
+  it("reserves existing newsletter discovery candidates outside the RSS snapshot ranks", async () => {
+    const rows = Array.from({ length: 5 }, (_, index) =>
+      createRow({
+        id: `newsletter-${index + 1}`,
+        briefing_date: "2026-05-11",
+        rank: index + 1,
+        title: `Newsletter Candidate ${index + 1}`,
+        selection_reason: "Newsletter discovery candidate; BM review required.",
+        ai_why_it_matters: "",
+        why_it_matters_validation_status: "requires_human_rewrite",
+        why_it_matters_validation_failures: ["incomplete_sentence"],
+        why_it_matters_validation_details: ["BM must write structural why-it-matters manually before publication."],
+        editorial_status: "needs_review",
+        final_slate_rank: null,
+        final_slate_tier: null,
+        editorial_decision: "pending_review",
+        is_live: false,
+        published_at: null,
+      }),
+    );
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+
+    const { persistSignalPostsForBriefing } = await loadEditorialModule();
+    const result = await persistSignalPostsForBriefing({
+      briefingDate: "2026-05-11",
+      items: Array.from({ length: 20 }, (_, index) => createBriefingItem(index + 1)),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.insertedCount).toBe(15);
+    expect(result.message).toContain("Reserved 5 newsletter discovery candidate rank(s)");
+
+    const rssRows = rows.filter((row) => row.title.startsWith("Generated Signal"));
+    const newsletterRows = rows.filter((row) => row.title.startsWith("Newsletter Candidate"));
+    expect(rssRows).toHaveLength(15);
+    expect(rssRows.map((row) => row.rank)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+    expect(newsletterRows.map((row) => row.rank)).toEqual([16, 17, 18, 19, 20]);
+  });
+
   it("draft_only mode persists only review rows with validation details", async () => {
     const rows: SignalPostRow[] = [];
     createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -154,6 +154,7 @@ const SIGNAL_POST_CANDIDATE_DEPTH_LIMIT = 20;
 const TOP_SIGNAL_SET_SIZE = 5;
 const CONTEXT_SIGNAL_SET_SIZE = 2;
 const PUBLIC_SIGNAL_SET_SIZE = TOP_SIGNAL_SET_SIZE + CONTEXT_SIGNAL_SET_SIZE;
+const NEWSLETTER_DISCOVERY_SELECTION_REASON = "Newsletter discovery candidate; BM review required.";
 
 type EditorialClient = NonNullable<ReturnType<typeof createSupabaseServiceRoleClient>>;
 
@@ -1250,7 +1251,7 @@ async function persistSignalPostCandidates(
 
   const existingResult = await client
     .from("signal_posts")
-    .select("id, rank")
+    .select("id, rank, selection_reason, editorial_status, final_slate_rank, is_live, published_at")
     .eq("briefing_date", briefingDate);
 
   if (existingResult.error) {
@@ -1271,13 +1272,32 @@ async function persistSignalPostCandidates(
     };
   }
 
-  const existingRows = ((existingResult.data ?? []) as Array<{ id: string; rank: number | null }>);
+  const existingRows = ((existingResult.data ?? []) as ExistingSignalSnapshotRow[]);
+  const newsletterRankReservation = await reserveNewsletterCandidateRanksForRssSnapshot(
+    client,
+    existingRows,
+  );
+
+  if (!newsletterRankReservation.ok) {
+    return {
+      ok: false,
+      briefingDate,
+      insertedCount: 0,
+      skippedCandidates,
+      mode,
+      message: newsletterRankReservation.message,
+    };
+  }
+
+  const candidatesForPersistence = sourceReadyCandidates.filter((post) =>
+    !newsletterRankReservation.reservedRanks.has(post.rank),
+  );
   const existingRanks = new Set(
-    existingRows
+    newsletterRankReservation.rows
       .map((row) => row.rank)
       .filter((rank): rank is number => typeof rank === "number"),
   );
-  const missingCandidates = sourceReadyCandidates.filter((post) => !existingRanks.has(post.rank));
+  const missingCandidates = candidatesForPersistence.filter((post) => !existingRanks.has(post.rank));
 
   if (missingCandidates.length === 0) {
     return {
@@ -1355,10 +1375,141 @@ async function persistSignalPostCandidates(
     skippedCandidates,
     mode,
     message:
-      missingCandidates.length === TOP_SIGNAL_SET_SIZE
-        ? "Persisted a new daily Top 5 snapshot for editorial review."
-        : `Persisted ${missingCandidates.length} missing signal snapshot rows for editorial review.`,
+      buildSignalPostPersistenceMessage(
+        missingCandidates.length,
+        newsletterRankReservation.reservedRanks.size,
+      ),
   };
+}
+
+type ExistingSignalSnapshotRow = {
+  id: string;
+  rank: number | null;
+  selection_reason: string | null;
+  editorial_status: string | null;
+  final_slate_rank: number | null;
+  is_live: boolean | null;
+  published_at: string | null;
+};
+
+type NewsletterRankReservationResult =
+  | {
+      ok: true;
+      rows: ExistingSignalSnapshotRow[];
+      reservedRanks: Set<number>;
+    }
+  | {
+      ok: false;
+      message: string;
+    };
+
+function isMovableNewsletterDiscoveryRow(row: ExistingSignalSnapshotRow) {
+  return (
+    row.selection_reason === NEWSLETTER_DISCOVERY_SELECTION_REASON &&
+    typeof row.rank === "number" &&
+    !row.is_live &&
+    row.editorial_status !== "published" &&
+    !row.published_at &&
+    row.final_slate_rank === null
+  );
+}
+
+async function reserveNewsletterCandidateRanksForRssSnapshot(
+  client: EditorialClient,
+  existingRows: ExistingSignalSnapshotRow[],
+): Promise<NewsletterRankReservationResult> {
+  const movableNewsletterRows = existingRows
+    .filter(isMovableNewsletterDiscoveryRow)
+    .sort((left, right) => (left.rank ?? 0) - (right.rank ?? 0));
+
+  if (movableNewsletterRows.length === 0) {
+    return {
+      ok: true,
+      rows: existingRows,
+      reservedRanks: new Set<number>(),
+    };
+  }
+
+  const movableNewsletterIds = new Set(movableNewsletterRows.map((row) => row.id));
+  const fixedRanks = new Set(
+    existingRows
+      .filter((row) => !movableNewsletterIds.has(row.id))
+      .map((row) => row.rank)
+      .filter((rank): rank is number => typeof rank === "number"),
+  );
+  const targetRanks: number[] = [];
+
+  for (let rank = SIGNAL_POST_CANDIDATE_DEPTH_LIMIT; rank >= 1; rank -= 1) {
+    if (!fixedRanks.has(rank)) {
+      targetRanks.push(rank);
+    }
+
+    if (targetRanks.length === movableNewsletterRows.length) {
+      break;
+    }
+  }
+
+  if (targetRanks.length < movableNewsletterRows.length) {
+    return {
+      ok: false,
+      message:
+        "RSS signal snapshot could not reserve rank space for existing newsletter candidates. No rows were changed.",
+    };
+  }
+
+  targetRanks.sort((left, right) => left - right);
+  const updatedRows = existingRows.map((row) => ({ ...row }));
+  const rowsById = new Map(updatedRows.map((row) => [row.id, row]));
+
+  const rankAssignments = movableNewsletterRows
+    .map((newsletterRow, index) => ({
+      newsletterRow,
+      targetRank: targetRanks[index],
+    }))
+    .filter((assignment): assignment is { newsletterRow: ExistingSignalSnapshotRow; targetRank: number } =>
+      typeof assignment.targetRank === "number"
+    )
+    .sort((left, right) => right.targetRank - left.targetRank);
+
+  for (const { newsletterRow, targetRank } of rankAssignments) {
+    const mutableRow = rowsById.get(newsletterRow.id);
+
+    if (!mutableRow || mutableRow.rank === targetRank) {
+      continue;
+    }
+
+    const updateResult = await client
+      .from("signal_posts")
+      .update({ rank: targetRank })
+      .eq("id", newsletterRow.id);
+
+    if (updateResult.error) {
+      return {
+        ok: false,
+        message: `RSS signal snapshot could not reserve newsletter candidate rank space: ${updateResult.error.message}`,
+      };
+    }
+
+    mutableRow.rank = targetRank;
+  }
+
+  return {
+    ok: true,
+    rows: updatedRows,
+    reservedRanks: new Set(targetRanks),
+  };
+}
+
+function buildSignalPostPersistenceMessage(insertedCount: number, reservedNewsletterRankCount: number) {
+  const baseMessage = insertedCount === TOP_SIGNAL_SET_SIZE
+    ? "Persisted a new daily Top 5 snapshot for editorial review."
+    : `Persisted ${insertedCount} missing signal snapshot rows for editorial review.`;
+
+  if (reservedNewsletterRankCount === 0) {
+    return baseMessage;
+  }
+
+  return `${baseMessage} Reserved ${reservedNewsletterRankCount} newsletter discovery candidate rank(s) outside the RSS snapshot range.`;
 }
 
 export async function persistSignalPostsForBriefing(input: {


### PR DESCRIPTION
## Summary
- Prevent newsletter discovery candidates from occupying the RSS snapshot's top rank space.
- Rebalance existing unselected newsletter discovery rows into lower-priority ranks before RSS persistence inserts the current snapshot.
- Allocate future newsletter promotion ranks from 20 downward so RSS can own the top editorial-review ranks.
- Add a bug-fix record and tracker-sync fallback for the remediation.

## Validation
- `npm install`
- `npm run test -- src/lib/signals-editorial.test.ts src/lib/newsletter-ingestion/storage-promotion.test.ts src/lib/newsletter-ingestion/dry-run-report.test.ts`
- `npm run lint`
- `npm run test`
- `npm run build`
- `python3 scripts/release-governance-gate.py`
- `python3 scripts/validate-documentation-coverage.py`
- `python3 scripts/pr-governance-audit.py`

## Production notes
- Current production `/signals` is still rendering briefing date `2026-05-06` until a post-merge fetch creates a current RSS candidate set and BM publishes an approved slate.
- Production Gmail newsletter ingestion is still blocked by the refresh token/account mismatch for `boot-up-benchmark`; this PR fixes the RSS/newsletter rank collision, not the OAuth token value.
