### PR TITLE
Record PRD-61 production Gmail token remediation

### DIFF
--- a/docs/engineering/bug-fixes/prd-61-production-gmail-token-label-mismatch-2026-05-12.md
+++ b/docs/engineering/bug-fixes/prd-61-production-gmail-token-label-mismatch-2026-05-12.md
@@ -1,0 +1,61 @@
+# PRD-61 Production Gmail Token Label Mismatch - Bug-Fix Record
+
+## Summary
+
+- Problem addressed: Production newsletter ingestion failed closed because the deployed Gmail REST OAuth token could not see the exact `boot-up-benchmark` Gmail label.
+- Root cause: The deployed Gmail OAuth credential set did not point to the Gmail account and OAuth client pairing that exposes the newsletter label used by PRD-61.
+- Affected object level: Article ingestion and non-live Surface Placement review candidates.
+
+## Fix
+
+- Exact change: Regenerated Gmail readonly OAuth authorization from the Gmail account that owns `boot-up-benchmark`, verified exact label visibility before upload, updated the Vercel Production Gmail OAuth env set, and redeployed production so the corrected token is active.
+- Related PRD: PRD-61.
+- PR: This remediation PR.
+- Branch: `docs/newsletter-prod-gmail-token-remediation-20260512`
+- Head SHA: See GitHub PR metadata for this branch.
+- Merge SHA: See GitHub PR metadata after merge.
+- GitHub source-of-truth status: Repo-safe remediation and validation records added.
+- External references reviewed, if any: Google OAuth consent flow and Vercel Production deployment state.
+- Google Sheet / Work Log reference, if historically relevant: None; GitHub repo documentation is canonical.
+- Branch cleanup status: Delete local and remote branch after merge.
+
+## Terminology Requirement
+
+- [x] Confirmed object level before coding: Article and Surface Placement.
+- [x] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [x] Legacy `signal_posts` references remain Surface Placement review-candidate persistence.
+
+## Validation
+
+Automated and operational checks:
+- Gmail OAuth authorization completed with readonly Gmail scope.
+- Gmail label preflight confirmed exact `boot-up-benchmark` visibility before Vercel env update.
+- Vercel Production Gmail OAuth env set was updated without printing secret values.
+- Production redeploy reached `READY`.
+- Protected newsletter diagnostic route returned HTTP `200`.
+- Protected combined editorial-input fetch route returned HTTP `200`.
+- `/` returned HTTP `200` and rendered the May 6 public briefing.
+- `/signals` returned HTTP `200` and rendered `3` published Signals.
+
+Production newsletter route evidence:
+- `dryRun=false`
+- `enabled=true`
+- `writeCandidates=true`
+- `targetEnvironment=production`
+- `fetchedMessageCount=3`
+- `existingEmailCount=3`
+- `storedEmailCount=0`
+- `extractedStoryCount=0`
+- `promotedCandidateCount=0`
+- `failedEmailCount=0`
+
+Safety checks:
+- No credential values, refresh tokens, raw email content, snippets, Gmail message IDs, thread IDs, or context material were committed.
+- No public Signal was published by this remediation.
+- Existing newsletter rows were treated idempotently; no duplicate newsletter email rows were inserted during validation.
+
+## Remaining Risks / Follow-Up
+
+- Public `/` and `/signals` remain on the May 6 published slate until BM separately approves editorial selection and publish.
+- The combined fetch can create non-live review candidates, but it does not publish them.
+- If the Gmail label is renamed or moved to another mailbox, production will fail closed again until a new refresh token is generated from the correct account.

--- a/docs/engineering/testing/2026-05-12-prd-61-production-gmail-token-remediation-validation.md
+++ b/docs/engineering/testing/2026-05-12-prd-61-production-gmail-token-remediation-validation.md
@@ -1,0 +1,91 @@
+# PRD-61 Production Gmail Token Remediation Validation
+
+## Scope
+
+- Date: 2026-05-12 Asia/Taipei
+- Branch: `docs/newsletter-prod-gmail-token-remediation-20260512`
+- Work type: Production remediation / controlled operations validation
+- Related PRD: PRD-61
+- Object level: Article ingestion and non-live Surface Placement review candidates
+
+## Result
+
+Production newsletter ingestion is no longer blocked by Gmail label/account mismatch.
+
+The corrected Gmail readonly OAuth token can see the exact `boot-up-benchmark` label, Vercel Production has the aligned Gmail OAuth env set, and the deployed production newsletter route now returns HTTP `200`.
+
+## Production OAuth Remediation
+
+- OAuth client family: `Boot Up Newsletter Ingestion OAuth Playground` Web application client.
+- Gmail account used for authorization: the account that owns the `boot-up-benchmark` label.
+- Scope: `https://www.googleapis.com/auth/gmail.readonly`
+- Secret values: not recorded.
+- Refresh token: not recorded.
+- Vercel Production env values updated:
+  - `GMAIL_CLIENT_ID`
+  - `GMAIL_CLIENT_SECRET`
+  - `GMAIL_REFRESH_TOKEN`
+- Production redeploy status: `READY`.
+
+## Protected Route Validation
+
+Newsletter-only route:
+
+| Check | Result |
+| --- | --- |
+| Route | `/api/cron/newsletter-ingestion` |
+| HTTP status | `200` |
+| `success` | `true` |
+| Label | `boot-up-benchmark` |
+| `dryRun` | `false` |
+| `enabled` | `true` |
+| `writeCandidates` | `true` |
+| Target environment | `production` |
+| Fetched messages | `3` |
+| Existing stored newsletter emails | `3` |
+| Newly stored newsletter emails | `0` |
+| Newly extracted stories | `0` |
+| Newly promoted candidates | `0` |
+| Failed emails | `0` |
+
+Combined route:
+
+| Check | Result |
+| --- | --- |
+| Route | `/api/cron/fetch-editorial-inputs` |
+| HTTP status | `200` |
+| `success` | `true` |
+| RSS raw items | `223` |
+| RSS clusters | `91` |
+| RSS ranked clusters | `91` |
+| RSS inserted Signal review candidates | `0` |
+| RSS message | Daily Signal snapshot already existed for the briefing date. |
+| Newsletter fetched messages | `3` |
+| Newsletter existing stored emails | `3` |
+| Newsletter failed emails | `0` |
+
+## Public Surface QA
+
+Automated and Chrome QA:
+
+| Surface | Result |
+| --- | --- |
+| `/` | HTTP `200`; Chrome rendered the May 6 public briefing. |
+| `/signals` | HTTP `200`; Chrome rendered `3` published Signals. |
+
+The public surface did not publish newsletter review candidates. It remains on the latest editor-approved May 6 slate until BM separately authorizes editorial publish.
+
+## Database Behavior Answer
+
+Newsletter emails do store in the database through PRD-61, but they are internal ingestion records. This validation found the three current labeled Gmail messages were already present (`existingEmailCount=3`), so the idempotent run inserted no duplicate email rows and no duplicate story extraction rows.
+
+## Privacy Verification
+
+- No credential values were printed or committed.
+- No refresh token was printed or committed.
+- No raw email content, snippets, Gmail message IDs, thread IDs, or context material were printed or committed.
+- No public route was observed exposing newsletter raw content.
+
+## Final Status
+
+Production Gmail newsletter ingestion label/account mismatch is fixed. The production route is unblocked, idempotent, and returning successful sanitized summaries.

--- a/docs/operations/newsletter-ingestion-cron-runbook.md
+++ b/docs/operations/newsletter-ingestion-cron-runbook.md
@@ -160,6 +160,14 @@ Required post-flight:
 - Public surface remained gated: `/` HTTP 200 with the May 6 slate, `/signals` HTTP 200, latest public renderable Signal count `3`.
 - Local secret files and OAuth capture files were deleted after validation.
 
+2026-05-12 production Gmail token remediation result:
+- Production Gmail OAuth was regenerated from the Gmail account that exposes exact label `boot-up-benchmark`.
+- Vercel Production `GMAIL_CLIENT_ID`, `GMAIL_CLIENT_SECRET`, and `GMAIL_REFRESH_TOKEN` were realigned to the same OAuth Playground Web application client without recording secret values.
+- Production redeploy reached `READY`.
+- Protected newsletter route returned HTTP `200` with `fetchedMessageCount=3`, `existingEmailCount=3`, `storedEmailCount=0`, `extractedStoryCount=0`, `promotedCandidateCount=0`, and `failedEmailCount=0`.
+- Protected combined editorial-input route returned HTTP `200`; RSS reported the daily Signal snapshot already existed, and newsletter ingestion remained successful and idempotent.
+- Public surface remained gated: `/` HTTP 200 with the May 6 slate, `/signals` HTTP 200 with `3` published Signals.
+
 ## Enable Production Cron After Approval
 
 Do this only after PR review, dry-run validation, and BM approval.


### PR DESCRIPTION
## Summary
- Records the PRD-61 production Gmail OAuth token/account-label remediation.
- Adds sanitized production validation showing `boot-up-benchmark` is visible, newsletter ingestion returns HTTP 200, and combined fetch returns HTTP 200.
- Updates the newsletter cron runbook with the May 12 production remediation result.

## Validation
- Gmail readonly OAuth token regenerated from the Gmail account that owns `boot-up-benchmark`; exact label preflight passed before Vercel env update.
- Vercel Production Gmail OAuth env set updated and production redeploy reached READY.
- Protected `/api/cron/newsletter-ingestion` returned HTTP 200 with `fetchedMessageCount=3`, `existingEmailCount=3`, `failedEmailCount=0`.
- Protected `/api/cron/fetch-editorial-inputs` returned HTTP 200; RSS snapshot already existed and newsletter ingestion stayed idempotent.
- Chrome QA: `/` rendered the May 6 public briefing; `/signals` rendered 3 published Signals.

## Local checks
- `git diff --check`
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name docs/newsletter-prod-gmail-token-remediation-20260512 --pr-title "Record PRD-61 production Gmail token remediation"`
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name docs/newsletter-prod-gmail-token-remediation-20260512 --pr-title "Record PRD-61 production Gmail token remediation"`
- `python3 scripts/pr-governance-audit.py --diff-mode local --branch-name docs/newsletter-prod-gmail-token-remediation-20260512 --pr-title "Record PRD-61 production Gmail token remediation"`

## Safety
- No credential values, refresh tokens, raw email content, snippets, Gmail message IDs, thread IDs, or context material are included.
- No public Signal was published by this remediation.
