### PR TITLE
[codex] Populate homepage category tabs from cron articles

### DIFF
--- a/docs/engineering/bug-fixes/homepage-category-tabs-cron-article-population.md
+++ b/docs/engineering/bug-fixes/homepage-category-tabs-cron-article-population.md
@@ -1,0 +1,45 @@
+# Homepage Category Tabs Cron Article Population — Bug-Fix Record
+
+## Summary
+- Problem addressed: Home category tabs could render as empty even after the scheduled Taipei cron jobs fetched broader Article supply.
+- Root cause: the public homepage read only the published Signal Card set from `signal_posts`, while the broader RSS cron Article candidate pool stayed in `pipeline_article_candidates` and was not available to the Tech, Finance, and Politics tab Surface Placements.
+- Affected object level: Article and Surface Placement.
+
+## Fix
+- Exact change: read the latest two cron-backed `pipeline_article_candidates` runs into a homepage category Article map, cap each category at 50 Articles, exclude likely paywalled sources, exclude URL/title duplicates from the current top 5-7 Signal Cards, render date/source/title/summary rows with clickable original Article links, and await candidate persistence during the cron pipeline so serverless execution does not drop candidate writes.
+- Related PRD: PRD-57 and PRD-60.
+- PR: pending.
+- Branch: `fix/category-tabs-populate-articles-20260512`
+- Head SHA: pending.
+- Merge SHA: pending.
+- GitHub source-of-truth status: pending PR review.
+- External references reviewed, if any: Vercel cron configuration in `vercel.json`; repo PR #220 metadata.
+- Google Sheet / Work Log reference, if historically relevant: not used.
+- Branch cleanup status: pending merge.
+
+## Terminology Requirement
+- Before implementation, read `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`.
+- [x] Confirmed object level before coding: Article and Surface Placement.
+- [x] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [x] Legacy `signal_posts` references remain treated as Surface Placement plus Card copy/read-model storage.
+
+## Validation
+- Automated checks:
+  - `npm install` passed.
+  - `npm run lint` passed.
+  - `npx vitest run src/lib/homepage-category-articles.test.ts src/components/home/home-category-components.test.tsx src/lib/homepage-model.test.ts src/lib/pipeline/controlled-persistence.test.ts` passed.
+  - `npx vitest run src/lib/data.test.ts` passed.
+  - `npm run test` passed: 93 files, 680 tests.
+  - `npm run build` passed.
+  - `python3 scripts/release-governance-gate.py --diff-mode local --branch-name fix/category-tabs-populate-articles-20260512 --pr-title "Fix homepage category tabs with cron Article population"` passed.
+  - `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name fix/category-tabs-populate-articles-20260512 --pr-title "Fix homepage category tabs with cron Article population"` passed.
+  - `python3 scripts/validate-feature-system-csv.py` passed with pre-existing slug warnings.
+  - `npx tsc --noEmit` still fails on unrelated existing test fixture type drift; `npm run build` completed its TypeScript phase successfully.
+- Human checks:
+  - Codex Computer / Chrome QA loaded `http://localhost:3012/`, confirmed HTTP 200 in the dev server log, and verified the Tech, Finance, and Politics tabs switch without rendering errors.
+  - Preview validation should confirm the deployed homepage category tabs show Article rows after the next scheduled production cron runs.
+  - Production data validation should confirm the Supabase migration is applied and new `pipeline_article_candidates.published_at` values are present.
+
+## Remaining Risks / Follow-up
+- Category tab population depends on production cron execution and Supabase service-role read access.
+- Existing rows created before this change may fall back to cron ingestion time until new cron runs store Article `published_at`.

--- a/docs/product/prd/prd-57-homepage-volume-layers.md
+++ b/docs/product/prd/prd-57-homepage-volume-layers.md
@@ -15,7 +15,7 @@ The current public homepage exposes only the Top 5 Signals layer plus client-sid
 
 ## Scope
 
-This feature adds two new Experience-layer modules beneath Top 5 Signals: a Developing Now module and a By Category module. Both modules must consume the existing ranked briefing output and the existing `homepageClassification` / fallback taxonomy path without modifying ingestion, source governance, ranking, or classification rules. Top 5 Signals remains capped at five and keeps its current rendering path. Category tabs remain client-side and keep their current hide-empty-tab behavior.
+This feature adds two new Experience-layer modules beneath Top 5 Signals: a Developing Now module and a By Category module. Both modules must consume the existing ranked briefing output and the existing `homepageClassification` / fallback taxonomy path without modifying ingestion, source governance, ranking, or classification rules. Top 5 Signals remains capped at five and keeps its current rendering path. Category tabs remain client-side and may also consume the persisted PRD-60 cron Article candidate pool when available, capped at 50 Articles per category and filtered away from the current top 5-7 Signal Cards.
 
 Developing Now selects from the ranked briefing output after excluding any event already surfaced in Top 5 Signals. Candidates are ordered by a composite of normalized freshness and a source-diversity bonus so the module favors recent developments from sources not already represented in the top layer. The module returns up to ten items, degrades honestly to fewer when supply is thin, and suppresses semantic near-duplicates so it does not restate the same story family with weaker phrasing.
 
@@ -23,11 +23,13 @@ By Category renders three subsections in the fixed order Tech, Finance, Politics
 
 ## Non-Goals
 
-This feature does not introduce story clusters, multi-article grouping, access-type metadata, personalization, new routes, manifest edits, ingestion changes, ranking changes, or taxonomy redesign. It also does not change the existing category-tab interaction model or the Top 5 Signals cap and rendering path.
+This feature does not introduce story clusters, multi-article grouping, personalization, new routes, manifest edits, source activation changes, ranking changes, or taxonomy redesign. It also does not change the existing category-tab interaction model or the Top 5 Signals cap and rendering path. Category Article rows must come from persisted cron output, not a live homepage RSS fetch.
 
 ## Implementation Shape / System Impact
 
 The implementation lives in the homepage view-model and rendering layers. `src/lib/homepage-model.ts` gains pure selection helpers for Developing Now and category previews, plus a wrapper that adds these selections to the homepage view model. The homepage component renders the new modules beneath the existing Top 5 Signals experience and reuses the existing lighter category card treatment rather than introducing new design primitives.
+
+Follow-up remediation adds a persisted Article list for the category tab Surface Placements. The homepage reads the latest two PRD-60 cron-backed `pipeline_article_candidates` runs, groups Articles into Tech, Finance, and Politics through the existing homepage taxonomy, excludes likely paywalled sources, excludes URL/title duplicates from the current top 5-7 Signal Cards, and renders date/source/title rows as direct links to the original Articles. This keeps homepage SSR on persisted read models and does not fetch RSS feeds during render.
 
 The key editorial choice is to reject a simple “positions 6–15” module. That approach is structurally redundant with Top 5 Signals because it only extends the same ranking story with weaker items. Source-diverse freshness is a distinct job: it answers what is newly building from sources not already represented above, which broadens awareness without diluting the understanding-first role of Top 5.
 
@@ -39,7 +41,7 @@ This feature depends on the current governed contracts from PRD-17, PRD-36, PRD-
 
 ## Acceptance Criteria
 
-When public source supply is healthy, the homepage surfaces materially more than five distinct events across Top 5 Signals, Developing Now, and By Category. Developing Now must exclude Top 5 IDs, favor fresher items, prefer sources not already represented in Top 5, and return no semantic near-duplicates of already surfaced stories. By Category must render Tech, Finance, and Politics in that order, show up to three fresh items per subsection, never overlap with Top 5 or Developing Now, and preserve honest empty-state behavior when a category has no eligible items. The existing Top 5 Signals path, category-tab behavior, public manifest, ranking logic, and Politics empty-state invariant must remain intact.
+When public source supply is healthy, the homepage surfaces materially more than five distinct events across Top 5 Signals, Developing Now, and By Category. Developing Now must exclude Top 5 IDs, favor fresher items, prefer sources not already represented in Top 5, and return no semantic near-duplicates of already surfaced stories. By Category must render Tech, Finance, and Politics in that order, show up to three fresh items per subsection, never overlap with Top 5 or Developing Now, and preserve honest empty-state behavior when a category has no eligible items. The existing Top 5 Signals path, category-tab behavior, public manifest, ranking logic, and Politics empty-state invariant must remain intact. When persisted PRD-60 Article candidates are available, each category tab may render up to 50 non-paywalled Articles from the latest two cron runs, with Article date and clickable original-source link, and those Article rows must not duplicate the current top 5-7 Signal Card source URLs or titles.
 
 ## Evidence and Confidence
 

--- a/docs/product/prd/prd-60-daily-6pm-taiwan-news-cron.md
+++ b/docs/product/prd/prd-60-daily-6pm-taiwan-news-cron.md
@@ -19,6 +19,7 @@ The editor needs generated Top 5 Signal Cards and newsletter-derived review cand
 - Add a protected `/api/cron/fetch-news` endpoint.
 - Require `Authorization: Bearer <CRON_SECRET>`.
 - Reuse the existing daily briefing generation and editorial snapshot persistence logic.
+- Persist Article candidate `published_at` metadata so cron-backed homepage category tabs can render Article dates without fetching feeds during homepage SSR.
 - Reuse the existing PRD-61 newsletter label preflight, parser, idempotent storage, and non-live review-candidate promotion gates.
 - Return a sanitized JSON summary with timestamp, success state, pipeline counts, and persistence result.
 - Refuse to persist deterministic seed-fallback output as editorial Signal Cards.
@@ -35,7 +36,7 @@ The editor needs generated Top 5 Signal Cards and newsletter-derived review cand
 
 ## Implementation Shape / System Impact
 
-The scheduled route delegates first to the existing `generateDailyBriefing` pipeline and `persistSignalPostsForBriefing` editorial read-model persistence, then to `runNewsletterIngestion({ writeCandidates: true })`. The cron wrapper adds authorization, observability, failure handling, seed-fallback protection through the existing RSS path, PRD-61 newsletter env/write gates, and a sanitized combined JSON run summary.
+The scheduled route delegates first to the existing `generateDailyBriefing` pipeline and `persistSignalPostsForBriefing` editorial read-model persistence, then to `runNewsletterIngestion({ writeCandidates: true })`. The cron wrapper adds authorization, observability, failure handling, seed-fallback protection through the existing RSS path, PRD-61 newsletter env/write gates, and a sanitized combined JSON run summary. The RSS pipeline also writes normalized Article candidates synchronously enough for serverless cron execution to retain candidate rows for downstream persisted read models.
 
 ## Terminology Requirement
 
@@ -59,6 +60,7 @@ The scheduled route delegates first to the existing `generateDailyBriefing` pipe
 - Unauthorized requests return HTTP `401` and do not call the pipeline.
 - Authorized requests call the existing RSS pipeline once and the existing PRD-61 newsletter ingestion path once.
 - Successful authorized requests persist generated Top 5 Signal Cards for editorial review.
+- Successful authorized RSS runs persist normalized Article candidate rows with source URL, title, source name, cron ingestion time, and Article publication date when available.
 - Successful authorized newsletter runs create only non-live `needs_review` review candidates.
 - Seed fallback output is not persisted.
 - Response JSON includes `success`, `timestamp`, and `summary`.

--- a/src/components/home/CategoryTabStrip.tsx
+++ b/src/components/home/CategoryTabStrip.tsx
@@ -9,6 +9,7 @@ import {
   TabsTrigger,
 } from "@/components/ui/tabs";
 import type { HomepageCategorySection, HomepageEvent } from "@/lib/homepage-model";
+import type { HomepageCategoryArticle } from "@/lib/types";
 import type { HomepageCategoryKey } from "@/lib/homepage-taxonomy";
 import { cn } from "@/lib/utils";
 
@@ -35,6 +36,11 @@ export type CategoryTabStripProps = {
     section: HomepageCategorySection,
     index: number,
   ) => ReactNode;
+  renderCategoryArticle?: (
+    article: HomepageCategoryArticle,
+    section: HomepageCategorySection,
+    index: number,
+  ) => ReactNode;
   topEventsEmptyState?: ReactNode;
   isAuthenticated?: boolean;
   gatedCategoryState?: ReactNode | ((args: GatedCategoryStateArgs) => ReactNode);
@@ -51,6 +57,7 @@ export function CategoryTabStrip({
   categorySections,
   renderTopEvent,
   renderCategoryEvent,
+  renderCategoryArticle,
   topEventsEmptyState,
   isAuthenticated = true,
   gatedCategoryState,
@@ -129,12 +136,18 @@ export function CategoryTabStrip({
       </TabsContent>
 
       {visibleCategorySections.map((section) => {
+        const sectionHasArticles = (section.articles?.length ?? 0) > 0 && Boolean(renderCategoryArticle);
         const sectionHasEvents = section.events.length > 0;
+        const sectionHasContent = sectionHasArticles || sectionHasEvents;
         const shouldRenderGate =
-          activeCategoryIsGated && safeActiveTab === section.key && sectionHasEvents;
+          activeCategoryIsGated && safeActiveTab === section.key && sectionHasContent;
         const sectionContent = (
           <div className="grid gap-4">
-            {sectionHasEvents ? (
+            {sectionHasArticles && renderCategoryArticle ? (
+              section.articles.map((article, index) => (
+                <div key={article.id}>{renderCategoryArticle(article, section, index)}</div>
+              ))
+            ) : sectionHasEvents ? (
               section.events.map((event, index) => (
                 <div key={event.id}>{renderCategoryEvent(event, section, index)}</div>
               ))

--- a/src/components/home/home-category-components.test.tsx
+++ b/src/components/home/home-category-components.test.tsx
@@ -70,6 +70,7 @@ function createSection(overrides: Partial<HomepageCategorySection>): HomepageCat
     label: overrides.label ?? "Tech",
     description: overrides.description ?? "Technology coverage.",
     events: overrides.events ?? [],
+    articles: overrides.articles ?? [],
     fallbackEvents: overrides.fallbackEvents ?? [],
     placeholderCount: overrides.placeholderCount ?? 0,
     state: overrides.state ?? "empty",
@@ -125,6 +126,46 @@ describe("CategoryTabStrip", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
 
     fetchSpy.mockRestore();
+  });
+
+  it("renders category Article rows ahead of fallback Signal cards", () => {
+    render(
+      <CategoryTabStrip
+        topEvents={[createEvent({ id: "top-1", title: "Top ranked event" })]}
+        categorySections={[
+          createSection({
+            key: "tech",
+            label: "Tech",
+            events: [createEvent({ id: "tech-signal", title: "Tech Signal card" })],
+            articles: [
+              {
+                id: "article-1",
+                category: "tech",
+                title: "Tech Article row",
+                sourceName: "The Verge",
+                url: "https://www.theverge.com/article-1",
+                summary: "Article summary.",
+                publishedAt: "2026-05-12T10:00:00.000Z",
+                ingestedAt: "2026-05-12T11:45:00.000Z",
+                runId: "pipeline-1",
+              },
+            ],
+            state: "sparse",
+          }),
+        ]}
+        renderTopEvent={(event) => <article>{event.title}</article>}
+        renderCategoryEvent={(event) => <article>{event.title}</article>}
+        renderCategoryArticle={(article) => <a href={article.url}>{article.title}</a>}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "Tech" }));
+
+    expect(screen.getByRole("link", { name: "Tech Article row" })).toHaveAttribute(
+      "href",
+      "https://www.theverge.com/article-1",
+    );
+    expect(screen.queryByText("Tech Signal card")).not.toBeInTheDocument();
   });
 
   it("lets signed-in users open populated category tabs without the soft gate", () => {

--- a/src/components/landing/homepage.tsx
+++ b/src/components/landing/homepage.tsx
@@ -23,7 +23,7 @@ import {
   type EditorialWhyItMattersContent,
 } from "@/lib/editorial-content";
 import { trackMvpMeasurementEvent } from "@/lib/mvp-measurement-client";
-import type { DashboardData, ViewerAccount } from "@/lib/types";
+import type { DashboardData, HomepageCategoryArticle, ViewerAccount } from "@/lib/types";
 import { cn, getBriefingDateKey, minutesToLabel } from "@/lib/utils";
 
 type LandingHomepageProps = {
@@ -125,6 +125,7 @@ export default function LandingHomepage({
               }}
             />
           )}
+          renderCategoryArticle={(article) => <CategoryArticleRow article={article} />}
         />
 
         <DevelopingNow events={developingNowEvents} />
@@ -145,6 +146,54 @@ export default function LandingHomepage({
       </div>
     </AppShell>
   );
+}
+
+function CategoryArticleRow({ article }: { article: HomepageCategoryArticle }) {
+  const summary = article.summary.trim();
+
+  return (
+    <a
+      href={article.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group block rounded-card border border-[var(--border)] bg-[var(--card)] px-4 py-3 transition-colors hover:border-[var(--text-secondary)]"
+      data-mvp-measurement-event="source_click"
+      data-mvp-route="/"
+      data-mvp-surface={`home_${article.category}_article_tab`}
+      data-mvp-source-name={article.sourceName}
+    >
+      <article className="space-y-2">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs font-semibold text-[var(--text-secondary)]">
+          <span>{formatArticleDate(article.publishedAt)}</span>
+          <span aria-hidden="true">/</span>
+          <span>{article.sourceName}</span>
+        </div>
+        <div className="flex items-start justify-between gap-3">
+          <h3 className="text-base font-semibold leading-snug text-[var(--text-primary)] group-hover:text-[var(--accent)]">
+            {article.title}
+          </h3>
+          <ExternalLink className="mt-1 h-4 w-4 shrink-0 text-[var(--text-secondary)]" />
+        </div>
+        {summary ? (
+          <p className="line-clamp-2 text-sm leading-6 text-[var(--text-secondary)]">{summary}</p>
+        ) : null}
+      </article>
+    </a>
+  );
+}
+
+function formatArticleDate(value: string) {
+  const timestamp = Date.parse(value);
+
+  if (!Number.isFinite(timestamp)) {
+    return "Latest";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "Asia/Taipei",
+  }).format(new Date(timestamp));
 }
 
 function dedupeEvents(events: Array<HomepageEvent | null>) {

--- a/src/lib/data.test.ts
+++ b/src/lib/data.test.ts
@@ -2,11 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const safeGetUser = vi.fn();
 const createSupabaseServerClient = vi.fn();
+const createSupabaseServiceRoleClient = vi.fn();
 const getHomepageSignalSnapshot = vi.fn();
 
 vi.mock("@/lib/supabase/server", () => ({
   safeGetUser,
   createSupabaseServerClient,
+  createSupabaseServiceRoleClient,
 }));
 
 vi.mock("@/lib/signals-editorial", () => ({
@@ -164,8 +166,10 @@ describe("homepage read model", () => {
   beforeEach(() => {
     safeGetUser.mockReset();
     createSupabaseServerClient.mockReset();
+    createSupabaseServiceRoleClient.mockReset();
     getHomepageSignalSnapshot.mockReset();
     createSupabaseServerClient.mockResolvedValue(null);
+    createSupabaseServiceRoleClient.mockReturnValue(null);
     safeGetUser.mockResolvedValue({
       supabase: null,
       user: null,
@@ -356,8 +360,10 @@ describe("account page read model", () => {
   beforeEach(() => {
     safeGetUser.mockReset();
     createSupabaseServerClient.mockReset();
+    createSupabaseServiceRoleClient.mockReset();
     getHomepageSignalSnapshot.mockReset();
     createSupabaseServerClient.mockResolvedValue(null);
+    createSupabaseServiceRoleClient.mockReturnValue(null);
   });
 
   it("keeps account SSR on auth, profile, and source reads only", async () => {

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -11,6 +11,10 @@ import { assembleExplanationPacket } from "@/lib/explanation-support";
 import { isAiConfigured } from "@/lib/env";
 import { buildEventIntelligence } from "@/lib/event-intelligence";
 import {
+  createEmptyHomepageCategoryArticleMap,
+  loadHomepageCategoryArticles,
+} from "@/lib/homepage-category-articles";
+import {
   classifyHomepageCategory,
   countSourcesByHomepageCategory,
 } from "@/lib/homepage-taxonomy";
@@ -480,7 +484,10 @@ function formatHomepageFreshnessDate(dateKey: string) {
   }).format(date);
 }
 
-function buildEmptyPublicHomepageData(message = "The latest briefing is not yet available. Please check back soon."): DashboardData {
+function buildEmptyPublicHomepageData(
+  message = "The latest briefing is not yet available. Please check back soon.",
+  homepageCategoryArticles = createEmptyHomepageCategoryArticleMap(),
+): DashboardData {
   const sources = getSourcesForPublicSurface("public.home");
   const briefingDate = normalizeCalendarSafeBriefingDate(getBriefingDateKey(formatISO(new Date())));
 
@@ -497,6 +504,7 @@ function buildEmptyPublicHomepageData(message = "The latest briefing is not yet 
     topics: demoTopics,
     sources,
     publicRankedItems: [],
+    homepageCategoryArticles,
     homepageFreshnessNotice: {
       kind: "empty",
       text: message,
@@ -511,8 +519,14 @@ async function buildPublicHomepageData(): Promise<DashboardData> {
   const sources = getSourcesForPublicSurface("public.home");
 
   if (homepageSignalSnapshot.posts.length === 0) {
+    const homepageCategoryArticles = await loadHomepageCategoryArticles({
+      excludedSignalItems: [],
+      route: "/",
+    });
+
     return buildEmptyPublicHomepageData(
       homepageSignalSnapshot.errorMessage ? PUBLIC_BRIEFING_TEMPORARILY_UNAVAILABLE_MESSAGE : undefined,
+      homepageCategoryArticles,
     );
   }
 
@@ -529,6 +543,10 @@ async function buildPublicHomepageData(): Promise<DashboardData> {
     ? homepageSignalSnapshot.depthPosts
     : homepageSignalSnapshot.posts
   ).map((post) => mapHomepageSignalPostToBriefingItem(post, homepageSignalSnapshot.source));
+  const homepageCategoryArticles = await loadHomepageCategoryArticles({
+    excludedSignalItems: depthItems,
+    route: "/",
+  });
   const intro =
     homepageSignalSnapshot.source === "published_live"
       ? "The homepage renders from today's published signal set instead of triggering feed ingestion during SSR."
@@ -555,6 +573,7 @@ async function buildPublicHomepageData(): Promise<DashboardData> {
     topics: demoTopics,
     sources,
     publicRankedItems: depthItems,
+    homepageCategoryArticles,
     homepageFreshnessNotice,
     homepageDiagnostics: buildReadOnlyHomepageDiagnostics(sources, depthItems.length),
   };
@@ -677,6 +696,10 @@ async function buildSignedInHomepageData(authState: RequestAuthState): Promise<D
     topics,
     sources,
     publicRankedItems: latestBriefing.items,
+    homepageCategoryArticles: await loadHomepageCategoryArticles({
+      excludedSignalItems: latestBriefing.items,
+      route: authState.route,
+    }),
     homepageDiagnostics: buildReadOnlyHomepageDiagnostics(sources, latestBriefing.items.length),
   };
 }
@@ -1106,6 +1129,7 @@ async function getPipelineBackedDashboardData(input: {
     topics: fallbackTopics,
     sources: fallbackSources,
     publicRankedItems,
+    homepageCategoryArticles: createEmptyHomepageCategoryArticleMap(),
     homepageDiagnostics: {
       totalArticlesFetched: pipelineRun.num_raw_items,
       totalCandidateEvents: pipelineRun.num_clusters,

--- a/src/lib/homepage-category-articles.test.ts
+++ b/src/lib/homepage-category-articles.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import { selectHomepageCategoryArticles } from "@/lib/homepage-category-articles";
+import type { BriefingItem } from "@/lib/types";
+
+function row(overrides: {
+  id: string;
+  run_id?: string;
+  ingested_at?: string;
+  source_name?: string;
+  canonical_url?: string;
+  title?: string;
+  summary?: string;
+  keywords?: string[];
+  published_at?: string;
+}) {
+  return {
+    run_id: overrides.run_id ?? "pipeline-latest",
+    ingested_at: overrides.ingested_at ?? "2026-05-12T11:45:00.000Z",
+    source_name: overrides.source_name ?? "TechCrunch",
+    canonical_url: overrides.canonical_url ?? `https://techcrunch.com/${overrides.id}`,
+    title: overrides.title ?? `AI platform update ${overrides.id}`,
+    summary: overrides.summary ?? "A software platform update affects AI infrastructure.",
+    keywords: overrides.keywords ?? ["ai", "software"],
+    published_at: overrides.published_at ?? "2026-05-12T10:30:00.000Z",
+    id: overrides.id,
+  };
+}
+
+function signalItem(overrides: Partial<BriefingItem>): BriefingItem {
+  return {
+    id: overrides.id ?? "signal-1",
+    topicId: "topic-tech",
+    topicName: "Tech",
+    title: overrides.title ?? "Top Signal",
+    whatHappened: "A top signal happened.",
+    keyPoints: ["", "", ""],
+    whyItMatters: "It matters.",
+    sources: overrides.sources ?? [{ title: "The Verge", url: "https://www.theverge.com/top-signal" }],
+    relatedArticles: overrides.relatedArticles,
+    estimatedMinutes: 4,
+    read: false,
+    priority: "top",
+  };
+}
+
+describe("selectHomepageCategoryArticles", () => {
+  it("groups latest cron Article candidates into capped category tab lists", () => {
+    const articles = selectHomepageCategoryArticles({
+      rows: [
+        row({ id: "tech-1", source_name: "TechCrunch", title: "AI platform vendors expand developer tools" }),
+        row({
+          id: "finance-1",
+          source_name: "NPR Economy",
+          canonical_url: "https://www.npr.org/economy/fed-rates",
+          title: "Fed rate debate resets economic expectations",
+          summary: "Federal Reserve officials weighed inflation and rate risks.",
+          keywords: ["fed", "economy", "rates"],
+        }),
+        row({
+          id: "politics-1",
+          source_name: "Politico Politics News",
+          canonical_url: "https://www.politico.com/news/policy",
+          title: "Congressional committee advances policy package",
+          summary: "Lawmakers advanced a government policy package.",
+          keywords: ["congress", "policy"],
+        }),
+      ],
+    });
+
+    expect(articles.tech.map((article) => article.id)).toEqual(["tech-1"]);
+    expect(articles.finance.map((article) => article.id)).toEqual(["finance-1"]);
+    expect(articles.politics.map((article) => article.id)).toEqual(["politics-1"]);
+  });
+
+  it("excludes paywalled sources and duplicates from the top Signal Card set", () => {
+    const articles = selectHomepageCategoryArticles({
+      excludedSignalItems: [
+        signalItem({
+          title: "Top signal about chips",
+          sources: [{ title: "The Verge", url: "https://www.theverge.com/top-signal" }],
+        }),
+      ],
+      rows: [
+        row({
+          id: "top-duplicate",
+          canonical_url: "https://www.theverge.com/top-signal?utm_source=rss",
+          title: "Top signal about chips",
+        }),
+        row({
+          id: "paywall",
+          source_name: "Financial Times",
+          canonical_url: "https://www.ft.com/content/paywalled",
+          title: "Markets move after central bank signal",
+          summary: "A market story.",
+          keywords: ["markets"],
+        }),
+        row({
+          id: "eligible",
+          canonical_url: "https://arstechnica.com/ai/eligible",
+          title: "Open source AI runtime lands new release",
+          summary: "A technology story.",
+          keywords: ["ai", "software"],
+        }),
+      ],
+    });
+
+    expect(articles.tech.map((article) => article.id)).toEqual(["eligible"]);
+    expect(Object.values(articles).flat().map((article) => article.id)).not.toContain("paywall");
+    expect(Object.values(articles).flat().map((article) => article.id)).not.toContain("top-duplicate");
+  });
+
+  it("uses only the latest two cron run ids", () => {
+    const articles = selectHomepageCategoryArticles({
+      rows: [
+        row({ id: "latest", run_id: "pipeline-3", ingested_at: "2026-05-12T11:45:00.000Z" }),
+        row({ id: "previous", run_id: "pipeline-2", ingested_at: "2026-05-12T10:15:00.000Z" }),
+        row({ id: "stale", run_id: "pipeline-1", ingested_at: "2026-05-11T11:45:00.000Z" }),
+      ],
+    });
+
+    expect(articles.tech.map((article) => article.id)).toEqual(["latest", "previous"]);
+  });
+});

--- a/src/lib/homepage-category-articles.ts
+++ b/src/lib/homepage-category-articles.ts
@@ -1,0 +1,278 @@
+import { classifyHomepageCategory, HOMEPAGE_CATEGORY_CONFIG } from "@/lib/homepage-taxonomy";
+import { logServerEvent } from "@/lib/observability";
+import { cleanText, normalizeUrl, stableId } from "@/lib/pipeline/shared/text";
+import { isLikelyPaywalledArticleSource } from "@/lib/source-accessibility";
+import { createSupabaseServiceRoleClient } from "@/lib/supabase/server";
+import type {
+  BriefingItem,
+  HomepageArticleCategory,
+  HomepageCategoryArticle,
+  HomepageCategoryArticleMap,
+} from "@/lib/types";
+
+const HOMEPAGE_CATEGORY_ARTICLE_LIMIT = 50;
+const HOMEPAGE_CATEGORY_ARTICLE_QUERY_LIMIT = 1000;
+const LATEST_CRON_RUN_COUNT = 2;
+
+type StoredPipelineArticleCandidate = {
+  id?: string | null;
+  run_id: string | null;
+  ingested_at: string | null;
+  source_name: string | null;
+  canonical_url: string | null;
+  title: string | null;
+  summary: string | null;
+  keywords: string[] | null;
+  published_at?: string | null;
+};
+
+type PipelineArticleCandidateQueryResult = {
+  data: StoredPipelineArticleCandidate[];
+  error: unknown | null;
+};
+
+export function createEmptyHomepageCategoryArticleMap(): HomepageCategoryArticleMap {
+  return {
+    tech: [],
+    finance: [],
+    politics: [],
+  };
+}
+
+function isMissingPublishedAtColumnError(error: unknown) {
+  const maybeError = error as { code?: unknown; message?: unknown; details?: unknown; hint?: unknown };
+  const haystack = [maybeError.code, maybeError.message, maybeError.details, maybeError.hint]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ")
+    .toLowerCase();
+
+  return (
+    haystack.includes("42703") ||
+    (haystack.includes("published_at") &&
+      (haystack.includes("does not exist") || haystack.includes("could not find")))
+  );
+}
+
+function getErrorMessage(error: unknown) {
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") {
+      return message;
+    }
+  }
+
+  return String(error);
+}
+
+function normalizeTitleKey(value: string) {
+  return cleanText(value).toLowerCase();
+}
+
+function normalizeArticleUrlKey(value: string) {
+  return normalizeUrl(value).toLowerCase();
+}
+
+function isHttpUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function collectSignalExclusions(items: BriefingItem[]) {
+  const urls = new Set<string>();
+  const titles = new Set<string>();
+
+  for (const item of items) {
+    titles.add(normalizeTitleKey(item.title));
+    [...item.sources, ...(item.relatedArticles ?? [])].forEach((source) => {
+      if (source.url && isHttpUrl(source.url)) {
+        urls.add(normalizeArticleUrlKey(source.url));
+      }
+    });
+  }
+
+  return { urls, titles };
+}
+
+function getLatestRunIds(rows: StoredPipelineArticleCandidate[]) {
+  const runIds: string[] = [];
+  const seen = new Set<string>();
+
+  for (const row of rows) {
+    const runId = row.run_id?.trim();
+
+    if (!runId || seen.has(runId)) {
+      continue;
+    }
+
+    runIds.push(runId);
+    seen.add(runId);
+
+    if (runIds.length === LATEST_CRON_RUN_COUNT) {
+      break;
+    }
+  }
+
+  return new Set(runIds);
+}
+
+function classifyArticle(row: StoredPipelineArticleCandidate): HomepageArticleCategory | null {
+  const classification = classifyHomepageCategory({
+    topicName: row.source_name ?? undefined,
+    title: row.title ?? undefined,
+    summary: row.summary ?? undefined,
+    matchedKeywords: row.keywords ?? undefined,
+    sourceNames: row.source_name ? [row.source_name] : [],
+  });
+
+  return classification.primaryCategory;
+}
+
+function mapCandidateToArticle(
+  row: StoredPipelineArticleCandidate,
+  category: HomepageArticleCategory,
+): HomepageCategoryArticle | null {
+  const title = cleanText(row.title);
+  const sourceName = cleanText(row.source_name) || "Source";
+  const url = cleanText(row.canonical_url);
+  const ingestedAt = row.ingested_at ?? new Date(0).toISOString();
+  const publishedAt = row.published_at ?? ingestedAt;
+
+  if (!title || !url || !isHttpUrl(url)) {
+    return null;
+  }
+
+  return {
+    id: row.id ?? stableId(row.run_id ?? "", url, title),
+    category,
+    title,
+    sourceName,
+    url,
+    summary: cleanText(row.summary),
+    publishedAt,
+    ingestedAt,
+    runId: row.run_id ?? "",
+  };
+}
+
+function compareArticlesByFreshness(left: HomepageCategoryArticle, right: HomepageCategoryArticle) {
+  const leftTime = Date.parse(left.publishedAt || left.ingestedAt);
+  const rightTime = Date.parse(right.publishedAt || right.ingestedAt);
+
+  if (Number.isFinite(leftTime) && Number.isFinite(rightTime) && leftTime !== rightTime) {
+    return rightTime - leftTime;
+  }
+
+  return left.title.localeCompare(right.title);
+}
+
+export function selectHomepageCategoryArticles(input: {
+  rows: StoredPipelineArticleCandidate[];
+  excludedSignalItems?: BriefingItem[];
+}): HomepageCategoryArticleMap {
+  const result = createEmptyHomepageCategoryArticleMap();
+  const latestRunIds = getLatestRunIds(input.rows);
+  const signalExclusions = collectSignalExclusions(input.excludedSignalItems ?? []);
+  const seenUrls = new Set<string>();
+  const seenTitles = new Set<string>();
+
+  for (const row of input.rows) {
+    const runId = row.run_id?.trim();
+    const url = cleanText(row.canonical_url);
+    const title = cleanText(row.title);
+
+    if (!runId || !latestRunIds.has(runId) || !url || !title || !isHttpUrl(url)) {
+      continue;
+    }
+
+    if (isLikelyPaywalledArticleSource({ sourceName: row.source_name, url })) {
+      continue;
+    }
+
+    const urlKey = normalizeArticleUrlKey(url);
+    const titleKey = normalizeTitleKey(title);
+
+    if (
+      seenUrls.has(urlKey) ||
+      seenTitles.has(titleKey) ||
+      signalExclusions.urls.has(urlKey) ||
+      signalExclusions.titles.has(titleKey)
+    ) {
+      continue;
+    }
+
+    const category = classifyArticle(row);
+
+    if (!category) {
+      continue;
+    }
+
+    const article = mapCandidateToArticle(row, category);
+
+    if (!article) {
+      continue;
+    }
+
+    result[category].push(article);
+    seenUrls.add(urlKey);
+    seenTitles.add(titleKey);
+  }
+
+  for (const category of HOMEPAGE_CATEGORY_CONFIG) {
+    result[category.key] = result[category.key]
+      .sort(compareArticlesByFreshness)
+      .slice(0, HOMEPAGE_CATEGORY_ARTICLE_LIMIT);
+  }
+
+  return result;
+}
+
+async function queryPipelineArticleCandidates(
+  client: NonNullable<ReturnType<typeof createSupabaseServiceRoleClient>>,
+  selectColumns: string,
+): Promise<PipelineArticleCandidateQueryResult> {
+  const result = await client
+    .from("pipeline_article_candidates")
+    .select(selectColumns)
+    .order("ingested_at", { ascending: false })
+    .limit(HOMEPAGE_CATEGORY_ARTICLE_QUERY_LIMIT);
+
+  return {
+    data: (result.data ?? []) as unknown as StoredPipelineArticleCandidate[],
+    error: result.error,
+  };
+}
+
+export async function loadHomepageCategoryArticles(input: {
+  excludedSignalItems?: BriefingItem[];
+  route?: string;
+} = {}): Promise<HomepageCategoryArticleMap> {
+  const client = createSupabaseServiceRoleClient();
+
+  if (!client) {
+    return createEmptyHomepageCategoryArticleMap();
+  }
+
+  const baseSelect = "id, run_id, ingested_at, source_name, canonical_url, title, summary, keywords";
+  let result = await queryPipelineArticleCandidates(client, `${baseSelect}, published_at`);
+
+  if (result.error && isMissingPublishedAtColumnError(result.error)) {
+    result = await queryPipelineArticleCandidates(client, baseSelect);
+  }
+
+  if (result.error) {
+    logServerEvent("warn", "Homepage category article candidates could not be loaded", {
+      route: input.route ?? "/",
+      errorMessage: getErrorMessage(result.error),
+    });
+    return createEmptyHomepageCategoryArticleMap();
+  }
+
+  return selectHomepageCategoryArticles({
+    rows: result.data,
+    excludedSignalItems: input.excludedSignalItems,
+  });
+}

--- a/src/lib/homepage-model.ts
+++ b/src/lib/homepage-model.ts
@@ -1,4 +1,9 @@
-import type { DashboardData, BriefingItem, EventIntelligence } from "@/lib/types";
+import type {
+  DashboardData,
+  BriefingItem,
+  EventIntelligence,
+  HomepageCategoryArticle,
+} from "@/lib/types";
 import {
   getEditorialHomepagePreviewText,
   type EditorialWhyItMattersContent,
@@ -75,6 +80,7 @@ export type HomepageCategorySection = {
   label: string;
   description: string;
   events: HomepageEvent[];
+  articles: HomepageCategoryArticle[];
   fallbackEvents: HomepageEvent[];
   placeholderCount: number;
   state: "populated" | "sparse" | "empty";
@@ -220,6 +226,11 @@ export function buildHomepageViewModel(
   });
   const categoryTabSourceEvents = categoryTabPool.sourceEvents;
   const excludedCategoryTabIds = new Set(categoryTabPool.initialExcludedEventIds);
+  const categoryArticleMap = data.homepageCategoryArticles ?? {
+    tech: [],
+    finance: [],
+    politics: [],
+  };
   const categorySections = HOMEPAGE_CATEGORY_CONFIG.map((category) => {
     const sectionSelection = selectCategoryTabEvents({
       rankedEvents: categoryTabSourceEvents,
@@ -266,12 +277,13 @@ export function buildHomepageViewModel(
       label: getCategoryTabLabel(category.key),
       description: getHomepageCategoryDescription(category.key),
       events: displayEvents,
+      articles: categoryArticleMap[category.key] ?? [],
       fallbackEvents: [] as HomepageEvent[],
       placeholderCount: 0,
       state:
-        displayEvents.length >= 3
+        displayEvents.length + (categoryArticleMap[category.key]?.length ?? 0) >= 3
           ? "populated"
-          : displayEvents.length > 0
+          : displayEvents.length + (categoryArticleMap[category.key]?.length ?? 0) > 0
             ? "sparse"
             : "empty",
       emptyReason,

--- a/src/lib/pipeline/article-candidates.ts
+++ b/src/lib/pipeline/article-candidates.ts
@@ -32,6 +32,26 @@ type CandidateUpdate = {
   };
 };
 
+type CandidateInsertRow = {
+  run_id: string;
+  ingested_at: string;
+  source_name: string;
+  source_tier: string | null;
+  canonical_url: string;
+  title: string;
+  summary: string | null;
+  keywords: string[] | null;
+  entities: string[] | null;
+  published_at: string;
+  cluster_id: string | null;
+  ranking_score: number | null;
+  surfaced: boolean;
+  pipeline_stage_reached: PipelineStageReached;
+  drop_reason: CandidateDropReason | null;
+};
+
+type LegacyCandidateInsertRow = Omit<CandidateInsertRow, "published_at">;
+
 function getPipelineCandidateClient() {
   return createSupabaseServiceRoleClient();
 }
@@ -85,7 +105,7 @@ function schedulePipelineCandidateWrite(
   runId: string,
   operation: (client: PipelineCandidateClient) => Promise<void>,
 ) {
-  void runPipelineCandidateWrite(label, runId, operation);
+  return runPipelineCandidateWrite(label, runId, operation);
 }
 
 function getSourceTier(article: NormalizedArticle) {
@@ -154,7 +174,40 @@ function getDedupDropReasons(articles: NormalizedArticle[]) {
   return dropReasons;
 }
 
-export function persistNormalizedArticleCandidates({
+function isMissingPublishedAtColumnError(error: unknown) {
+  const maybeError = error as { code?: unknown; message?: unknown; details?: unknown; hint?: unknown };
+  const haystack = [maybeError.code, maybeError.message, maybeError.details, maybeError.hint]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ")
+    .toLowerCase();
+
+  return (
+    haystack.includes("42703") ||
+    (haystack.includes("published_at") &&
+      (haystack.includes("does not exist") || haystack.includes("could not find")))
+  );
+}
+
+function omitPublishedAt(rows: CandidateInsertRow[]): LegacyCandidateInsertRow[] {
+  return rows.map((row) => ({
+    run_id: row.run_id,
+    ingested_at: row.ingested_at,
+    source_name: row.source_name,
+    source_tier: row.source_tier,
+    canonical_url: row.canonical_url,
+    title: row.title,
+    summary: row.summary,
+    keywords: row.keywords,
+    entities: row.entities,
+    cluster_id: row.cluster_id,
+    ranking_score: row.ranking_score,
+    surfaced: row.surfaced,
+    pipeline_stage_reached: row.pipeline_stage_reached,
+    drop_reason: row.drop_reason,
+  }));
+}
+
+export async function persistNormalizedArticleCandidates({
   runId,
   articles,
   ingestedAt = new Date(),
@@ -167,8 +220,8 @@ export function persistNormalizedArticleCandidates({
     return;
   }
 
-  schedulePipelineCandidateWrite("normalized_insert", runId, async (client) => {
-    const rows = articles.map((article) => ({
+  await schedulePipelineCandidateWrite("normalized_insert", runId, async (client) => {
+    const rows = articles.map((article): CandidateInsertRow => ({
       run_id: runId,
       ingested_at: ingestedAt.toISOString(),
       source_name: article.source,
@@ -178,14 +231,19 @@ export function persistNormalizedArticleCandidates({
       summary: article.content || null,
       keywords: article.keywords.length ? article.keywords : null,
       entities: article.normalized_entities.length ? article.normalized_entities : article.entities,
+      published_at: article.published_at,
       cluster_id: null,
       ranking_score: null,
       surfaced: false,
-      pipeline_stage_reached: "normalized" satisfies PipelineStageReached,
+      pipeline_stage_reached: "normalized",
       drop_reason: null,
     }));
 
-    const result = await client.from(PIPELINE_ARTICLE_CANDIDATES_TABLE).insert(rows);
+    let result = await client.from(PIPELINE_ARTICLE_CANDIDATES_TABLE).insert(rows);
+    if (result.error && isMissingPublishedAtColumnError(result.error)) {
+      result = await client.from(PIPELINE_ARTICLE_CANDIDATES_TABLE).insert(omitPublishedAt(rows));
+    }
+
     if (result.error) {
       throw result.error;
     }
@@ -197,7 +255,7 @@ export function persistNormalizedArticleCandidates({
   });
 }
 
-export function updateArticleCandidateClusters({
+export async function updateArticleCandidateClusters({
   runId,
   clusters,
 }: {
@@ -219,7 +277,7 @@ export function updateArticleCandidateClusters({
     return;
   }
 
-  schedulePipelineCandidateWrite("cluster_update", runId, async (client) => {
+  await schedulePipelineCandidateWrite("cluster_update", runId, async (client) => {
     await applyCandidateUpdates(client, runId, updates);
     logPipelineEvent("info", "Updated article candidate cluster assignments", {
       run_id: runId,
@@ -228,7 +286,7 @@ export function updateArticleCandidateClusters({
   });
 }
 
-export function updateArticleCandidateRankingOutcomes({
+export async function updateArticleCandidateRankingOutcomes({
   runId,
   normalizedArticles,
   dedupedArticles,
@@ -299,7 +357,7 @@ export function updateArticleCandidateRankingOutcomes({
     };
   });
 
-  schedulePipelineCandidateWrite("ranking_surface_update", runId, async (client) => {
+  await schedulePipelineCandidateWrite("ranking_surface_update", runId, async (client) => {
     await applyCandidateUpdates(client, runId, updates);
     logPipelineEvent("info", "Updated article candidate ranking outcomes", {
       run_id: runId,

--- a/src/lib/pipeline/index.ts
+++ b/src/lib/pipeline/index.ts
@@ -61,9 +61,9 @@ export async function runClusterFirstPipeline(options: {
   const rankedStoryClusters = rankStoryClusters(clusters);
 
   if (shouldPersistArticleCandidates) {
-    persistNormalizedArticleCandidates({ runId: run.run_id, articles: normalized });
-    updateArticleCandidateClusters({ runId: run.run_id, clusters });
-    updateArticleCandidateRankingOutcomes({
+    await persistNormalizedArticleCandidates({ runId: run.run_id, articles: normalized });
+    await updateArticleCandidateClusters({ runId: run.run_id, clusters });
+    await updateArticleCandidateRankingOutcomes({
       runId: run.run_id,
       normalizedArticles: normalized,
       dedupedArticles: deduped,

--- a/src/lib/source-accessibility.ts
+++ b/src/lib/source-accessibility.ts
@@ -28,6 +28,20 @@ const PAYWALL_LIMITED_HOSTS = [
   "theinformation.com",
   "stratechery.com",
   "puck.news",
+  "foreignaffairs.com",
+  "marketwatch.com",
+];
+
+const PAYWALL_LIMITED_SOURCE_NAMES = [
+  "financial times",
+  "bloomberg",
+  "wall street journal",
+  "the economist",
+  "the information",
+  "stratechery",
+  "puck",
+  "foreign affairs",
+  "marketwatch",
 ];
 
 const CORE_SUPPORTING_ROLES = new Set<SourceRole>([
@@ -103,16 +117,36 @@ function sourceHost(value: string | null | undefined) {
   }
 }
 
+export function isPaywallLimitedHost(value: string | null | undefined) {
+  const host = sourceHost(value);
+
+  return PAYWALL_LIMITED_HOSTS.some(
+    (paywallHost) => host === paywallHost || host.endsWith(`.${paywallHost}`),
+  );
+}
+
+export function isLikelyPaywalledArticleSource(input: {
+  sourceName?: string | null;
+  url?: string | null;
+  homepageUrl?: string | null;
+  feedUrl?: string | null;
+}) {
+  const normalizedSourceName = cleanText(input.sourceName).toLowerCase();
+
+  return (
+    [input.url, input.homepageUrl, input.feedUrl].some((value) => isPaywallLimitedHost(value)) ||
+    PAYWALL_LIMITED_SOURCE_NAMES.some((sourceName) => normalizedSourceName.includes(sourceName))
+  );
+}
+
 function isPaywallLimitedSource(source: SourceDefinition, articleUrl: string) {
   const hostCandidates = [
-    sourceHost(articleUrl),
-    sourceHost(source.homepageUrl),
-    sourceHost(source.fetch.feedUrl),
+    articleUrl,
+    source.homepageUrl,
+    source.fetch.feedUrl,
   ];
 
-  return hostCandidates.some((host) =>
-    PAYWALL_LIMITED_HOSTS.some((paywallHost) => host === paywallHost || host.endsWith(`.${paywallHost}`)),
-  );
+  return hostCandidates.some((value) => isPaywallLimitedHost(value));
 }
 
 function isTitleOnlySummary(summary: string, title: string) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -238,6 +238,7 @@ export type DashboardData = {
   topics: Topic[];
   sources: Source[];
   publicRankedItems?: BriefingItem[];
+  homepageCategoryArticles?: HomepageCategoryArticleMap;
   homepageFreshnessNotice?: {
     kind: "stale" | "empty";
     text: string;
@@ -258,6 +259,22 @@ export type DashboardData = {
     };
   };
 };
+
+export type HomepageArticleCategory = "tech" | "finance" | "politics";
+
+export type HomepageCategoryArticle = {
+  id: string;
+  category: HomepageArticleCategory;
+  title: string;
+  sourceName: string;
+  url: string;
+  summary: string;
+  publishedAt: string;
+  ingestedAt: string;
+  runId: string;
+};
+
+export type HomepageCategoryArticleMap = Record<HomepageArticleCategory, HomepageCategoryArticle[]>;
 
 export type ViewerAccount = {
   id: string;

--- a/supabase/migrations/20260512120000_pipeline_article_candidates_published_at.sql
+++ b/supabase/migrations/20260512120000_pipeline_article_candidates_published_at.sql
@@ -1,0 +1,5 @@
+alter table public.pipeline_article_candidates
+  add column if not exists published_at timestamptz;
+
+create index if not exists pipeline_article_candidates_published_at_idx
+on public.pipeline_article_candidates (published_at desc);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -407,6 +407,7 @@ create table if not exists public.pipeline_article_candidates (
   id uuid primary key default gen_random_uuid(),
   run_id text not null,
   ingested_at timestamptz not null,
+  published_at timestamptz,
   source_name text not null,
   source_tier text check (source_tier in ('tier_1', 'tier_2', 'tier_3')),
   canonical_url text not null,
@@ -440,6 +441,9 @@ on public.pipeline_article_candidates (run_id, surfaced);
 
 create index if not exists pipeline_article_candidates_ingested_at_idx
 on public.pipeline_article_candidates (ingested_at);
+
+create index if not exists pipeline_article_candidates_published_at_idx
+on public.pipeline_article_candidates (published_at desc);
 
 create table if not exists public.newsletter_story_extractions (
   id uuid primary key default gen_random_uuid(),


### PR DESCRIPTION
## Summary
- Populate the public homepage Tech, Finance, and Politics tabs from the latest two cron-backed `pipeline_article_candidates` runs, capped at 50 Articles per category.
- Render category Article rows with date, source, title, summary, and clickable original links.
- Filter likely paywalled sources and URL/title duplicates from the current top Signal Card set.
- Persist Article `published_at` metadata and await candidate writes during cron execution so serverless runs retain the category-tab Article pool.

## Root Cause
The homepage tabs only consumed the published Signal Card read model. The broader Article candidate pool created by the scheduled Taipei cron jobs stayed in `pipeline_article_candidates`, so category tab Surface Placements had no persisted Article rows to render.

## Validation
Local validation before PR:
- `npm install`
- `npm run lint`
- `npx vitest run src/lib/homepage-category-articles.test.ts src/components/home/home-category-components.test.tsx src/lib/homepage-model.test.ts src/lib/pipeline/controlled-persistence.test.ts src/lib/data.test.ts`
- `npm run test` passed: 93 files, 680 tests
- `npm run build`
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name fix/category-tabs-populate-articles-20260512 --pr-title "Fix homepage category tabs with cron Article population"`
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name fix/category-tabs-populate-articles-20260512 --pr-title "Fix homepage category tabs with cron Article population"`
- `python3 scripts/validate-feature-system-csv.py` passed with pre-existing slug warnings

PR / preview validation after PR opened:
- PR #227 Vercel preview: https://bootup-git-fix-category-tabs-popul-8598af-brandonma25s-projects.vercel.app
- Vercel preview returned HTTP 200 from Vercel.
- Preview page title resolved to `Boot Up`.
- Preview tab interaction check clicked `Top Events`, `Tech`, `Finance`, and `Politics`; each tab became selected.
- Preview browser console check reported 0 errors.
- GitHub PR checks are green: Vercel, feature-system-csv-validation, pr-lint, pr-unit-tests, pr-build, pr-e2e-chromium, pr-e2e-webkit, pr-summary, and release-governance-gate.

## Production Caveat
This does not manually trigger production cron or write production data. Production tab population requires the migration to be applied/deployed and the next scheduled 6:15 PM / 7:45 PM Taiwan cron runs to write fresh candidate rows.