### PR TITLE
[codex] Fix Vercel post-deployment warning noise

### DIFF
--- a/docs/engineering/bug-fixes/homepage-category-tabs-cron-article-population.md
+++ b/docs/engineering/bug-fixes/homepage-category-tabs-cron-article-population.md
@@ -7,8 +7,9 @@
 
 ## Fix
 - Exact change: read the latest two cron-backed `pipeline_article_candidates` runs into a homepage category Article map, cap each category at 50 Articles, exclude likely paywalled sources, exclude URL/title duplicates from the current top 5-7 Signal Cards, render date/source/title/summary rows with clickable original Article links, and await candidate persistence during the cron pipeline so serverless execution does not drop candidate writes.
+- Post-deployment warning cleanup: disable Sentry release creation and sourcemap upload during builds that intentionally lack `SENTRY_AUTH_TOKEN`, and mark the package as ESM so Vercel no longer warns while loading `tailwind.config.ts`.
 - Related PRD: PRD-57 and PRD-60.
-- PR: pending.
+- PR: #227.
 - Branch: `fix/category-tabs-populate-articles-20260512`
 - Head SHA: pending.
 - Merge SHA: pending.
@@ -31,6 +32,7 @@
   - `npx vitest run src/lib/data.test.ts` passed.
   - `npm run test` passed: 93 files, 680 tests.
   - `npm run build` passed.
+  - Post-deployment warning fix validation: `npm run lint`, `npm run build`, `npm run test`, and `node scripts/preview-check.js https://bootup-git-fix-category-tabs-popul-8598af-brandonma25s-projects.vercel.app` passed after the Sentry and ESM changes.
   - `python3 scripts/release-governance-gate.py --diff-mode local --branch-name fix/category-tabs-populate-articles-20260512 --pr-title "Fix homepage category tabs with cron Article population"` passed.
   - `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name fix/category-tabs-populate-articles-20260512 --pr-title "Fix homepage category tabs with cron Article population"` passed.
   - `python3 scripts/validate-feature-system-csv.py` passed with pre-existing slug warnings.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 
+const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN?.trim();
+const sentryBuildPluginEnabled = Boolean(sentryAuthToken);
+
 const nextConfig: NextConfig = {
   async redirects() {
     return [
@@ -26,9 +29,17 @@ const nextConfig: NextConfig = {
 export default withSentryConfig(nextConfig, {
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
-  authToken: process.env.SENTRY_AUTH_TOKEN,
-  silent: !process.env.CI,
+  authToken: sentryAuthToken,
+  silent: !process.env.CI || !sentryBuildPluginEnabled,
+  sourcemaps: {
+    disable: !sentryBuildPluginEnabled,
+  },
   webpack: {
+    unstable_sentryWebpackPluginOptions: {
+      // Release creation and sourcemap upload require SENTRY_AUTH_TOKEN, which
+      // may intentionally be absent in preview builds.
+      disable: !sentryBuildPluginEnabled,
+    },
     treeshake: {
       removeDebugLogging: true,
     },

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "daily-intelligence-aggregator",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev --webpack",
     "build": "next build --webpack",

--- a/scripts/preview-check.js
+++ b/scripts/preview-check.js
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
-const { spawnSync } = require("node:child_process");
+import { spawnSync } from "node:child_process";
 
 const url = process.argv[2];
 

--- a/scripts/prod-check.js
+++ b/scripts/prod-check.js
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
-const { spawnSync } = require("node:child_process");
+import { spawnSync } from "node:child_process";
 
 const url = process.argv[2];
 


### PR DESCRIPTION
## Summary
- Disable Sentry release creation and sourcemap upload when `SENTRY_AUTH_TOKEN` is not configured, which is expected for preview builds.
- Add package-level ESM mode so Vercel no longer warns while loading `tailwind.config.ts`.
- Convert the preview/prod route probe scripts from CommonJS `require` to ESM imports so they still run under the package setting.
- Record the warning cleanup in the existing homepage category tabs bug-fix record because this follows the #227 deployment.

## Root Cause
The Vercel build was loading Sentry's build plugin without an auth token, so the plugin warned that it could not create a release or upload source maps. Separately, the repo used ESM-style TypeScript config files while the package did not declare module type, so Node emitted the typeless package warning when Vercel loaded Tailwind config.

## Validation
- `npm run lint`
- `npm run build` passed; the Sentry auth-token warnings and Tailwind module-type warning are gone from the local production build output.
- `npm run test` passed: 93 files, 680 tests.
- `python3 scripts/release-governance-gate.py --diff-mode local --branch-name fix/vercel-post-deploy-warning-noise-20260512 --pr-title "Fix Vercel post-deployment warning noise"`
- `python3 scripts/validate-documentation-coverage.py --diff-mode local --branch-name fix/vercel-post-deploy-warning-noise-20260512 --pr-title "Fix Vercel post-deployment warning noise"`
- GitHub checks passed: feature-system-csv-validation, release-governance-gate, pr-lint, pr-build, pr-unit-tests, pr-e2e-chromium, pr-e2e-webkit, pr-summary.

## Preview QA
Preview: https://bootup-git-fix-vercel-post-deploy-e83513-brandonma25s-projects.vercel.app

- Vercel deployment `dpl_C6V4hYJZAGVLZptHqFGG7AcXZLdS` is Ready for commit `5313802`.
- Vercel build logs were inspected with `vercel inspect --logs`; no `Sentry`, `auth token`, `source maps`, `MODULE_TYPELESS`, `tailwind.config`, or `Warning` matches were present.
- `curl -I -L` returned HTTP 200 for the preview homepage.
- `node scripts/preview-check.js` passed for `/` and `/dashboard`.
- Headless preview browser check passed: Top Events, Tech, Finance, and Politics tabs all selected and rendered content with zero console errors.
- Codex Computer Chrome QA loaded the same preview URL and verified Tech, Finance, and Politics tabs switch to populated article lists.