### PR TITLE
docs: require governance files for new feature work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,15 @@ Rules:
 
 This repository uses a strict documentation system to prevent bloat and maintain clarity.
 
+### Required Governance Files Before Implementation
+- Before editing product or system code, classify the request using `docs/engineering/templates/llm-prompt-template-change-classification.md`.
+- If the user explicitly asks for a new feature or new system-level behavior and no existing `PRD-XX` / `feature-system.csv` row covers it, create the required governance files in the same branch before or alongside the first implementation commit.
+- Required files for new feature or system work:
+  1. exactly one canonical PRD at `/docs/product/prd/prd-XX-<feature-name>.md`
+  2. exactly one matching row in `/docs/product/feature-system.csv` with `prd_id` and `prd_file`
+- Do not wait for `release-governance-gate` to fail before adding these files. The branch is incomplete until the governance files and implementation changes agree.
+- This does not authorize documentation sprawl: bug fixes, remediation, refactors, audits, and tiny UI/copy changes still use the smaller documentation lane defined below.
+
 ### Source of Truth
 - `PRD-XX` is the single source of truth for feature identity across the repo.
 - Public repo documentation is the source of truth for product framing, durable decisions, canonical PRDs, feature metadata, and standing governance rules.
@@ -276,7 +285,7 @@ After merge or explicit user acceptance:
 Do not:
 - implement features marked `delay` or `kill`
 - change `build_order` without explicit user instruction
-- create new feature rows unless explicitly asked
+- create new feature rows unless explicitly asked, or unless the user has requested a new feature/system implementation that has no existing PRD/CSV mapping and is classified as `new-feature-or-system`
 
 If a feature is no longer active:
 - set `status = Deprecated`

--- a/docs/product/documentation-rules.md
+++ b/docs/product/documentation-rules.md
@@ -60,17 +60,18 @@ This repository uses a controlled documentation system. The goal is to keep docs
 3. Respect dependencies before implementation.
 4. Complete the terminology check and state which object level the work modifies: Article, Story Cluster, Signal, Card, or Surface Placement.
 5. If the feature already has a PRD, update that file instead of creating a new one.
-6. Update stable public documentation only when the change creates durable product, governance, or portfolio-facing information.
-7. Do not update Google Sheets or claim tracker updates.
-8. Do not create routine tracker-sync fallback files or public operational logs.
-9. During active branch work, set CSV `status = In Progress` when feature metadata changes are in scope.
-10. When implementation is complete but awaiting merge or review, set CSV `status = In Review` when feature metadata changes are in scope.
-11. After merge or explicit user acceptance, set CSV `status = Built`, `decision = keep`, and update `last_updated` when feature metadata changes are in scope.
+6. If the user explicitly asks for a new feature or new system-level behavior and no existing row maps it, create the canonical PRD and matching CSV row in the same branch before or alongside implementation.
+7. Update stable public documentation only when the change creates durable product, governance, or portfolio-facing information.
+8. Do not update Google Sheets or claim tracker updates.
+9. Do not create routine tracker-sync fallback files or public operational logs.
+10. During active branch work, set CSV `status = In Progress` when feature metadata changes are in scope.
+11. When implementation is complete but awaiting merge or review, set CSV `status = In Review` when feature metadata changes are in scope.
+12. After merge or explicit user acceptance, set CSV `status = Built`, `decision = keep`, and update `last_updated` when feature metadata changes are in scope.
 
 ## Change Control
 - Do not implement features marked `delay` or `kill`.
 - Do not change `build_order` without explicit user instruction.
-- Do not create new feature rows unless explicitly asked.
+- Do not create new feature rows unless explicitly asked, or unless the user has requested a new feature/system implementation that has no existing PRD/CSV mapping and is classified as `new-feature-or-system`.
 - If a feature is no longer active, set `status = Deprecated`.
 - Update `decision` accordingly if explicitly instructed.
 - Update the CSV in the same PR as the feature work whenever feature state changes.


### PR DESCRIPTION
## Summary

Updates AGENTS.md and documentation routing rules so new feature/system implementation work creates the required canonical PRD and feature-system.csv mapping before or alongside code changes, instead of waiting for release-governance-gate to fail.

## Validation

- python3 scripts/validate-feature-system-csv.py
- python3 scripts/release-governance-gate.py
- git diff --check
