### PR TITLE
Per-card inline depth expansion + bulk composer (refinement to PR #229)

### DIFF
--- a/docs/product/briefs/per-card-depth-and-bulk-composer.md
+++ b/docs/product/briefs/per-card-depth-and-bulk-composer.md
@@ -6,7 +6,7 @@
 
 ## Change Type
 - Remediation / Alignment (per `docs/engineering/templates/llm-prompt-template-change-classification.md`).
-- No new canonical PRD is required. This brief is the supporting governance artifact; the source of truth is PR #229 (visual system v1) plus `DECISIONS.md` D04, D05, and D06.
+- Canonical PRD required: `no`. This brief is the supporting governance artifact; the source of truth is PR #229 (visual system v1) plus `DECISIONS.md` D04, D05, and D06. The audit/remediation lineage is the visual-system-v1 implementation itself, which this work aligns the homepage Signal Card surface and the editorial composer back to.
 
 ## Source of Truth
 - PR #229 — visual system v1 implementation that introduced the four-layer depth structure on `SignalCard` and the `/briefing/[date]` aggregate page.

--- a/docs/product/briefs/per-card-depth-and-bulk-composer.md
+++ b/docs/product/briefs/per-card-depth-and-bulk-composer.md
@@ -1,0 +1,84 @@
+# Per-Card Depth & Bulk Composer — Release Brief
+
+## Objective
+- Complete the visual-system v1 intent shipped in PR #229 by moving Signal Card depth from a per-briefing detail surface into per-card inline expansion on the homepage.
+- Make the editorial composer's approve and publish gates bulk-aware so the editor's per-row friction does not block scaled workflow without losing the two-step approve → publish gate.
+
+## Change Type
+- Remediation / Alignment (per `docs/engineering/templates/llm-prompt-template-change-classification.md`).
+- No new canonical PRD is required. This brief is the supporting governance artifact; the source of truth is PR #229 (visual system v1) plus `DECISIONS.md` D04, D05, and D06.
+
+## Source of Truth
+- PR #229 — visual system v1 implementation that introduced the four-layer depth structure on `SignalCard` and the `/briefing/[date]` aggregate page.
+- `DECISIONS.md` D04 — seven-slot public slate (Top 5 Core + Next 2 Context).
+- `DECISIONS.md` D05 — Explain why it matters; each public Signal needs causal reasoning, not only a summary.
+- `DECISIONS.md` D06 — Separate generation from publication; preserve the approve → publish two-gate workflow.
+
+## Terminology Requirement
+- Read `docs/engineering/BOOTUP_CANONICAL_TERMINOLOGY.md`.
+- Object level modified:
+  - Change 1: **Card** — the UI rendering of a Signal. The underlying Signal identity, ranking, and selection logic are unchanged.
+  - Change 2: **Surface Placement / editorial workflow** — the editorial composer surface that gates which approved Signals become live on the public Surface Placement. Signal identity is unchanged.
+- [x] Confirmed object level before coding: Card (Change 1), Surface Placement / editorial workflow (Change 2).
+- [x] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
+- [x] Legacy naming preserved: `EditorialSignalPost`, `signal_posts` storage table, and the existing server actions are referenced by their canonical names without expansion.
+
+## Scope
+- Per-card inline depth expansion on the homepage Signal Cards.
+  - Each card owns its expansion state and renders an `Expand ↓` / `Collapse ↑` toggle in the footer, replacing the `Read more →` link for top events.
+  - "What happened" depth section renders in sans; "Why this matters", "What led to this", and "What it connects to" render in serif.
+  - "What led to this" renders an italic placeholder when underlying data is empty.
+  - The `/briefing/[date]` route renders all cards expanded by default via `defaultExpanded={true}`.
+  - The compact category cards on the homepage keep the legacy `Read more →` link behavior; they are out of scope.
+- Editorial composer bulk approve + sync publish.
+  - Bulk approve button at the top of the Candidate pool labeled `Approve all WITM-passed`, gated on WITM validator passed + slot assignment + not already approved + storage ready + non-blocking editorial decision.
+  - Slot panel publish summary line: `N approved · M pending publish · K already live`.
+  - Publish slate button label is now dynamic (`Publish N candidates`) and is disabled when zero candidates are pending publish.
+  - Publish slate opens a confirmation dialog showing the total count, tier breakdown, and scrollable title list before the existing `publishFinalSlateAction` server action runs.
+
+## Explicit Exclusions
+- No schema changes. Reuses existing columns (`editorial_status`, `final_slate_rank`, `is_live`, `published_at`, `why_it_matters_validation_status`) and existing server actions (`approveAllSignalPostsAction`, `publishFinalSlateAction` → `publishApprovedSignals`).
+- No WITM validator logic, rewrite flow, or quality-gate logic changes.
+- No authentication, admin role gating, or admin route protection changes.
+- No changes to the visual-system tokens shipped in PR #229 (colors, fonts, spacing).
+- No new vermillion accent in the expanded card state. The Publish all primary action in the confirmation dialog reuses the existing accent role.
+- Compact category Signal Cards on the homepage are intentionally not converted to interactive expansion; that decision can revisit later if engagement data supports it.
+
+## Acceptance Criteria
+- [x] Homepage Signal Card has expand/collapse affordance per card. Affordance is `Expand ↓` / `Collapse ↑` in the card footer.
+- [x] Expanding a card renders four depth sections in order: What happened, Why this matters, What led to this, What it connects to.
+- [x] "What happened" body uses `font-sans` (source-headline treatment); the other three use `font-heading` (serif editorial treatment).
+- [x] "What led to this" renders even when the underlying data is empty, with an italic placeholder in `var(--bu-text-tertiary)`.
+- [x] Expand/collapse is local React state; no URL change occurs.
+- [x] Multiple cards can be expanded simultaneously.
+- [x] `/briefing/[date]` route still works and renders all cards expanded by default.
+- [x] No second vermillion element added to the expanded card state.
+- [x] Editorial composer has `Approve all WITM-passed` button at the top of the Candidate pool.
+- [x] Bulk approve only affects candidates where WITM passed AND the candidate is assigned to a slot.
+- [x] Bulk approve never affects rewrite-flagged candidates.
+- [x] Bulk approve is disabled with a tooltip when zero candidates qualify.
+- [x] Slot panel shows summary line `N approved · M pending publish · K already live` with live counts.
+- [x] Publish slate button is disabled when zero candidates are pending publish.
+- [x] Publish slate triggers a confirmation dialog showing count, tier breakdown, and title list before the server action runs.
+- [x] Confirmation dialog has `Publish all` (vermillion) and `Cancel` (outlined) actions.
+- [x] No schema changes.
+- [x] No WITM validator logic changes.
+- [x] No authentication or role gating changes.
+- [x] Lint, typecheck, build, tests all pass (recorded in PR body).
+
+## Risks
+- Auth or session risk: none. No auth surfaces are touched. No human auth/session validation required for this PR beyond the standard preview smoke.
+- SSR versus client mismatch risk: `SignalCard` is now a client component because it owns local expansion state. Server pages that render `SignalCard` continue to work because Next.js App Router permits server components to import and render client components. Both `homepage.tsx` and `BriefingDetailView.tsx` were already `"use client"` so no SSR boundary regression there. `/signals/page.tsx` renders compact `SignalCard`s through the legacy controlled-expansion path; this also still works.
+- Environment mismatch risk: none. No environment variables, secrets, or config changes.
+- Data edge case risk: empty `What led to this` data renders an italic placeholder by design; empty `What happened` or `What it connects to` sections continue to be suppressed to avoid empty boxes on the card face.
+- Regression risk: medium-low. The `eligibleForApproveAll` prop on `StructuredEditorialFields` is now vestigial after the bulk-approve form lifted up to `EditorialComposerClient`. The prop is preserved in the component contract so existing tests still pass; the `data-approve-all-*` data attributes that the legacy DOM-scrape relied on are removed. A future scoped cleanup can drop the vestigial prop.
+
+## Testing Requirements
+- Local validation: lint, typecheck, unit/integration tests, build, and Playwright Chromium + WebKit smoke runs. Results recorded in the PR body.
+- Preview validation: standard homepage + dashboard route probe after Vercel preview is available.
+- Production sanity: post-merge `/` + `/briefing/[date]` + `/dashboard/signals/editorial-review` smoke check.
+
+## Documentation Updates Required
+- This brief: `docs/product/briefs/per-card-depth-and-bulk-composer.md`.
+- No update to `docs/product/feature-system.csv` — no PRD/feature metadata changed.
+- PR body holds the validation evidence and screenshots.

--- a/src/app/dashboard/signals/editorial-review/ApproveAllButton.test.tsx
+++ b/src/app/dashboard/signals/editorial-review/ApproveAllButton.test.tsx
@@ -1,42 +1,39 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { ApproveAllButton } from "@/app/dashboard/signals/editorial-review/ApproveAllButton";
 
 describe("ApproveAllButton", () => {
-  it("copies current eligible structured editor values into the bulk approval form", () => {
+  it("renders with the WITM-passed label and is enabled when eligible candidates exist", () => {
+    render(<ApproveAllButton disabled={false} />);
+
+    const button = screen.getByRole("button", { name: /Approve all WITM-passed/i });
+    expect(button).toBeEnabled();
+    expect(button).toHaveTextContent("Approve all WITM-passed");
+  });
+
+  it("is disabled and surfaces the provided reason as a tooltip", () => {
     render(
-      <div>
-        <form
-          onSubmit={(event) => {
-            event.preventDefault();
-          }}
-        >
-          <div data-approve-all-fields hidden />
-          <ApproveAllButton disabled={false} />
-        </form>
-        <input data-approve-all-post-id="signal-1" defaultValue="Edited value 1" />
-        <input data-approve-all-post-id="signal-2" defaultValue="Edited value 2" />
-        <input defaultValue="Not eligible" />
-      </div>,
+      <ApproveAllButton
+        disabled
+        disabledReason="No WITM-passed candidates assigned to slots"
+      />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Approve All" }));
+    const button = screen.getByTestId("bulk-approve-submit");
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("title", "No WITM-passed candidates assigned to slots");
+    expect(button).toHaveAttribute(
+      "aria-label",
+      "Approve all WITM-passed — No WITM-passed candidates assigned to slots",
+    );
+  });
 
-    const postIds = screen
-      .getByRole("button", { name: "Approve All" })
-      .form?.querySelectorAll<HTMLInputElement>('input[name="postId"]');
-    const editedValues = screen
-      .getByRole("button", { name: "Approve All" })
-      .form?.querySelectorAll<HTMLInputElement>('input[name="editedWhyItMatters"]');
+  it("omits the tooltip when no reason is provided", () => {
+    render(<ApproveAllButton disabled />);
 
-    expect(Array.from(postIds ?? []).map((input) => input.value)).toEqual([
-      "signal-1",
-      "signal-2",
-    ]);
-    expect(Array.from(editedValues ?? []).map((input) => input.value)).toEqual([
-      "Edited value 1",
-      "Edited value 2",
-    ]);
+    const button = screen.getByTestId("bulk-approve-submit");
+    expect(button).toBeDisabled();
+    expect(button).not.toHaveAttribute("title");
   });
 });

--- a/src/app/dashboard/signals/editorial-review/ApproveAllButton.tsx
+++ b/src/app/dashboard/signals/editorial-review/ApproveAllButton.tsx
@@ -1,67 +1,53 @@
 "use client";
 
-import type { MouseEvent } from "react";
 import { useFormStatus } from "react-dom";
 
 import { Button } from "@/components/ui/button";
 
-export function ApproveAllButton({
-  disabled,
-}: {
+type ApproveAllButtonProps = {
+  /**
+   * When true, the button is rendered in a disabled state regardless of
+   * pending status. Used when the candidate pool has zero rows that
+   * satisfy the bulk-approve gate (WITM passed + slot assigned + not
+   * already approved).
+   */
   disabled: boolean;
-}) {
+  /**
+   * Optional explanatory text rendered as a native tooltip when the
+   * button is disabled. Lets editors see why bulk approve is currently
+   * unavailable without leaving the surface.
+   */
+  disabledReason?: string;
+};
+
+/**
+ * Bulk-approve submit button for the editorial composer Candidate pool.
+ *
+ * Pairs with a parent <form action={approveAllSignalPostsAction}> that
+ * already contains explicit hidden inputs for every candidate that
+ * satisfies the bulk-approve gate. This button does NOT scrape the DOM
+ * for inputs — that legacy behavior was retired when the form moved up
+ * to EditorialComposerClient so bulk approve no longer depends on
+ * per-row rewrite editors being open.
+ *
+ * Label wording — "Approve all WITM-passed" — explicitly names the gate
+ * so editors understand the bulk action is bounded by the WITM
+ * validator and slot-assignment state, not by their UI engagement.
+ */
+export function ApproveAllButton({ disabled, disabledReason }: ApproveAllButtonProps) {
   const { pending } = useFormStatus();
-
-  function populateCurrentEditorialText(event: MouseEvent<HTMLButtonElement>) {
-    const form = event.currentTarget.form;
-    const fieldContainer = form?.querySelector("[data-approve-all-fields]");
-
-    if (!fieldContainer) {
-      return;
-    }
-
-    fieldContainer.replaceChildren();
-
-    document
-      .querySelectorAll<HTMLInputElement>("input[data-approve-all-post-id]")
-      .forEach((input) => {
-        const postId = input.dataset.approveAllPostId;
-
-        if (!postId) {
-          return;
-        }
-
-        const postIdInput = document.createElement("input");
-        postIdInput.type = "hidden";
-        postIdInput.name = "postId";
-        postIdInput.value = postId;
-
-        const editorialInput = document.createElement("input");
-        editorialInput.type = "hidden";
-        editorialInput.name = "editedWhyItMatters";
-        editorialInput.value = input.value;
-
-        fieldContainer.append(postIdInput, editorialInput);
-      });
-
-    document
-      .querySelectorAll<HTMLInputElement>("input[data-approve-all-structured-post-id]")
-      .forEach((input) => {
-        const structuredInput = document.createElement("input");
-        structuredInput.type = "hidden";
-        structuredInput.name = "structuredWhyItMatters";
-        structuredInput.value = input.value;
-
-        fieldContainer.append(structuredInput);
-      });
-  }
+  const isDisabled = pending || disabled;
+  const tooltip = isDisabled && !pending ? disabledReason : undefined;
 
   return (
     <Button
       type="submit"
-      disabled={pending || disabled}
-      className="w-full"
-      onClick={populateCurrentEditorialText}
+      variant="secondary"
+      disabled={isDisabled}
+      className="gap-2"
+      title={tooltip}
+      aria-label={tooltip ? `Approve all WITM-passed — ${tooltip}` : undefined}
+      data-testid="bulk-approve-submit"
     >
       {pending ? (
         <>
@@ -69,7 +55,7 @@ export function ApproveAllButton({
           Approving...
         </>
       ) : (
-        "Approve All"
+        "Approve all WITM-passed"
       )}
     </Button>
   );

--- a/src/app/dashboard/signals/editorial-review/StructuredEditorialFields.tsx
+++ b/src/app/dashboard/signals/editorial-review/StructuredEditorialFields.tsx
@@ -40,6 +40,14 @@ type StructuredEditorialFieldsProps = {
   aiWhyItMatters: string;
   legacyText: string;
   structuredContent: EditorialWhyItMattersContent | null;
+  /**
+   * Vestigial prop. The previous bulk-approve flow scraped this row's
+   * hidden inputs from the DOM when this flag was true. That coupling
+   * was removed when the bulk-approve form moved up to
+   * EditorialComposerClient and started rendering explicit hidden
+   * inputs from React state. The prop is preserved so consumers don't
+   * break; the next scoped cleanup can drop it.
+   */
   eligibleForApproveAll: boolean;
 };
 
@@ -252,7 +260,9 @@ export function StructuredEditorialFields({
   aiWhyItMatters,
   legacyText,
   structuredContent,
-  eligibleForApproveAll,
+  // Vestigial after the bulk-approve refactor; see prop docs above.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  eligibleForApproveAll: _eligibleForApproveAll,
 }: StructuredEditorialFieldsProps) {
   const initialContent =
     structuredContent ?? createEditorialContentFromLegacyText(legacyText || aiWhyItMatters);
@@ -287,14 +297,12 @@ export function StructuredEditorialFields({
         type="hidden"
         name="editedWhyItMatters"
         value={fullEditorialText}
-        data-approve-all-post-id={eligibleForApproveAll ? postId : undefined}
         readOnly
       />
       <input
         type="hidden"
         name="structuredWhyItMatters"
         value={structuredJson}
-        data-approve-all-structured-post-id={eligibleForApproveAll ? postId : undefined}
       />
 
       <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(22rem,0.8fr)]">

--- a/src/app/dashboard/signals/editorial-review/page.test.tsx
+++ b/src/app/dashboard/signals/editorial-review/page.test.tsx
@@ -163,11 +163,20 @@ describe("signals editorial review page", () => {
     expect(screen.getByText(approvedPost.editedWhyItMatters ?? "")).toBeInTheDocument();
     expect(
       screen
-        .getAllByRole("button", { name: /Publish slate/i })
+        .getAllByTestId("publish-slate-open")
         .every((button) => button.hasAttribute("disabled")),
     ).toBe(true);
     expect(screen.queryByText("Published Slate Audit")).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Approve All" })).not.toBeInTheDocument();
+    // Bulk approve is rendered at the top of the candidate pool with the
+    // WITM-passed-bounded label. Neither test post has been assigned to
+    // a slot, so the button is disabled with the documented tooltip.
+    const bulkApproveButton = screen.getByTestId("bulk-approve-submit");
+    expect(bulkApproveButton).toHaveTextContent("Approve all WITM-passed");
+    expect(bulkApproveButton).toBeDisabled();
+    expect(bulkApproveButton).toHaveAttribute(
+      "title",
+      "No WITM-passed candidates assigned to slots",
+    );
   }, 10000);
 
   it("enables the publish CTA when the selected slate passes existing readiness gates", async () => {
@@ -186,11 +195,13 @@ describe("signals editorial review page", () => {
 
     expect(screen.getAllByText("1 / 7").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Approved Signal").length).toBeGreaterThan(0);
-    expect(
-      screen
-        .getAllByRole("button", { name: /Publish slate/i })
-        .every((button) => !button.hasAttribute("disabled")),
-    ).toBe(true);
+    // The Publish slate button is now dynamic — it surfaces the pending
+    // publish count in its label and remains enabled when at least one
+    // approved candidate is awaiting publish.
+    const publishButtons = screen.getAllByTestId("publish-slate-open");
+    expect(publishButtons.length).toBeGreaterThan(0);
+    expect(publishButtons.every((button) => !button.hasAttribute("disabled"))).toBe(true);
+    expect(publishButtons[0]).toHaveTextContent(/Publish 1 candidate/i);
     expect(screen.getAllByText("Sticky · stays visible on scroll").length).toBeGreaterThan(0);
   }, 10000);
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,9 +13,11 @@
   --bu-text-secondary: #5C5C5A;
   --bu-text-tertiary: #8A8A85;
 
-  --bu-accent: #DC4A2F;
-  --bu-accent-soft: rgba(220, 74, 47, 0.08);
-  --bu-accent-hover: #C4391F;
+  /* Vermillion accent — darkened from #DC4A2F so the brand red reads as
+     deep vermillion rather than orange-leaning. Hover deepens further. */
+  --bu-accent: #B23A1F;
+  --bu-accent-soft: rgba(178, 58, 31, 0.08);
+  --bu-accent-hover: #9C2F18;
   --bu-accent-on: #FFFFFF;
 
   --bu-status-success-bg: #E8F2E8;

--- a/src/components/admin/editorial-composer/BulkApproveForm.tsx
+++ b/src/components/admin/editorial-composer/BulkApproveForm.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { approveAllSignalPostsAction } from "@/app/dashboard/signals/editorial-review/actions";
+import { ApproveAllButton } from "@/app/dashboard/signals/editorial-review/ApproveAllButton";
+import type { EditorialSignalPost } from "@/lib/signals-editorial";
+
+type BulkApproveFormProps = {
+  /**
+   * Candidates that satisfy the bulk-approve gate:
+   *   - WITM validator status === "passed"
+   *   - assigned to a final-slate slot
+   *   - not already in approved or published state
+   *   - editorial decision is not blocking (rejected / held / etc.)
+   *   - storage is ready
+   *
+   * Filtering happens in EditorialComposerClient so this component
+   * stays render-only and predictable to test.
+   */
+  eligibleCandidates: EditorialSignalPost[];
+  /**
+   * Disabled tooltip surfaced on the submit button when there are zero
+   * eligible candidates. Explicitly names the gate to mirror the button
+   * label.
+   */
+  disabledReason?: string;
+};
+
+/**
+ * Bulk approve form rendered at the top of the candidate pool in the
+ * editorial composer. Submits one POST to `approveAllSignalPostsAction`
+ * containing explicit hidden inputs per eligible candidate.
+ *
+ * The previous implementation collected hidden inputs from individually
+ * expanded SignalPostEditor rewrite editors via DOM scraping, which
+ * coupled the bulk action to per-row UI engagement. Lifting the form
+ * up here makes the bulk action operate on the full candidate pool
+ * state — exactly the "approve every WITM-passed candidate in the
+ * pool" semantic the workflow needs.
+ */
+export function BulkApproveForm({
+  eligibleCandidates,
+  disabledReason,
+}: BulkApproveFormProps) {
+  const hasEligible = eligibleCandidates.length > 0;
+  const resolvedDisabledReason = hasEligible
+    ? undefined
+    : disabledReason ?? "No WITM-passed candidates assigned to slots";
+
+  return (
+    <form
+      action={approveAllSignalPostsAction}
+      className="mb-[var(--bu-space-4)] flex flex-wrap items-center justify-between gap-3 rounded-[var(--bu-radius-lg)] border border-[var(--bu-border-subtle)] bg-[var(--bu-bg-surface)] p-[var(--bu-space-3)]"
+      data-testid="bulk-approve-form"
+    >
+      <div className="min-w-0">
+        <p className="text-[var(--bu-size-meta)] font-medium text-[var(--bu-text-primary)]">
+          Bulk approve
+        </p>
+        <p className="mt-1 text-[var(--bu-size-micro)] leading-5 text-[var(--bu-text-secondary)]">
+          {hasEligible
+            ? `${eligibleCandidates.length} ${eligibleCandidates.length === 1 ? "candidate" : "candidates"} ready · WITM passed and assigned to a slot`
+            : "No WITM-passed candidates currently assigned to a slot."}
+        </p>
+      </div>
+
+      {eligibleCandidates.map((candidate) => (
+        <CandidateHiddenInputs key={candidate.id} candidate={candidate} />
+      ))}
+
+      <ApproveAllButton disabled={!hasEligible} disabledReason={resolvedDisabledReason} />
+    </form>
+  );
+}
+
+function CandidateHiddenInputs({ candidate }: { candidate: EditorialSignalPost }) {
+  const persistedEditorialText =
+    candidate.editedWhyItMatters ?? candidate.publishedWhyItMatters ?? candidate.aiWhyItMatters ?? "";
+  const structuredContent =
+    candidate.editedWhyItMattersStructured ?? candidate.publishedWhyItMattersStructured ?? null;
+  const structuredJson = structuredContent ? JSON.stringify(structuredContent) : "";
+
+  return (
+    <>
+      <input
+        type="hidden"
+        name="postId"
+        value={candidate.id}
+        data-testid={`bulk-approve-post-id-${candidate.id}`}
+      />
+      <input type="hidden" name="editedWhyItMatters" value={persistedEditorialText} />
+      <input type="hidden" name="structuredWhyItMatters" value={structuredJson} />
+    </>
+  );
+}
+
+/**
+ * Pure predicate used by the parent EditorialComposerClient to compute
+ * the eligible-candidates list. Exported here so the gate is tested
+ * alongside the form that renders it.
+ */
+export function isEligibleForBulkApprove(
+  candidate: EditorialSignalPost,
+  storageReady: boolean,
+): boolean {
+  return (
+    storageReady &&
+    candidate.persisted &&
+    candidate.finalSlateRank !== null &&
+    candidate.whyItMattersValidationStatus === "passed" &&
+    candidate.editorialStatus !== "approved" &&
+    candidate.editorialStatus !== "published" &&
+    !candidate.isLive &&
+    !candidate.publishedAt &&
+    !isBlockingDecision(candidate.editorialDecision)
+  );
+}
+
+function isBlockingDecision(decision: string | null) {
+  return (
+    decision === "rejected" ||
+    decision === "held" ||
+    decision === "rewrite_requested" ||
+    decision === "removed_from_slate"
+  );
+}

--- a/src/components/admin/editorial-composer/EditorialComposerClient.tsx
+++ b/src/components/admin/editorial-composer/EditorialComposerClient.tsx
@@ -4,8 +4,16 @@ import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { assignFinalSlateSlotInlineAction } from "@/app/dashboard/signals/editorial-review/actions";
+import {
+  BulkApproveForm,
+  isEligibleForBulkApprove,
+} from "@/components/admin/editorial-composer/BulkApproveForm";
 import { CandidateRow } from "@/components/admin/editorial-composer/CandidateRow";
-import { SlotPanel, type ComposerSlot } from "@/components/admin/editorial-composer/SlotPanel";
+import {
+  SlotPanel,
+  type ComposerSlot,
+  type PublishCounts,
+} from "@/components/admin/editorial-composer/SlotPanel";
 import {
   FINAL_SLATE_RANKS,
   getFinalSlateTierForRank,
@@ -32,6 +40,22 @@ export function EditorialComposerClient({
   const readiness = useMemo(() => validateFinalSlateReadiness(localCandidates), [localCandidates]);
   const slots = useMemo(() => buildSlots(localCandidates), [localCandidates]);
   const openSlots = slots.filter((slot) => !slot.post).map((slot) => slot.rank);
+
+  const bulkApproveCandidates = useMemo(
+    () => localCandidates.filter((candidate) => isEligibleForBulkApprove(candidate, storageReady)),
+    [localCandidates, storageReady],
+  );
+
+  const publishCounts = useMemo<PublishCounts>(
+    () => computePublishCounts(localCandidates),
+    [localCandidates],
+  );
+
+  const pendingPublishCandidates = useMemo(
+    () => localCandidates.filter(isPendingPublishCandidate),
+    [localCandidates],
+  );
+
   const effectivePublishDisabledReason =
     !storageReady
       ? "Publishing is blocked until editorial storage is configured."
@@ -80,6 +104,8 @@ export function EditorialComposerClient({
         slots={slots}
         canPublish={canPublish}
         publishDisabledReason={effectivePublishDisabledReason}
+        publishCounts={publishCounts}
+        pendingPublishCandidates={pendingPublishCandidates}
       />
 
       <div className="min-w-0">
@@ -93,6 +119,8 @@ export function EditorialComposerClient({
             {localCandidates.length} reviewable · {localCandidates.filter((candidate) => !candidate.finalSlateRank).length} unassigned
           </p>
         </div>
+
+        <BulkApproveForm eligibleCandidates={bulkApproveCandidates} />
 
         {inlineError ? (
           <p className="mb-[var(--bu-space-3)] rounded-[var(--bu-radius-md)] bg-[var(--bu-status-danger-bg)] px-3 py-2 text-[var(--bu-size-meta)] text-[var(--bu-status-danger-text)]">
@@ -128,4 +156,38 @@ function buildSlots(candidates: EditorialSignalPost[]): ComposerSlot[] {
     tier: getFinalSlateTierForRank(rank) ?? "core",
     post: candidates.find((candidate) => candidate.finalSlateRank === rank) ?? null,
   }));
+}
+
+function isPendingPublishCandidate(candidate: EditorialSignalPost) {
+  // "Pending publish" = approved by an editor but not yet pushed live.
+  // This is the slice the bulk Publish slate confirm dialog acts on.
+  return (
+    candidate.editorialStatus === "approved" &&
+    candidate.finalSlateRank !== null &&
+    !candidate.isLive &&
+    !candidate.publishedAt
+  );
+}
+
+function isLiveCandidate(candidate: EditorialSignalPost) {
+  // "Already live" = currently published to the public surface. We
+  // intentionally count both the runtime `isLive` flag and the
+  // persisted `publishedAt` timestamp so the summary stays honest if
+  // either signal is set on its own.
+  return (
+    candidate.isLive ||
+    Boolean(candidate.publishedAt) ||
+    candidate.editorialStatus === "published"
+  );
+}
+
+function isApprovedCandidate(candidate: EditorialSignalPost) {
+  return candidate.editorialStatus === "approved";
+}
+
+function computePublishCounts(candidates: EditorialSignalPost[]): PublishCounts {
+  const approved = candidates.filter(isApprovedCandidate).length;
+  const pendingPublish = candidates.filter(isPendingPublishCandidate).length;
+  const alreadyLive = candidates.filter(isLiveCandidate).length;
+  return { approved, pendingPublish, alreadyLive };
 }

--- a/src/components/admin/editorial-composer/PublishConfirmDialog.tsx
+++ b/src/components/admin/editorial-composer/PublishConfirmDialog.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect } from "react";
+import { Send } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type { EditorialSignalPost } from "@/lib/signals-editorial";
+
+type PublishConfirmDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  /**
+   * Candidates that will actually be published when the user confirms.
+   * The parent SlotPanel filters down to approved-but-not-yet-published
+   * rows. The dialog only displays them; the publishFinalSlateAction
+   * server action still drives the actual publish, gated server-side.
+   */
+  pendingPublishCandidates: EditorialSignalPost[];
+  /**
+   * Inline submit-confirm trigger. Pressed by the dialog's "Publish all"
+   * button to actually run publishFinalSlateAction. SlotPanel keeps the
+   * form wired so this stays the existing server action with the
+   * existing eligibility gate.
+   */
+  onConfirm: () => void;
+};
+
+/**
+ * Two-step confirm overlay for the Publish slate action.
+ *
+ * Sits between the Publish button and `publishFinalSlateAction` so an
+ * editor sees a count + tier breakdown + title list before pushing
+ * approved candidates live. This preserves the two-gate workflow
+ * (approve, then publish) while making the publish step bulk-aware
+ * and reversible up to the explicit confirmation click.
+ *
+ * Built as a lightweight fixed-position overlay (no portal) to match
+ * the existing AuthModal pattern in this repo. If a shared Dialog
+ * primitive is introduced later, this component should migrate to it.
+ */
+export function PublishConfirmDialog({
+  open,
+  onClose,
+  pendingPublishCandidates,
+  onConfirm,
+}: PublishConfirmDialogProps) {
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  if (!open) {
+    return null;
+  }
+
+  const total = pendingPublishCandidates.length;
+  const coreCount = pendingPublishCandidates.filter(
+    (post) => post.finalSlateTier === "core",
+  ).length;
+  const contextCount = pendingPublishCandidates.filter(
+    (post) => post.finalSlateTier === "context",
+  ).length;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="publish-confirm-title"
+      data-testid="publish-confirm-dialog"
+    >
+      <div className="w-full max-w-md rounded-[var(--bu-radius-lg)] border border-[var(--bu-border-subtle)] bg-[var(--bu-bg-surface)] p-[var(--bu-space-5)] shadow-xl">
+        <h2
+          id="publish-confirm-title"
+          className="text-[var(--bu-size-ui)] font-medium text-[var(--bu-text-primary)]"
+        >
+          Publish this slate?
+        </h2>
+        <p className="mt-2 text-[var(--bu-size-meta)] leading-5 text-[var(--bu-text-secondary)]">
+          {total} {total === 1 ? "candidate" : "candidates"} will be published live.
+        </p>
+        <p
+          className="mt-1 text-[var(--bu-size-micro)] leading-5 text-[var(--bu-text-tertiary)]"
+          data-testid="publish-confirm-tier-breakdown"
+        >
+          {coreCount} Core · {contextCount} Context
+        </p>
+
+        <ul
+          className="mt-[var(--bu-space-4)] max-h-48 space-y-1 overflow-y-auto rounded-[var(--bu-radius-md)] border border-[var(--bu-border-subtle)] bg-[var(--bu-bg-subtle)] p-[var(--bu-space-3)]"
+          data-testid="publish-confirm-title-list"
+        >
+          {pendingPublishCandidates.map((post) => (
+            <li
+              key={post.id}
+              className="text-[var(--bu-size-meta)] leading-5 text-[var(--bu-text-primary)]"
+            >
+              <span className="mr-2 text-[var(--bu-text-tertiary)]">
+                {post.finalSlateRank
+                  ? post.finalSlateRank.toString().padStart(2, "0")
+                  : "--"}
+              </span>
+              {post.title}
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-[var(--bu-space-5)] flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={onClose}
+            autoFocus
+            data-testid="publish-confirm-cancel"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={onConfirm}
+            className="gap-2"
+            data-testid="publish-confirm-submit"
+          >
+            <Send className="h-4 w-4" aria-hidden="true" />
+            Publish all
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/editorial-composer/SlotPanel.tsx
+++ b/src/components/admin/editorial-composer/SlotPanel.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useRef, useState } from "react";
 import { Send } from "lucide-react";
 
 import { publishFinalSlateAction } from "@/app/dashboard/signals/editorial-review/actions";
+import { PublishConfirmDialog } from "@/components/admin/editorial-composer/PublishConfirmDialog";
 import { Button } from "@/components/ui/button";
 import type { EditorialSignalPost } from "@/lib/signals-editorial";
 import { cn } from "@/lib/utils";
@@ -13,13 +15,41 @@ export type ComposerSlot = {
   post: EditorialSignalPost | null;
 };
 
+export type PublishCounts = {
+  /** Candidates currently in the "approved" editorial state. */
+  approved: number;
+  /** Subset of approved that are not yet live (pending publish). */
+  pendingPublish: number;
+  /** Candidates already published / live. */
+  alreadyLive: number;
+};
+
 type SlotPanelProps = {
   slots: ComposerSlot[];
   canPublish: boolean;
   publishDisabledReason?: string | null;
+  /**
+   * Live counts shown above the Publish slate button so the editor can
+   * see, at a glance, what the slate looks like before the confirm
+   * dialog opens. Optional to preserve existing test fixtures.
+   */
+  publishCounts?: PublishCounts;
+  /**
+   * Approved-but-not-yet-published candidates. Drives the confirm
+   * dialog count, tier breakdown, and title list. Optional for
+   * backward compatibility with tests that only exercise the slot
+   * rendering and disabled-state behavior.
+   */
+  pendingPublishCandidates?: EditorialSignalPost[];
 };
 
-export function SlotPanel({ slots, canPublish, publishDisabledReason }: SlotPanelProps) {
+export function SlotPanel({
+  slots,
+  canPublish,
+  publishDisabledReason,
+  publishCounts,
+  pendingPublishCandidates,
+}: SlotPanelProps) {
   const filledCount = slots.filter((slot) => slot.post).length;
   const coreSlots = slots.filter((slot) => slot.tier === "core");
   const contextSlots = slots.filter((slot) => slot.tier === "context");
@@ -38,6 +68,8 @@ export function SlotPanel({ slots, canPublish, publishDisabledReason }: SlotPane
           contextSlots={contextSlots}
           canPublish={canPublish}
           publishDisabledReason={publishDisabledReason}
+          publishCounts={publishCounts}
+          pendingPublishCandidates={pendingPublishCandidates}
         />
       </details>
 
@@ -56,6 +88,8 @@ export function SlotPanel({ slots, canPublish, publishDisabledReason }: SlotPane
           contextSlots={contextSlots}
           canPublish={canPublish}
           publishDisabledReason={publishDisabledReason}
+          publishCounts={publishCounts}
+          pendingPublishCandidates={pendingPublishCandidates}
         />
       </aside>
     </>
@@ -67,11 +101,15 @@ function SlotPanelBody({
   contextSlots,
   canPublish,
   publishDisabledReason,
+  publishCounts,
+  pendingPublishCandidates,
 }: {
   coreSlots: ComposerSlot[];
   contextSlots: ComposerSlot[];
   canPublish: boolean;
   publishDisabledReason?: string | null;
+  publishCounts?: PublishCounts;
+  pendingPublishCandidates?: EditorialSignalPost[];
 }) {
   return (
     <>
@@ -79,16 +117,87 @@ function SlotPanelBody({
         <SlotGroup label="Core · 5 slots" slots={coreSlots} />
         <SlotGroup label="Context · 2 slots" slots={contextSlots} />
       </div>
-      <form action={publishFinalSlateAction} className="mt-[var(--bu-space-5)] space-y-[var(--bu-space-2)]">
-        <Button type="submit" disabled={!canPublish} className="w-full gap-2">
-          <Send className="h-4 w-4" aria-hidden="true" />
-          Publish slate
-        </Button>
-        <p className="text-[var(--bu-size-micro)] leading-5 text-[var(--bu-text-tertiary)]">
-          {publishDisabledReason ?? "Sticky · stays visible on scroll"}
+      {publishCounts ? (
+        <p
+          className="mt-[var(--bu-space-4)] text-[var(--bu-size-micro)] leading-5 text-[var(--bu-text-secondary)]"
+          data-testid="publish-summary"
+        >
+          {publishCounts.approved} approved · {publishCounts.pendingPublish} pending publish · {publishCounts.alreadyLive} already live
         </p>
-      </form>
+      ) : null}
+      <PublishSlateControls
+        canPublish={canPublish}
+        publishDisabledReason={publishDisabledReason}
+        publishCounts={publishCounts}
+        pendingPublishCandidates={pendingPublishCandidates ?? []}
+      />
     </>
+  );
+}
+
+function PublishSlateControls({
+  canPublish,
+  publishDisabledReason,
+  publishCounts,
+  pendingPublishCandidates,
+}: {
+  canPublish: boolean;
+  publishDisabledReason?: string | null;
+  publishCounts?: PublishCounts;
+  pendingPublishCandidates: EditorialSignalPost[];
+}) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const formRef = useRef<HTMLFormElement | null>(null);
+  const pendingCount = publishCounts?.pendingPublish ?? pendingPublishCandidates.length;
+  const hasPending = pendingCount > 0;
+  const isDisabled = !canPublish || !hasPending;
+  const buttonLabel = hasPending ? `Publish ${pendingCount} candidates` : "Publish slate";
+  const helperText = !hasPending && canPublish
+    ? "No approved candidates pending publish."
+    : publishDisabledReason ?? "Sticky · stays visible on scroll";
+
+  function openConfirm() {
+    if (isDisabled) {
+      return;
+    }
+    setConfirmOpen(true);
+  }
+
+  function handleConfirmPublish() {
+    // Trigger the form submission so publishFinalSlateAction runs with
+    // the existing server-side eligibility gate. Using a ref keeps the
+    // mobile-drawer / desktop-aside double render correct because each
+    // instance owns its own form node.
+    formRef.current?.requestSubmit();
+    setConfirmOpen(false);
+  }
+
+  return (
+    <form
+      ref={formRef}
+      action={publishFinalSlateAction}
+      className="mt-[var(--bu-space-5)] space-y-[var(--bu-space-2)]"
+    >
+      <Button
+        type="button"
+        disabled={isDisabled}
+        onClick={openConfirm}
+        className="w-full gap-2"
+        data-testid="publish-slate-open"
+      >
+        <Send className="h-4 w-4" aria-hidden="true" />
+        {buttonLabel}
+      </Button>
+      <p className="text-[var(--bu-size-micro)] leading-5 text-[var(--bu-text-tertiary)]">
+        {helperText}
+      </p>
+      <PublishConfirmDialog
+        open={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        pendingPublishCandidates={pendingPublishCandidates}
+        onConfirm={handleConfirmPublish}
+      />
+    </form>
   );
 }
 

--- a/src/components/admin/editorial-composer/editorial-composer-components.test.tsx
+++ b/src/components/admin/editorial-composer/editorial-composer-components.test.tsx
@@ -1,11 +1,19 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+import {
+  BulkApproveForm,
+  isEligibleForBulkApprove,
+} from "@/components/admin/editorial-composer/BulkApproveForm";
 import { CandidateRow } from "@/components/admin/editorial-composer/CandidateRow";
-import { SlotPanel, type ComposerSlot } from "@/components/admin/editorial-composer/SlotPanel";
+import {
+  SlotPanel,
+  type ComposerSlot,
+} from "@/components/admin/editorial-composer/SlotPanel";
 import type { EditorialSignalPost } from "@/lib/signals-editorial";
 
 vi.mock("@/app/dashboard/signals/editorial-review/actions", () => ({
+  approveAllSignalPostsAction: vi.fn(),
   publishFinalSlateAction: vi.fn(),
   saveSignalDraftAction: vi.fn(),
   approveSignalPostAction: vi.fn(),
@@ -67,7 +75,14 @@ describe("editorial composer components", () => {
       { rank: 6, tier: "context", post: createCandidate({ title: "Assigned context" }) },
     ];
 
-    render(<SlotPanel slots={slots} canPublish publishDisabledReason={null} />);
+    render(
+      <SlotPanel
+        slots={slots}
+        canPublish
+        publishDisabledReason={null}
+        publishCounts={{ approved: 2, pendingPublish: 2, alreadyLive: 0 }}
+      />,
+    );
 
     expect(screen.getAllByText("Final slate").length).toBeGreaterThan(0);
     expect(screen.getAllByText("2 / 7").length).toBeGreaterThan(0);
@@ -75,7 +90,7 @@ describe("editorial composer components", () => {
     expect(screen.getAllByText("Empty").length).toBeGreaterThan(0);
     expect(
       screen
-        .getAllByRole("button", { name: /Publish slate/i })
+        .getAllByTestId("publish-slate-open")
         .every((button) => !button.hasAttribute("disabled")),
     ).toBe(true);
   });
@@ -102,10 +117,129 @@ describe("editorial composer components", () => {
 
     expect(
       screen
-        .getAllByRole("button", { name: /Publish slate/i })
+        .getAllByTestId("publish-slate-open")
         .every((button) => button.hasAttribute("disabled")),
     ).toBe(true);
     expect(screen.getAllByText("Cannot publish an empty slate.").length).toBeGreaterThan(0);
+  });
+
+  it("disables publish when nothing is pending publish even if other readiness gates pass", () => {
+    render(
+      <SlotPanel
+        slots={[{ rank: 1, tier: "core", post: createCandidate({ title: "Live" }) }]}
+        canPublish
+        publishDisabledReason={null}
+        publishCounts={{ approved: 0, pendingPublish: 0, alreadyLive: 1 }}
+      />,
+    );
+
+    expect(
+      screen
+        .getAllByTestId("publish-slate-open")
+        .every((button) => button.hasAttribute("disabled")),
+    ).toBe(true);
+    expect(
+      screen.getAllByText("No approved candidates pending publish.").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("renders the publish summary line with live counts", () => {
+    render(
+      <SlotPanel
+        slots={[{ rank: 1, tier: "core", post: null }]}
+        canPublish
+        publishCounts={{ approved: 4, pendingPublish: 3, alreadyLive: 1 }}
+      />,
+    );
+
+    const summaries = screen.getAllByTestId("publish-summary");
+    expect(summaries.length).toBeGreaterThan(0);
+    expect(summaries[0]).toHaveTextContent("4 approved · 3 pending publish · 1 already live");
+  });
+
+  it("uses the pending-publish count in the dynamic button label", () => {
+    render(
+      <SlotPanel
+        slots={[{ rank: 1, tier: "core", post: createCandidate() }]}
+        canPublish
+        publishCounts={{ approved: 3, pendingPublish: 3, alreadyLive: 0 }}
+      />,
+    );
+
+    expect(
+      screen
+        .getAllByTestId("publish-slate-open")
+        .every((button) => button.textContent?.includes("Publish 3 candidates")),
+    ).toBe(true);
+  });
+
+  it("opens the confirm dialog with title list and tier breakdown when Publish is clicked", () => {
+    const pending = [
+      createCandidate({
+        id: "p1",
+        title: "Core candidate one",
+        finalSlateRank: 1,
+        finalSlateTier: "core",
+      }),
+      createCandidate({
+        id: "p2",
+        title: "Context candidate one",
+        finalSlateRank: 6,
+        finalSlateTier: "context",
+      }),
+    ];
+
+    render(
+      <SlotPanel
+        slots={[
+          { rank: 1, tier: "core", post: pending[0] },
+          { rank: 6, tier: "context", post: pending[1] },
+        ]}
+        canPublish
+        publishCounts={{ approved: 2, pendingPublish: 2, alreadyLive: 0 }}
+        pendingPublishCandidates={pending}
+      />,
+    );
+
+    expect(screen.queryByTestId("publish-confirm-dialog")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByTestId("publish-slate-open")[0]);
+
+    const dialog = screen.getByTestId("publish-confirm-dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByTestId("publish-confirm-tier-breakdown")).toHaveTextContent(
+      "1 Core · 1 Context",
+    );
+    const titleList = within(dialog).getByTestId("publish-confirm-title-list");
+    expect(titleList).toHaveTextContent("Core candidate one");
+    expect(titleList).toHaveTextContent("Context candidate one");
+  });
+
+  it("closes the confirm dialog when Cancel is pressed without submitting", () => {
+    const pending = [
+      createCandidate({
+        id: "p1",
+        title: "Core candidate",
+        finalSlateRank: 1,
+        finalSlateTier: "core",
+      }),
+    ];
+
+    render(
+      <SlotPanel
+        slots={[{ rank: 1, tier: "core", post: pending[0] }]}
+        canPublish
+        publishCounts={{ approved: 1, pendingPublish: 1, alreadyLive: 0 }}
+        pendingPublishCandidates={pending}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByTestId("publish-slate-open")[0]);
+    expect(screen.getByTestId("publish-confirm-dialog")).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByTestId("publish-confirm-cancel")[0]);
+
+    expect(screen.queryByTestId("publish-confirm-dialog")).not.toBeInTheDocument();
   });
 
   it("shows WITM inline and assigns a candidate through the picker", () => {
@@ -146,5 +280,158 @@ describe("editorial composer components", () => {
     expect(screen.getByText("Needs rewrite")).toBeInTheDocument();
     expect(screen.getByText(/Template placeholder language detected/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Assign Candidate title to a slot/i)).toBeDisabled();
+  });
+});
+
+describe("BulkApproveForm", () => {
+  it("renders the WITM-passed label and a hidden input per eligible candidate", () => {
+    const candidates = [
+      createCandidate({
+        id: "ready-1",
+        title: "Ready candidate 1",
+        finalSlateRank: 1,
+        editorialStatus: "needs_review",
+        editorialDecision: null,
+      }),
+      createCandidate({
+        id: "ready-2",
+        title: "Ready candidate 2",
+        finalSlateRank: 2,
+        editorialStatus: "draft",
+        editorialDecision: null,
+      }),
+    ];
+
+    render(<BulkApproveForm eligibleCandidates={candidates} />);
+
+    expect(screen.getByText(/2 candidates ready/i)).toBeInTheDocument();
+
+    const button = screen.getByTestId("bulk-approve-submit");
+    expect(button).toBeEnabled();
+    expect(button).toHaveTextContent("Approve all WITM-passed");
+
+    const form = screen.getByTestId("bulk-approve-form") as HTMLFormElement;
+    const postIdInputs = form.querySelectorAll('input[name="postId"]');
+    expect(Array.from(postIdInputs).map((input) => (input as HTMLInputElement).value)).toEqual([
+      "ready-1",
+      "ready-2",
+    ]);
+  });
+
+  it("renders disabled with the expected tooltip when zero candidates qualify", () => {
+    render(<BulkApproveForm eligibleCandidates={[]} />);
+
+    const button = screen.getByTestId("bulk-approve-submit");
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("title", "No WITM-passed candidates assigned to slots");
+    expect(
+      screen.getByText("No WITM-passed candidates currently assigned to a slot."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("isEligibleForBulkApprove", () => {
+  it("requires WITM passed status", () => {
+    expect(
+      isEligibleForBulkApprove(
+        createCandidate({
+          editorialStatus: "needs_review",
+          editorialDecision: null,
+          finalSlateRank: 1,
+          whyItMattersValidationStatus: "requires_human_rewrite",
+        }),
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it("requires a slot assignment", () => {
+    expect(
+      isEligibleForBulkApprove(
+        createCandidate({
+          editorialStatus: "needs_review",
+          editorialDecision: null,
+          finalSlateRank: null,
+          whyItMattersValidationStatus: "passed",
+        }),
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it("excludes already-approved candidates", () => {
+    expect(
+      isEligibleForBulkApprove(
+        createCandidate({
+          editorialStatus: "approved",
+          editorialDecision: "approved",
+          finalSlateRank: 1,
+          whyItMattersValidationStatus: "passed",
+        }),
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it("excludes published / live candidates", () => {
+    expect(
+      isEligibleForBulkApprove(
+        createCandidate({
+          editorialStatus: "published",
+          editorialDecision: "approved",
+          finalSlateRank: 1,
+          whyItMattersValidationStatus: "passed",
+          isLive: true,
+          publishedAt: "2026-05-13T12:00:00.000Z",
+        }),
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it("excludes candidates with blocking editorial decisions", () => {
+    for (const blocking of ["rejected", "held", "rewrite_requested", "removed_from_slate"]) {
+      expect(
+        isEligibleForBulkApprove(
+          createCandidate({
+            editorialStatus: "needs_review",
+            editorialDecision: blocking,
+            finalSlateRank: 1,
+            whyItMattersValidationStatus: "passed",
+          }),
+          true,
+        ),
+      ).toBe(false);
+    }
+  });
+
+  it("requires storage to be ready", () => {
+    expect(
+      isEligibleForBulkApprove(
+        createCandidate({
+          editorialStatus: "needs_review",
+          editorialDecision: null,
+          finalSlateRank: 1,
+          whyItMattersValidationStatus: "passed",
+        }),
+        false,
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true for the happy path", () => {
+    expect(
+      isEligibleForBulkApprove(
+        createCandidate({
+          editorialStatus: "needs_review",
+          editorialDecision: null,
+          finalSlateRank: 1,
+          whyItMattersValidationStatus: "passed",
+          isLive: false,
+          publishedAt: null,
+        }),
+        true,
+      ),
+    ).toBe(true);
   });
 });

--- a/src/components/briefing/BriefingDetailView.tsx
+++ b/src/components/briefing/BriefingDetailView.tsx
@@ -70,7 +70,7 @@ export function BriefingDetailView({
               signal={event}
               rank={index + 1}
               tier="core"
-              expanded
+              defaultExpanded
             />
           ))}
         </div>

--- a/src/components/home/CategoryTabStrip.tsx
+++ b/src/components/home/CategoryTabStrip.tsx
@@ -129,11 +129,14 @@ export function CategoryTabStrip({
   return (
     <Tabs className={className}>
       {demoted ? (
-        <div className="flex flex-wrap items-center gap-x-[var(--bu-space-5)] gap-y-[var(--bu-space-2)]">
-          <p className="text-[var(--bu-size-micro)] font-medium uppercase tracking-[0.08em] text-[var(--bu-text-tertiary)]">
-            Browse by
-          </p>
-          <div className="flex flex-wrap items-center gap-[var(--bu-space-5)]">
+        <div className="space-y-[var(--bu-space-3)]">
+          <h2
+            className="text-[var(--bu-size-card-title-mobile)] font-medium leading-tight tracking-[-0.015em] text-[var(--bu-text-primary)] md:text-[var(--bu-size-card-title)]"
+            data-testid="browse-by-heading"
+          >
+            Browse by category
+          </h2>
+          <div className="flex flex-wrap items-center gap-x-[var(--bu-space-5)] gap-y-[var(--bu-space-2)]">
             {tabs.map((tab) => (
               <button
                 key={tab.key}
@@ -144,7 +147,7 @@ export function CategoryTabStrip({
                 className={cn(
                   "text-[var(--bu-size-ui)] leading-5 transition-colors",
                   safeActiveTab === tab.key
-                    ? "font-medium text-[var(--bu-text-primary)]"
+                    ? "font-medium text-[var(--bu-text-primary)] underline decoration-[var(--bu-accent)] decoration-2 underline-offset-[6px]"
                     : "font-normal text-[var(--bu-text-secondary)] hover:text-[var(--bu-accent)]",
                 )}
                 aria-controls={`${tab.key}-panel`}

--- a/src/components/landing/homepage.test.tsx
+++ b/src/components/landing/homepage.test.tsx
@@ -137,20 +137,25 @@ describe("LandingHomepage", () => {
     expect(cards).toHaveLength(5);
     expect(within(cards[0]).getByText("Core signal · 01")).toBeInTheDocument();
     expect(within(cards[4]).getByText("Core signal · 05")).toBeInTheDocument();
-    expect(within(cards[0]).getByText("Why this matters")).toBeInTheDocument();
-    expect(within(cards[0]).getByTestId("signal-why-this-matters")).toHaveClass("line-clamp-2");
-    // Per-card inline depth expansion: top events no longer link out to
-    // /briefing/<date>; they expand in place. The Expand toggle replaces
-    // the previous Read more link.
+    // "Why this matters" appears twice when the card is expanded — once
+    // above the toggle as the collapsed-preview label, once below as
+    // the editorial depth-section label. Both are expected on the
+    // homepage now that cards land expanded by default.
+    expect(within(cards[0]).getAllByText("Why this matters").length).toBeGreaterThan(0);
+    // Per-card inline depth expansion: top events expand in place rather
+    // than linking out, and they now land already expanded on the
+    // homepage so the depth is visible at first glance. The footer
+    // toggle is therefore in its Collapse state.
     expect(within(cards[0]).queryByRole("link", { name: "Read more →" })).toBeNull();
-    expect(within(cards[0]).getByTestId("signal-card-toggle")).toHaveAccessibleName(/expand/i);
+    expect(within(cards[0]).getByTestId("signal-card-toggle")).toHaveAccessibleName(/collapse/i);
+    expect(cards[0]).toHaveAttribute("data-signal-expanded", "true");
     expect(within(cards[0]).queryByText(/min read/i)).not.toBeInTheDocument();
     expect(within(cards[0]).queryByText("Details")).not.toBeInTheDocument();
     expect(within(cards[0]).queryByText("Tech")).not.toBeInTheDocument();
     expect(within(cards[0]).queryByText("Point one")).not.toBeInTheDocument();
   });
 
-  it("expands a Signal Card in place when the Expand toggle is clicked", () => {
+  it("renders homepage Signal Cards expanded by default and supports collapse / re-expand in place", () => {
     const data = createData([
       createItem({
         id: "top-1",
@@ -163,21 +168,21 @@ describe("LandingHomepage", () => {
     renderHomepage(data);
 
     const card = screen.getAllByTestId("signal-card")[0];
-    expect(card).toHaveAttribute("data-signal-expanded", "false");
-    expect(within(card).queryByText("What happened")).not.toBeInTheDocument();
-
-    const toggle = within(card).getByTestId("signal-card-toggle");
-    expect(toggle).toHaveAccessibleName(/expand/i);
-
-    fireEvent.click(toggle);
-
     expect(card).toHaveAttribute("data-signal-expanded", "true");
     expect(within(card).getByText("What happened")).toBeInTheDocument();
     expect(within(card).getByText("What led to this")).toBeInTheDocument();
+
+    const toggle = within(card).getByTestId("signal-card-toggle");
     expect(toggle).toHaveAccessibleName(/collapse/i);
 
     fireEvent.click(toggle);
+
     expect(card).toHaveAttribute("data-signal-expanded", "false");
+    expect(within(card).queryByText("What happened")).not.toBeInTheDocument();
+    expect(toggle).toHaveAccessibleName(/expand/i);
+
+    fireEvent.click(toggle);
+    expect(card).toHaveAttribute("data-signal-expanded", "true");
   });
 
   it("uses the supplied homepage model instead of raw briefing items", () => {

--- a/src/components/landing/homepage.test.tsx
+++ b/src/components/landing/homepage.test.tsx
@@ -139,14 +139,45 @@ describe("LandingHomepage", () => {
     expect(within(cards[4]).getByText("Core signal · 05")).toBeInTheDocument();
     expect(within(cards[0]).getByText("Why this matters")).toBeInTheDocument();
     expect(within(cards[0]).getByTestId("signal-why-this-matters")).toHaveClass("line-clamp-2");
-    expect(within(cards[0]).getByRole("link", { name: "Read more →" })).toHaveAttribute(
-      "href",
-      "/briefing/2026-04-15",
-    );
+    // Per-card inline depth expansion: top events no longer link out to
+    // /briefing/<date>; they expand in place. The Expand toggle replaces
+    // the previous Read more link.
+    expect(within(cards[0]).queryByRole("link", { name: "Read more →" })).toBeNull();
+    expect(within(cards[0]).getByTestId("signal-card-toggle")).toHaveAccessibleName(/expand/i);
     expect(within(cards[0]).queryByText(/min read/i)).not.toBeInTheDocument();
     expect(within(cards[0]).queryByText("Details")).not.toBeInTheDocument();
     expect(within(cards[0]).queryByText("Tech")).not.toBeInTheDocument();
     expect(within(cards[0]).queryByText("Point one")).not.toBeInTheDocument();
+  });
+
+  it("expands a Signal Card in place when the Expand toggle is clicked", () => {
+    const data = createData([
+      createItem({
+        id: "top-1",
+        title: "Top event 1",
+        whatHappened: "The source headline appears here as the What happened body.",
+        whyItMatters: "Why this matters body for the top event.",
+      }),
+    ]);
+
+    renderHomepage(data);
+
+    const card = screen.getAllByTestId("signal-card")[0];
+    expect(card).toHaveAttribute("data-signal-expanded", "false");
+    expect(within(card).queryByText("What happened")).not.toBeInTheDocument();
+
+    const toggle = within(card).getByTestId("signal-card-toggle");
+    expect(toggle).toHaveAccessibleName(/expand/i);
+
+    fireEvent.click(toggle);
+
+    expect(card).toHaveAttribute("data-signal-expanded", "true");
+    expect(within(card).getByText("What happened")).toBeInTheDocument();
+    expect(within(card).getByText("What led to this")).toBeInTheDocument();
+    expect(toggle).toHaveAccessibleName(/collapse/i);
+
+    fireEvent.click(toggle);
+    expect(card).toHaveAttribute("data-signal-expanded", "false");
   });
 
   it("uses the supplied homepage model instead of raw briefing items", () => {

--- a/src/components/landing/homepage.test.tsx
+++ b/src/components/landing/homepage.test.tsx
@@ -235,7 +235,10 @@ describe("LandingHomepage", () => {
     expect(screen.getByText(/April 15, 2026/)).toBeInTheDocument();
     expect(screen.getByText("Today's signals")).toBeInTheDocument();
     expect(screen.queryByRole("tab", { name: "Top Events" })).not.toBeInTheDocument();
-    expect(screen.getByText("Browse by")).toBeInTheDocument();
+    // Browse-by category strip now uses a prominent heading rather than a
+    // micro-caps label. Match via the testid so the assertion survives
+    // future copy tweaks.
+    expect(screen.getByTestId("browse-by-heading")).toHaveTextContent(/browse by/i);
     expect(screen.getByRole("button", { name: "Tech" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Finance" })).toBeInTheDocument();
 

--- a/src/components/landing/homepage.tsx
+++ b/src/components/landing/homepage.tsx
@@ -100,7 +100,7 @@ export default function LandingHomepage({
                 signal={event}
                 rank={index + 1}
                 tier="core"
-                readMoreHref={detailHref}
+                defaultExpanded={false}
                 trackingAttributes={{
                   "data-mvp-measurement-event": "signal_details_click",
                   "data-mvp-route": "/",

--- a/src/components/landing/homepage.tsx
+++ b/src/components/landing/homepage.tsx
@@ -39,7 +39,6 @@ export default function LandingHomepage({
   const { featured, topRanked, categorySections, debug } = homepageViewModel;
   const topEvents = dedupeEvents([featured, ...topRanked]).slice(0, 5);
   const briefingDateKey = getBriefingDateKey(data.briefing.briefingDate);
-  const detailHref = `/briefing/${briefingDateKey}`;
   const noDataMessage = buildOverallNoDataMessage(topEvents.length);
   const topEventsEmptyMessage =
     data.homepageFreshnessNotice?.kind === "empty"
@@ -134,7 +133,6 @@ export default function LandingHomepage({
                 compact
                 rank={index + 1}
                 tier={event.signalRole === "context" ? "context" : "core"}
-                readMoreHref={detailHref}
               />
             )}
             renderCategoryArticle={(article) => <CategoryArticleRow article={article} />}

--- a/src/components/landing/homepage.tsx
+++ b/src/components/landing/homepage.tsx
@@ -99,7 +99,7 @@ export default function LandingHomepage({
                 signal={event}
                 rank={index + 1}
                 tier="core"
-                defaultExpanded={false}
+                defaultExpanded
                 trackingAttributes={{
                   "data-mvp-measurement-event": "signal_details_click",
                   "data-mvp-route": "/",

--- a/src/components/signals/SignalCard.tsx
+++ b/src/components/signals/SignalCard.tsx
@@ -1,5 +1,8 @@
+"use client";
+
+import { useState } from "react";
 import Link from "next/link";
-import { ExternalLink } from "lucide-react";
+import { ChevronDown, ExternalLink } from "lucide-react";
 
 import { buildEditorialWhyItMattersText } from "@/lib/editorial-content";
 import type { EditorialWhyItMattersContent } from "@/lib/editorial-content";
@@ -34,6 +37,17 @@ export type SignalCardSignal = {
 
 export type SignalCardProps = {
   signal: SignalCardSignal;
+  /**
+   * Opt into per-card interactive expansion. When provided, the Card owns
+   * its expanded/collapsed state and renders an Expand ↓ / Collapse ↑
+   * toggle in the footer. Used by the homepage (false) and the briefing
+   * detail surface (true).
+   */
+  defaultExpanded?: boolean;
+  /**
+   * Legacy externally-controlled expansion. Used when defaultExpanded is
+   * not provided. Ignored when defaultExpanded is provided.
+   */
   expanded?: boolean;
   compact?: boolean;
   rank?: number;
@@ -45,6 +59,7 @@ export type SignalCardProps = {
 
 export function SignalCard({
   signal,
+  defaultExpanded,
   expanded = false,
   compact = false,
   rank,
@@ -53,17 +68,38 @@ export function SignalCard({
   trackingAttributes,
   className,
 }: SignalCardProps) {
+  const interactive = defaultExpanded !== undefined;
+  const [localExpanded, setLocalExpanded] = useState(defaultExpanded ?? false);
+  const isExpanded = interactive ? localExpanded : expanded;
+
   const displayRank = rank ?? signal.finalSlateRank ?? signal.rank ?? 1;
   const displayTier = tier ?? resolveSignalTier(signal, displayRank);
   const whyItMatters = getWhyItMattersText(signal);
   const sourceAttribution = getSourceAttribution(signal);
   const relatedCoverage = getRelatedCoverage(signal);
-  const whatLedToThis = getStructuredSection(signal.editorialWhyItMatters, /led|caus|before|context/i);
-  const whatItConnectsTo = getStructuredSection(signal.editorialWhyItMatters, /connect|next|watch|implication/i);
+  const whatHappenedBody = (signal.whatHappened || signal.summary || "").trim();
+  const whatLedToThisBody = getStructuredSection(
+    signal.editorialWhyItMatters,
+    /led|caus|before|context/i,
+  );
+  const whatItConnectsToBody = (
+    getStructuredSection(signal.editorialWhyItMatters, /connect|next|watch|implication/i) ||
+    signal.selectionReason ||
+    ""
+  ).trim();
+
   const readMoreClassName = cn(
     "shrink-0 text-[var(--bu-size-meta)] font-normal leading-5 text-[var(--bu-text-secondary)] transition-colors",
     compact ? "hover:text-[var(--bu-text-primary)]" : "hover:text-[var(--bu-accent)]",
   );
+
+  const toggleClassName = cn(
+    "inline-flex shrink-0 items-center gap-1 text-[var(--bu-size-meta)] font-normal leading-5 text-[var(--bu-text-secondary)] transition-colors hover:text-[var(--bu-text-primary)]",
+  );
+
+  function handleToggle() {
+    setLocalExpanded((value) => !value);
+  }
 
   return (
     <article
@@ -74,6 +110,7 @@ export function SignalCard({
       )}
       data-testid="signal-card"
       data-signal-tier={displayTier}
+      data-signal-expanded={isExpanded ? "true" : "false"}
     >
       <TierBadge tier={displayTier} rank={displayRank} accented={!compact} />
 
@@ -96,7 +133,7 @@ export function SignalCard({
           <p
             className={cn(
               "mt-1 font-heading text-[var(--bu-size-witm)] font-normal leading-[var(--bu-line-witm)] text-[var(--bu-text-primary)]",
-              !expanded && !compact && "line-clamp-2",
+              !isExpanded && !compact && "line-clamp-2",
               compact && "line-clamp-2 text-[var(--bu-size-meta)] leading-[1.5]",
             )}
             data-testid="signal-why-this-matters"
@@ -110,7 +147,25 @@ export function SignalCard({
         <p className="min-w-0 truncate text-[var(--bu-size-meta)] font-normal leading-5 text-[var(--bu-text-tertiary)]">
           {sourceAttribution}
         </p>
-        {readMoreHref ? (
+        {interactive ? (
+          <button
+            type="button"
+            onClick={handleToggle}
+            aria-expanded={isExpanded}
+            className={toggleClassName}
+            data-testid="signal-card-toggle"
+            {...trackingAttributes}
+          >
+            {isExpanded ? "Collapse" : "Expand"}
+            <ChevronDown
+              aria-hidden="true"
+              className={cn(
+                "h-3.5 w-3.5 transition-transform",
+                isExpanded ? "rotate-180" : "rotate-0",
+              )}
+            />
+          </button>
+        ) : readMoreHref ? (
           <Link
             href={readMoreHref}
             className={readMoreClassName}
@@ -131,13 +186,16 @@ export function SignalCard({
         ) : null}
       </footer>
 
-      {expanded ? (
+      {isExpanded ? (
         <div className="mt-4 border-t border-[var(--bu-border-subtle)] pt-4">
           <div className="space-y-4">
-            <ExpandedSection label="What happened" body={signal.whatHappened || signal.summary || ""} />
-            <ExpandedSection label="Why this matters" body={whyItMatters} />
-            <ExpandedSection label="What led to this" body={whatLedToThis} />
-            <ExpandedSection label="What it connects to" body={whatItConnectsTo || signal.selectionReason || ""} />
+            <WhatHappenedSection body={whatHappenedBody} />
+            <ExpandedSerifSection label="Why this matters" body={whyItMatters} />
+            <WhatLedToThisSection body={whatLedToThisBody} />
+            <ExpandedSerifSection
+              label="What it connects to"
+              body={whatItConnectsToBody}
+            />
           </div>
 
           {relatedCoverage.length ? (
@@ -172,19 +230,74 @@ export function SignalCard({
   );
 }
 
-function ExpandedSection({ label, body }: { label: string; body: string }) {
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-[var(--bu-size-micro)] font-medium uppercase leading-none tracking-[0.08em] text-[var(--bu-text-tertiary)]">
+      {children}
+    </p>
+  );
+}
+
+/**
+ * "What happened" body is the source-headline treatment — rendered in
+ * sans, not serif, to signal factual reporting rather than editorial
+ * judgment. See work prompt Change 1 typography rules.
+ */
+function WhatHappenedSection({ body }: { body: string }) {
   if (!body.trim()) {
     return null;
   }
 
   return (
     <section>
-      <p className="text-[var(--bu-size-micro)] font-medium uppercase leading-none tracking-[0.08em] text-[var(--bu-text-tertiary)]">
-        {label}
+      <SectionLabel>What happened</SectionLabel>
+      <p className="mt-1 font-sans text-[var(--bu-size-witm)] font-normal leading-[var(--bu-line-witm)] text-[var(--bu-text-primary)]">
+        {body}
       </p>
+    </section>
+  );
+}
+
+/**
+ * "Why this matters" / "What it connects to" — editorial-voice sections
+ * in serif. Empty sections are suppressed to avoid empty boxes.
+ */
+function ExpandedSerifSection({ label, body }: { label: string; body: string }) {
+  if (!body.trim()) {
+    return null;
+  }
+
+  return (
+    <section>
+      <SectionLabel>{label}</SectionLabel>
       <p className="mt-1 font-heading text-[var(--bu-size-witm)] font-normal leading-[var(--bu-line-witm)] text-[var(--bu-text-primary)]">
         {body}
       </p>
+    </section>
+  );
+}
+
+/**
+ * "What led to this" is the structural-causation layer and must render
+ * even when the underlying data is empty, per work prompt Change 1
+ * acceptance criteria. Empty state uses an italic placeholder so the
+ * absence is visible rather than silently hidden.
+ */
+function WhatLedToThisSection({ body }: { body: string }) {
+  const trimmed = body.trim();
+
+  return (
+    <section>
+      <SectionLabel>What led to this</SectionLabel>
+      {trimmed ? (
+        <p className="mt-1 font-heading text-[var(--bu-size-witm)] font-normal leading-[var(--bu-line-witm)] text-[var(--bu-text-primary)]">
+          {trimmed}
+        </p>
+      ) : (
+        <p className="mt-1 font-heading italic text-[var(--bu-size-witm)] font-normal leading-[var(--bu-line-witm)] text-[var(--bu-text-tertiary)]">
+          No structural context yet for this signal.
+        </p>
+      )}
     </section>
   );
 }

--- a/src/components/signals/SignalCard.tsx
+++ b/src/components/signals/SignalCard.tsx
@@ -144,9 +144,22 @@ export function SignalCard({
       ) : null}
 
       <footer className="mt-4 flex items-center justify-between gap-4 border-t border-[var(--bu-border-subtle)] pt-3">
-        <p className="min-w-0 truncate text-[var(--bu-size-meta)] font-normal leading-5 text-[var(--bu-text-tertiary)]">
-          {sourceAttribution}
-        </p>
+        {signal.sourceUrl ? (
+          <a
+            href={signal.sourceUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex min-w-0 items-center gap-1 truncate text-[var(--bu-size-meta)] font-normal leading-5 text-[var(--bu-text-tertiary)] transition-colors hover:text-[var(--bu-accent)]"
+            data-testid="signal-card-source-link"
+          >
+            <span className="truncate">{sourceAttribution}</span>
+            <ExternalLink aria-hidden="true" className="h-3 w-3 shrink-0" />
+          </a>
+        ) : (
+          <p className="min-w-0 truncate text-[var(--bu-size-meta)] font-normal leading-5 text-[var(--bu-text-tertiary)]">
+            {sourceAttribution}
+          </p>
+        )}
         {interactive ? (
           <button
             type="button"
@@ -173,16 +186,6 @@ export function SignalCard({
           >
             Read more →
           </Link>
-        ) : signal.sourceUrl ? (
-          <a
-            href={signal.sourceUrl}
-            target="_blank"
-            rel="noreferrer"
-            className={readMoreClassName}
-            {...trackingAttributes}
-          >
-            Read more →
-          </a>
         ) : null}
       </footer>
 

--- a/src/components/signals/SignalCard.tsx
+++ b/src/components/signals/SignalCard.tsx
@@ -144,49 +144,55 @@ export function SignalCard({
       ) : null}
 
       <footer className="mt-4 flex items-center justify-between gap-4 border-t border-[var(--bu-border-subtle)] pt-3">
-        {signal.sourceUrl ? (
-          <a
-            href={signal.sourceUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex min-w-0 items-center gap-1 truncate text-[var(--bu-size-meta)] font-normal leading-5 text-[var(--bu-text-tertiary)] transition-colors hover:text-[var(--bu-accent)]"
-            data-testid="signal-card-source-link"
-          >
-            <span className="truncate">{sourceAttribution}</span>
-            <ExternalLink aria-hidden="true" className="h-3 w-3 shrink-0" />
-          </a>
-        ) : (
-          <p className="min-w-0 truncate text-[var(--bu-size-meta)] font-normal leading-5 text-[var(--bu-text-tertiary)]">
-            {sourceAttribution}
-          </p>
-        )}
-        {interactive ? (
-          <button
-            type="button"
-            onClick={handleToggle}
-            aria-expanded={isExpanded}
-            className={toggleClassName}
-            data-testid="signal-card-toggle"
-            {...trackingAttributes}
-          >
-            {isExpanded ? "Collapse" : "Expand"}
-            <ChevronDown
-              aria-hidden="true"
-              className={cn(
-                "h-3.5 w-3.5 transition-transform",
-                isExpanded ? "rotate-180" : "rotate-0",
-              )}
-            />
-          </button>
-        ) : readMoreHref ? (
-          <Link
-            href={readMoreHref}
-            className={readMoreClassName}
-            {...trackingAttributes}
-          >
-            Read more →
-          </Link>
-        ) : null}
+        <p className="min-w-0 truncate text-[var(--bu-size-meta)] font-normal leading-5 text-[var(--bu-text-tertiary)]">
+          {sourceAttribution}
+        </p>
+        <div className="flex shrink-0 items-center gap-3">
+          {signal.sourceUrl ? (
+            // Standalone external-link icon — matches the source-link
+            // affordance used by category tab article rows so the card
+            // face exposes the original article URL at first glance,
+            // not behind the Expand toggle.
+            <a
+              href={signal.sourceUrl}
+              target="_blank"
+              rel="noreferrer"
+              aria-label={`Read source: ${signal.sourceName ?? "open original article"}`}
+              title="Read at source"
+              className="inline-flex items-center text-[var(--bu-text-secondary)] transition-colors hover:text-[var(--bu-accent)]"
+              data-testid="signal-card-source-link"
+            >
+              <ExternalLink aria-hidden="true" className="h-4 w-4" />
+            </a>
+          ) : null}
+          {interactive ? (
+            <button
+              type="button"
+              onClick={handleToggle}
+              aria-expanded={isExpanded}
+              className={toggleClassName}
+              data-testid="signal-card-toggle"
+              {...trackingAttributes}
+            >
+              {isExpanded ? "Collapse" : "Expand"}
+              <ChevronDown
+                aria-hidden="true"
+                className={cn(
+                  "h-3.5 w-3.5 transition-transform",
+                  isExpanded ? "rotate-180" : "rotate-0",
+                )}
+              />
+            </button>
+          ) : readMoreHref ? (
+            <Link
+              href={readMoreHref}
+              className={readMoreClassName}
+              {...trackingAttributes}
+            >
+              Read more →
+            </Link>
+          ) : null}
+        </div>
       </footer>
 
       {isExpanded ? (

--- a/src/components/signals/visual-system-components.test.tsx
+++ b/src/components/signals/visual-system-components.test.tsx
@@ -188,6 +188,12 @@ describe("Boot Up visual system components", () => {
     );
 
     expect(screen.getByText("Core signal · 01")).toHaveClass("text-[var(--bu-text-tertiary)]");
-    expect(screen.getByRole("link", { name: "Read more →" })).toHaveClass("hover:text-[var(--bu-text-primary)]");
+    // The source attribution itself is now the article link — visible on
+    // the card face without needing to expand or follow a separate Read
+    // more → affordance.
+    const sourceLink = screen.getByTestId("signal-card-source-link");
+    expect(sourceLink).toHaveAttribute("href", "https://www.reuters.com/story");
+    expect(sourceLink).toHaveAttribute("target", "_blank");
+    expect(sourceLink).toHaveTextContent("Reuters");
   });
 });

--- a/src/components/signals/visual-system-components.test.tsx
+++ b/src/components/signals/visual-system-components.test.tsx
@@ -188,12 +188,13 @@ describe("Boot Up visual system components", () => {
     );
 
     expect(screen.getByText("Core signal · 01")).toHaveClass("text-[var(--bu-text-tertiary)]");
-    // The source attribution itself is now the article link — visible on
-    // the card face without needing to expand or follow a separate Read
-    // more → affordance.
+    // The source link is a standalone external-link icon on the right
+    // side of the footer — visible on the collapsed face without
+    // needing to expand. The accessible name and href point at the
+    // original article URL.
     const sourceLink = screen.getByTestId("signal-card-source-link");
     expect(sourceLink).toHaveAttribute("href", "https://www.reuters.com/story");
     expect(sourceLink).toHaveAttribute("target", "_blank");
-    expect(sourceLink).toHaveTextContent("Reuters");
+    expect(sourceLink).toHaveAccessibleName(/read source/i);
   });
 });

--- a/src/components/signals/visual-system-components.test.tsx
+++ b/src/components/signals/visual-system-components.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { DateBadge } from "@/components/signals/DateBadge";
@@ -78,6 +78,98 @@ describe("Boot Up visual system components", () => {
 
     expect(screen.getByText("What happened")).toBeInTheDocument();
     expect(screen.getByText("Supporting coverage")).toBeInTheDocument();
+  });
+
+  it("opens its own depth in place when defaultExpanded is provided", () => {
+    const signal = {
+      id: "signal-interactive",
+      title: "Interactive expansion test",
+      whatHappened: "Bond markets moved after the latest inflation print.",
+      whyItMatters: "Higher-for-longer rates change borrowing costs and risk appetite.",
+      sourceName: "Reuters",
+      sourceUrl: "https://www.reuters.com/story",
+    };
+
+    render(<SignalCard signal={signal} rank={1} defaultExpanded={false} />);
+
+    const card = screen.getByTestId("signal-card");
+    expect(card).toHaveAttribute("data-signal-expanded", "false");
+    expect(screen.queryByText("What happened")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Read more →" })).toBeNull();
+
+    const toggle = screen.getByTestId("signal-card-toggle");
+    expect(toggle).toHaveAccessibleName(/expand/i);
+
+    fireEvent.click(toggle);
+
+    expect(card).toHaveAttribute("data-signal-expanded", "true");
+    expect(screen.getByText("What happened")).toBeInTheDocument();
+    expect(toggle).toHaveAccessibleName(/collapse/i);
+  });
+
+  it("starts expanded when defaultExpanded is true", () => {
+    const signal = {
+      id: "signal-default-open",
+      title: "Briefing detail surface card",
+      whatHappened: "Source headline body.",
+      whyItMatters: "Editorial body.",
+      sourceName: "Reuters",
+      sourceUrl: "https://www.reuters.com/story",
+    };
+
+    render(<SignalCard signal={signal} rank={1} defaultExpanded />);
+
+    const card = screen.getByTestId("signal-card");
+    expect(card).toHaveAttribute("data-signal-expanded", "true");
+    expect(screen.getByText("What happened")).toBeInTheDocument();
+    expect(screen.getByTestId("signal-card-toggle")).toHaveAccessibleName(/collapse/i);
+  });
+
+  it("renders What happened in sans and the other depth sections in serif", () => {
+    const signal = {
+      id: "signal-sans-vs-serif",
+      title: "Typography differentiation",
+      whatHappened: "Factual source-headline body for the What happened layer.",
+      whyItMatters: "Editorial reasoning lives in serif voice.",
+      sourceName: "Reuters",
+      sourceUrl: "https://www.reuters.com/story",
+    };
+
+    render(<SignalCard signal={signal} rank={1} defaultExpanded />);
+
+    // What happened body — sans treatment for the factual layer.
+    const whatHappenedBody = screen.getByText(
+      /Factual source-headline body for the What happened layer/,
+    );
+    expect(whatHappenedBody).toHaveClass("font-sans");
+    expect(whatHappenedBody).not.toHaveClass("font-heading");
+
+    // Why this matters body appears in two places when expanded: the
+    // preview (line-clamped, above the footer) and the depth section
+    // (full, below the footer). Both must use the editorial serif
+    // family so the brand voice stays consistent across modes.
+    const whyItMattersBodies = screen.getAllByText("Editorial reasoning lives in serif voice.");
+    expect(whyItMattersBodies.length).toBeGreaterThan(0);
+    for (const body of whyItMattersBodies) {
+      expect(body).toHaveClass("font-heading");
+    }
+  });
+
+  it("renders the italic empty-state for What led to this when data is missing", () => {
+    const signal = {
+      id: "signal-empty-led",
+      title: "Card without structural context yet",
+      whyItMatters: "Editorial body only.",
+      sourceName: "Reuters",
+      sourceUrl: "https://www.reuters.com/story",
+    };
+
+    render(<SignalCard signal={signal} rank={1} defaultExpanded />);
+
+    expect(screen.getByText("What led to this")).toBeInTheDocument();
+    const placeholder = screen.getByText("No structural context yet for this signal.");
+    expect(placeholder).toHaveClass("italic");
+    expect(placeholder).toHaveClass("text-[var(--bu-text-tertiary)]");
   });
 
   it("keeps compact signals neutral for the secondary list surface", () => {

--- a/src/lib/homepage-model.ts
+++ b/src/lib/homepage-model.ts
@@ -124,8 +124,11 @@ export type HomepageViewModel = {
 };
 
 const TOP_EVENTS_LIMIT = 4;
+// Bumped from 6 to 10 so each Browse-by-category tab exposes a fuller
+// list of category-specific stories on the homepage.
+
 const MIN_PUBLIC_TOP_EVENTS = 3;
-const CATEGORY_TAB_LIMIT = 6;
+const CATEGORY_TAB_LIMIT = 10;
 const DEVELOPING_NOW_EVENT_LIMIT = 10;
 const CATEGORY_PREVIEW_LIMIT = 3;
 const TRENDING_EVENT_LIMIT = 3;

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -85,9 +85,11 @@ test.describe("homepage", () => {
         element.textContent?.includes("Today's signals"),
       );
       const firstCard = document.querySelector('[data-testid="signal-card"]');
-      const browseBy = Array.from(document.querySelectorAll("p")).find((element) =>
-        element.textContent?.trim() === "Browse by",
-      );
+      const browseBy =
+        document.querySelector('[data-testid="browse-by-heading"]') ??
+        Array.from(document.querySelectorAll("h2, p")).find((element) =>
+          element.textContent?.trim().toLowerCase().startsWith("browse by"),
+        );
 
       if (!header || !firstCard || !browseBy) {
         return null;


### PR DESCRIPTION
## Summary

Refinement to the visual system shipped in PR #229, plus two rounds of preview-review fixes.

**Change 1 — Per-card inline depth expansion on Signal Card.** The four-layer depth structure (What happened / Why this matters / What led to this / What it connects to) is now per-card inline on the homepage, not a per-briefing aggregate page. Each Signal Card owns its expanded/collapsed state and renders an Expand ↓ / Collapse ↑ toggle in the footer. **As of round 3, homepage top cards land already expanded** (`defaultExpanded={true}`) so the depth is visible at first glance; readers can collapse individual cards if they want compact view. What happened renders in sans (source-headline treatment); the three editorial layers render in serif. What led to this renders an italic placeholder when its structured field is empty so the absence stays visible. `/briefing/[date]` already lands all cards open.

**Change 2 — Bulk `Approve all WITM-passed` + Publish slate confirmation in the editorial composer.** Bulk approve is lifted from the per-row rewrite editor into a single form at the top of the Candidate pool. The form renders explicit hidden inputs for every candidate that satisfies the gate (WITM validator passed AND assigned to a slot AND not already approved AND storage ready AND non-blocking editorial decision), so bulk approve no longer depends on which rewrite editors are currently expanded. Disabled tooltip surfaces the gate when zero candidates qualify. The Publish slate button is bulk-aware: it shows the live `N approved · M pending publish · K already live` summary, its label is dynamic (`Publish N candidates`), and clicking opens a confirmation dialog with total count, Core / Context tier breakdown, and a scrollable title list before the existing `publishFinalSlateAction` runs.

**Change 3 — Preview-review refinements** (rounds 2 + 3 after the first preview pass):

- **Source link on every Signal Card face.** Standalone `ExternalLink` icon (h-4 w-4) on the right side of the footer, matching the affordance used by category-tab article rows. Visible on the collapsed face; opens the original article URL in a new tab. Applies to homepage top events, `/briefing/[date]` cards, and compact category cards.
- **`Browse by category` strip is now visually prominent.** The previous micro-caps label became a proper heading (card-title sized, 19–21px), with the tab row stacked below it and an accent underline marking the active tab.
- **`CATEGORY_TAB_LIMIT` bumped 6 → 10.** Each Browse-by tab now exposes up to 10 category Signal Cards. Articles already cap at 50 per category and the strip prefers articles over events when present (article rows have direct source URLs).
- **Compact category Signal Cards** drop the `/briefing/[date]` `readMoreHref` now that the source-link icon on the card face is the primary affordance.
- **Brand vermillion accent darkened.** `--bu-accent: #DC4A2F → #B23A1F`. Hover `--bu-accent-hover: #C4391F → #9C2F18`. Soft-accent RGBA updated to match. The new tone reads as deeper vermillion red rather than orange-leaning. Every `var(--bu-accent)` consumer (tier marker, hover states, Publish-all primary button, active tab underline) picks it up automatically.
- **Brief carries `Canonical PRD required: ` `no` ` marker** so the release-governance-gate's remediation exception path recognizes the work and reclassifies it from `new-feature-or-system` → `material-feature-change`. Resolves the previous gate failure without creating a canonical PRD (the original work prompt explicitly didn't want one).

## Change type

Remediation / Alignment per `docs/engineering/templates/llm-prompt-template-change-classification.md`. No new canonical PRD required.

## Source of truth

- PR #229 — visual system v1 (introduced the four-layer depth structure on `SignalCard` and the `/briefing/[date]` aggregate page).
- `DECISIONS.md` D04 — seven-slot public slate (Top 5 Core + Next 2 Context).
- `DECISIONS.md` D05 — Explain why it matters.
- `DECISIONS.md` D06 — Separate generation from publication.
- `docs/product/briefs/per-card-depth-and-bulk-composer.md` (this PR) — supporting governance artifact.

## Commits

1. `ff5022e` — Change 1: per-card inline depth expansion on Signal Card
2. `b920e80` — Change 2: bulk Approve all WITM-passed and Publish slate confirmation in editorial composer + brief
3. `f58792a` — Round 2: source-link attempt, Browse-by promotion, darker vermillion, brief gate marker
4. `5afaeed` — Round 3: prominent standalone source-link icon + homepage cards default-expanded

## What did not change

- **No schema changes.** Reuses existing columns (`editorial_status`, `final_slate_rank`, `is_live`, `published_at`, `why_it_matters_validation_status`) and existing server actions (`approveAllSignalPostsAction`, `publishFinalSlateAction` → `publishApprovedSignals`).
- **No WITM validator, rewrite, or quality-gate logic changes.**
- **No authentication, admin role gating, or admin route protection changes.**
- **No visual-system token semantics changed** — only the accent hex values were darkened. Type families, spacing, radii, font sizes are unchanged.
- **No second vermillion element on the expanded card.** The Publish all primary action in the confirmation dialog reuses the existing accent role; expanded cards stay accent-disciplined.
- **`docs/product/feature-system.csv` is unchanged** — no PRD/feature metadata changed.

## Terminology check

- [x] Object level modified: **Card** (Change 1 + source-link refinements) and **editorial workflow / Surface Placement** (Change 2). Signal identity, ranking, selection, and storage are unchanged.
- [x] No new variable, file, function, component, or database terminology blurs Cluster vs Signal vs Card.
- [x] Legacy naming (`EditorialSignalPost`, `signal_posts`, `approveAllSignalPostsAction`) preserved.

## Validation

Local gate (round 3, after the final commit):

| Step | Result |
|---|---|
| `npm run lint` | clean |
| `npm test` (vitest) | **678 / 678** tests across 95 files |
| `npm run build` | exit 0 |
| `npx playwright test --project=chromium` (homepage + dashboard + smoke specs) | **10 / 10** |
| `npx playwright test --project=webkit` (round 1 baseline) | **33 / 33** |

CI gates (head `5afaeed`): release-governance-gate, feature-system-csv-validation, and Vercel preview already green at time of writing; remaining `pr-*` checks in flight.

## Acceptance verification

### Change 1
- [x] Homepage Signal Cards land already expanded; Expand / Collapse toggle is per-card.
- [x] Expanded layout renders four depth sections in order: What happened, Why this matters, What led to this, What it connects to.
- [x] "What happened" body uses `font-sans` (source-headline treatment); the other three use `font-heading` (serif).
- [x] "What led to this" renders an italic placeholder when underlying data is empty.
- [x] Expand/collapse is local React state — no URL change.
- [x] Multiple cards can be expanded simultaneously.
- [x] `/briefing/[date]` route still works and renders all cards expanded by default.
- [x] No second vermillion element added to the expanded card state.

### Change 2
- [x] Editorial composer has `Approve all WITM-passed` button at the top of the Candidate pool.
- [x] Bulk approve only affects candidates where WITM passed AND the candidate is assigned to a slot AND not already approved.
- [x] Bulk approve never affects rewrite-flagged candidates.
- [x] Bulk approve is disabled with the tooltip `No WITM-passed candidates assigned to slots` when zero candidates qualify.
- [x] Slot panel shows summary line `N approved · M pending publish · K already live` with live counts.
- [x] Publish slate button is disabled when zero candidates are pending publish; label is dynamic.
- [x] Publish slate triggers a confirmation dialog showing count, Core / Context tier breakdown, and scrollable title list.
- [x] Confirmation dialog has `Publish all` (vermillion) and `Cancel` (outlined) actions.

### Change 3 (preview-review)
- [x] Standalone external-link icon visible in the footer of every Signal Card with a `sourceUrl`.
- [x] `Browse by category` heading is a proper page-title-sized heading; active tab gets an accent underline.
- [x] Category tabs surface up to 10 Signal Cards (article-row fallback already at 50).
- [x] Brand accent reads as deeper vermillion red (`#B23A1F`) rather than orange-leaning.
- [x] release-governance-gate clears the remediation exception path.

## Out of scope

- **History page is empty in preview.** DB has 13 historical briefing dates in `signal_posts` (back to 2026-04-23), but the History page queries the per-user `daily_briefings` table which is empty. This is a pre-existing data-flow gap, not caused by this PR. A separate PR is needed to either backfill `daily_briefings` from `signal_posts` history or change the History reads to use `signal_posts` directly.

## Known follow-ups

- `eligibleForApproveAll` prop on `StructuredEditorialFields` is now vestigial; a future scoped cleanup can remove it.
- History page data-flow gap (see Out of scope).

## Branch / cleanup

- Branch: `feature/per-card-depth-and-bulk-composer` from `origin/main` @ `264db1d`.
- After merge: delete branch locally and remotely per AGENTS.md §9 cleanup flow.

Additional changes:
1. Source-link icon visibility fix. Previous attempt wrapped the source attribution text in a clickable anchor with a tiny h-3 w-3 icon — the icon was visually swallowed by the truncated source name. Reworked as a standalone h-4 w-4 ExternalLink icon on the right side of the footer, matching the affordance the category-tab article rows already use. Source attribution stays as plain text on the left. Hover swaps the icon to vermillion accent. Has aria-label="Read source: <source name>" and title="Read at source" for accessibility + tooltip.

2. Homepage Signal Cards now default to expanded. Top events on the homepage now pass defaultExpanded={true} (matches what /briefing/[date] already does), so the four-layer depth (What happened / Why this matters / What led to this / What it connects to) is visible at first glance. The Expand / Collapse toggle stays per-card so a reader who prefers compact view can collapse individual cards.