### PR TITLE
Update canonical domain to bootupnews.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,7 @@ SENTRY_PROJECT=your_sentry_project_slug
 SENTRY_AUTH_TOKEN=
 RSS_CRON_MONITOR_SLUG=rss-feed-refresh
 RSS_STALE_THRESHOLD_MS=108000000
-PUBLIC_SITE_URL=https://bootupnews.vercel.app
+PUBLIC_SITE_URL=https://bootupnews.com
 
 # PostHog product analytics. Keep real project tokens in deployment env only.
 NEXT_PUBLIC_ENABLE_POSTHOG=0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Boot Up
 
-Live app: [https://bootupnews.vercel.app](https://bootupnews.vercel.app)
+Live app: [https://bootupnews.com](https://bootupnews.com)
 
 Boot Up is a curated daily intelligence briefing for people who want to understand what matters without scanning a large news surface. It is designed around a simple product bet: a useful briefing should reduce the number of things a reader has to inspect while increasing the quality of the judgment behind each item.
 

--- a/docs/engineering/bug-fixes/bootupnews-com-canonical-domain.md
+++ b/docs/engineering/bug-fixes/bootupnews-com-canonical-domain.md
@@ -1,0 +1,21 @@
+# Bootupnews.com Canonical Domain
+
+- Date: 2026-05-14
+- Branch: `chore/bootupnews-com-canonical-domain`
+- Change type: domain and deployment configuration remediation
+
+## Problem
+
+Repo-controlled production URL defaults still treated `https://bootupnews.vercel.app` as the canonical public origin. That made metadata, sitemap, robots output, documentation, and release examples point at the default Vercel deployment host instead of the production apex domain.
+
+## Resolution
+
+- Set the repo-controlled canonical public origin to `https://bootupnews.com`.
+- Updated public URL examples, metadata expectations, sitemap/robots URL tests, and current production verification docs to use the apex domain.
+- Added exact-host production redirects for `bootupnews.vercel.app` and `www.bootupnews.com` to `https://bootupnews.com` while leaving localhost and Vercel preview deployment hosts untouched.
+- Renamed the npm package identity to `bootupnews` while preserving the locked user-facing `Boot Up` brand.
+
+## Follow-Up
+
+- Vercel production env variables that store public app URLs should be set to `https://bootupnews.com`.
+- Third-party OAuth, analytics, replay, and source-map dashboards should allow `https://bootupnews.com` and `https://www.bootupnews.com` before removing the legacy default Vercel host.

--- a/docs/engineering/bug-fixes/briefing-detail-public-debug-artifacts.md
+++ b/docs/engineering/bug-fixes/briefing-detail-public-debug-artifacts.md
@@ -7,7 +7,7 @@
 
 ## Source Of Truth
 - Cowork frontend UX analysis 2026-05-06, prioritized shortlist Fix 1 and Fix 2.
-- Production URL observed before fix: `https://bootupnews.vercel.app/briefing/2026-05-06`.
+- Production URL observed before fix: `https://bootupnews.com/briefing/2026-05-06`.
 - BOOT_UP_WORK_LOG Decision D3 historical reference: no false freshness; trust matters more than daily automation optics.
 - Canonical PRD required: no.
 

--- a/docs/engineering/bug-fixes/public-card-cleanup-remediation-2026-05-02.md
+++ b/docs/engineering/bug-fixes/public-card-cleanup-remediation-2026-05-02.md
@@ -6,7 +6,7 @@
 - Affected object level: Card and Surface Placement.
 
 ## Source Of Truth
-- Live production audit of `bootupnews.vercel.app` on 2026-05-02.
+- Live production audit of `bootupnews.com` on 2026-05-02.
 - PR #180, #181, #187, and #189 metadata and PR bodies.
 - Prior Phase 1 change-record evidence was preserved as operational evidence. The durable public interpretation is captured in the relevant PRs, product source-of-truth docs, and this consolidated remediation record.
 - GitHub source-of-truth status: canonical consolidated remediation record created on 2026-05-04.

--- a/docs/engineering/bug-fixes/public-card-tabs-remediation-2026-05-08.md
+++ b/docs/engineering/bug-fixes/public-card-tabs-remediation-2026-05-08.md
@@ -8,7 +8,7 @@
 ## Source Of Truth
 - Cowork eliminate-only analysis 2026-05-08 subtraction-lens shortlist.
 - Cowork frontend UX analysis 2026-05-06 taxonomy mismatch diagnosis.
-- Production homepage HTML/RSC payload fetched 2026-05-08 from `https://bootupnews.vercel.app/`.
+- Production homepage HTML/RSC payload fetched 2026-05-08 from `https://bootupnews.com/`.
 - Product Position fail-closed empty-state principle, no false freshness, and Signal Card structure guidance supplied by PM.
 - PR #202 and PR #204 GitHub diffs.
 - Canonical PRD required: No.

--- a/docs/engineering/bug-fixes/public-surface-copy-remediation-2026-05-07.md
+++ b/docs/engineering/bug-fixes/public-surface-copy-remediation-2026-05-07.md
@@ -55,7 +55,7 @@
   - Local browser `/briefing/2026-05-06` did not have production snapshot data available, but confirmed `Why this ranks here` and `confirmed-event rail` were absent from the rendered page.
   - Vercel preview verification passed for `/`, `/signals`, and `/briefing/2026-05-06`; removed internal strings were absent and unchanged public content remained visible.
   - Production deployment was verified without retaining concrete deployment identifiers in the public doc.
-  - Production alias checked: `https://bootupnews.vercel.app`.
+  - Production alias checked: `https://bootupnews.com`.
   - Production HTTP checks passed: `/` 200, `/signals` 200, `/briefing/2026-05-06` 200.
   - Production Chrome incognito click-level QA passed: homepage category tabs, category gates, login routing, briefing detail navigation, detail tabs, `/signals`, and `/signals` to homepage navigation all worked.
   - Fix-specific production QA passed: `/briefing/2026-05-06` no longer rendered `Why this ranks here` or `confirmed-event rail`; `/signals` no longer rendered `watch`, `High`, or `Published editorial layer`; `/signals` still rendered category tags such as `Finance` and `Tech`.

--- a/docs/engineering/reports/2026-05-10-current-db-schema-progress-report.md
+++ b/docs/engineering/reports/2026-05-10-current-db-schema-progress-report.md
@@ -22,11 +22,11 @@ Production now has the schema foundation for:
 
 This is schema-only foundation. It does not implement Gmail ingestion, newsletter parsing, LLM extraction, source matching, clustering logic, newsletter cron, promotion into `signal_posts`, admin UI, public historical browsing, signal evolution rendering, or cross-event rendering.
 
-The current public content state at `https://bootupnews.vercel.app` shows a May 6 three-signal live slate. That is a public live-row/editorial state issue, not a schema migration issue.
+The current public content state at `https://bootupnews.com` shows a May 6 three-signal live slate. That is a public live-row/editorial state issue, not a schema migration issue.
 
 ## Source Of Truth
 
-- Production URL: `https://bootupnews.vercel.app`
+- Production URL: `https://bootupnews.com`
 - Supabase project: `fwkqjeumreaznfhnlzev`
 - Environment: `main PRODUCTION`
 - PR #210: Newsletter ingestion, story clusters, and historical signal snapshot foundation
@@ -268,7 +268,7 @@ No unexpected rows were found in the six new Phase 2 tables.
 
 ## Public App Smoke
 
-Production URL: `https://bootupnews.vercel.app`
+Production URL: `https://bootupnews.com`
 
 | Route | Status | Observation |
 | --- | ---: | --- |

--- a/docs/engineering/testing/homepage-progressive-loading-performance-gate-2026-05-14.md
+++ b/docs/engineering/testing/homepage-progressive-loading-performance-gate-2026-05-14.md
@@ -21,7 +21,7 @@ This record covers the production load-time remediation for the public homepage.
 - Focused unit and component tests for the category selector, category API, progressive tab fetch states, and analytics sanitization.
 - Homepage E2E smoke for initial signal-only render plus category tab click behavior.
 - Standard local gate: `npm run lint`, `npm run test`, `npm run build`, and Chromium/WebKit Playwright.
-- Production gate after merge: `npm run release:production -- --base-url https://bootupnews.vercel.app` followed by `npm run release:performance -- --base-url https://bootupnews.vercel.app`.
+- Production gate after merge: `npm run release:production -- --base-url https://bootupnews.com` followed by `npm run release:performance -- --base-url https://bootupnews.com`.
 
 ## Validation Run
 
@@ -33,8 +33,8 @@ This record covers the production load-time remediation for the public homepage.
 - `git diff --check`: passed.
 - `python3 scripts/validate-feature-system-csv.py`: passed with pre-existing slug warnings.
 - `python3 scripts/release-governance-gate.py`: passed.
-- `npm run release:production -- --base-url https://bootupnews.vercel.app`: passed route probe for current production.
-- `npm run release:performance -- --base-url https://bootupnews.vercel.app`: failed against current production before this PR is deployed, with LCP 19756 ms, FCP 4080 ms, decompressed homepage HTML 827.3 KB, script bytes 1.75 MB, and 45 route requests.
+- `npm run release:production -- --base-url https://bootupnews.com`: passed route probe for current production.
+- `npm run release:performance -- --base-url https://bootupnews.com`: failed against current production before this PR is deployed, with LCP 19756 ms, FCP 4080 ms, decompressed homepage HTML 827.3 KB, script bytes 1.75 MB, and 45 route requests.
 - Local browser QA on `http://127.0.0.1:3000/`: passed. The homepage rendered category links without an initial category panel; opening Technology routed to the dedicated category page and no browser console errors were observed.
 
 ## Notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "daily-intelligence-aggregator",
+  "name": "bootupnews",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "daily-intelligence-aggregator",
+      "name": "bootupnews",
       "version": "0.1.0",
       "dependencies": {
         "@sentry/nextjs": "^10.50.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "daily-intelligence-aggregator",
+  "name": "bootupnews",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/src/app/metadata.test.ts
+++ b/src/app/metadata.test.ts
@@ -18,15 +18,15 @@ describe("public page metadata", () => {
   it("exposes canonical and social URL metadata for the public homepage", async () => {
     const { metadata } = await import("@/app/page");
 
-    expect(metadata.metadataBase?.toString()).toBe("https://bootupnews.vercel.app/");
+    expect(metadata.metadataBase?.toString()).toBe("https://bootupnews.com/");
     expect(metadata.alternates).toEqual({
-      canonical: "https://bootupnews.vercel.app/",
+      canonical: "https://bootupnews.com/",
     });
     expect(metadata.openGraph).toEqual({
-      url: "https://bootupnews.vercel.app/",
+      url: "https://bootupnews.com/",
     });
     expect(metadata.other).toEqual({
-      "twitter:url": "https://bootupnews.vercel.app/",
+      "twitter:url": "https://bootupnews.com/",
     });
   });
 

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -44,6 +44,6 @@ describe("public Supabase env resolution", () => {
   });
 
   it("builds public URLs from the canonical production origin by default", () => {
-    expect(buildPublicAppUrl("/sitemap.xml")).toBe("https://bootupnews.vercel.app/sitemap.xml");
+    expect(buildPublicAppUrl("/sitemap.xml")).toBe("https://bootupnews.com/sitemap.xml");
   });
 });

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -12,7 +12,7 @@ function normalizePositiveIntegerEnv(value: string | undefined) {
   return Number.isFinite(parsed) && parsed > 0 ? String(parsed) : "";
 }
 
-export const CANONICAL_PRODUCTION_APP_URL = "https://bootupnews.vercel.app";
+export const CANONICAL_PRODUCTION_APP_URL = "https://bootupnews.com";
 
 function normalizeUrlOrigin(value: string | undefined) {
   const normalized = normalizeEnv(value);

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -47,6 +47,64 @@ describe("proxy auth return handling", () => {
     );
   });
 
+  it("redirects the legacy default Vercel host to the canonical production domain", async () => {
+    const { proxy } = await import("@/proxy");
+
+    const response = await proxy(
+      {
+        url: "https://bootupnews.vercel.app/briefing/2026-05-06?ref=legacy",
+        headers: new Headers({ host: "bootupnews.vercel.app" }),
+        cookies: {
+          getAll: () => [],
+          set: () => undefined,
+        },
+      } as unknown as NextRequest,
+    );
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get("location")).toBe(
+      "https://bootupnews.com/briefing/2026-05-06?ref=legacy",
+    );
+    expect(getUser).not.toHaveBeenCalled();
+  });
+
+  it("redirects the www host to the apex canonical production domain", async () => {
+    const { proxy } = await import("@/proxy");
+
+    const response = await proxy(
+      {
+        url: "https://www.bootupnews.com/signals?ref=www",
+        headers: new Headers({ host: "www.bootupnews.com" }),
+        cookies: {
+          getAll: () => [],
+          set: () => undefined,
+        },
+      } as unknown as NextRequest,
+    );
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get("location")).toBe("https://bootupnews.com/signals?ref=www");
+    expect(getUser).not.toHaveBeenCalled();
+  });
+
+  it("does not redirect Vercel preview deployment hosts", async () => {
+    const { proxy } = await import("@/proxy");
+
+    const response = await proxy(
+      {
+        url: "https://feature-x-bootupnews.vercel.app/signals",
+        headers: new Headers({ host: "feature-x-bootupnews.vercel.app" }),
+        cookies: {
+          getAll: () => [],
+          set: () => undefined,
+        },
+      } as unknown as NextRequest,
+    );
+
+    expect(response.headers.get("location")).toBeNull();
+    expect(getUser).toHaveBeenCalled();
+  });
+
   it("does not refresh auth state on the callback route before code exchange", async () => {
     const { proxy } = await import("@/proxy");
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,8 +4,34 @@ import { NextResponse, type NextRequest } from "next/server";
 import { buildAuthCallbackExchangeUrl, hasAuthReturnParams } from "@/lib/auth";
 import { env, isSupabaseConfigured } from "@/lib/env";
 
+const CANONICAL_HOST = "bootupnews.com";
+const LEGACY_REDIRECT_HOSTS = new Set(["bootupnews.vercel.app", "www.bootupnews.com"]);
+
+function buildCanonicalHostRedirectUrl(requestUrl: URL, host: string) {
+  const normalizedHost = host.split(":")[0]?.toLowerCase() ?? "";
+
+  if (!LEGACY_REDIRECT_HOSTS.has(normalizedHost)) {
+    return null;
+  }
+
+  const redirectUrl = new URL(requestUrl);
+  redirectUrl.protocol = "https:";
+  redirectUrl.hostname = CANONICAL_HOST;
+  redirectUrl.port = "";
+  return redirectUrl;
+}
+
 export async function proxy(request: NextRequest) {
   const requestUrl = new URL(request.url);
+  const canonicalRedirectUrl = buildCanonicalHostRedirectUrl(
+    requestUrl,
+    request.headers?.get("host") ?? requestUrl.host,
+  );
+
+  if (canonicalRedirectUrl) {
+    return NextResponse.redirect(canonicalRedirectUrl, 301);
+  }
+
   const isAuthCallbackRequest = requestUrl.pathname === "/auth/callback";
   const isPasswordResetRequest = requestUrl.pathname === "/reset-password";
 


### PR DESCRIPTION
## Summary
- set bootupnews.com as the repo-controlled canonical public origin
- add exact-host redirects for legacy Vercel/default hosts while preserving preview deployments
- update public URL examples, metadata tests, and package identity to bootupnews

## Verification
- npm install
- npm run lint
- npm run test
- npm run build
- local robots/sitemap/canonical/OG/Twitter checks
- local redirect smoke for legacy and preview hosts
