### PR TITLE
fix: trim trailing newlines from Notion env vars

### DIFF
--- a/src/app/api/editorial/push-approved/route.ts
+++ b/src/app/api/editorial/push-approved/route.ts
@@ -286,7 +286,7 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const notionDbId = process.env.NOTION_EDITORIAL_QUEUE_DB_ID;
+  const notionDbId = process.env.NOTION_EDITORIAL_QUEUE_DB_ID?.trim();
   if (!notionDbId) {
     return NextResponse.json({ error: "NOTION_EDITORIAL_QUEUE_DB_ID is not configured." }, { status: 500 });
   }

--- a/src/lib/editorial-staging/notion-writer.ts
+++ b/src/lib/editorial-staging/notion-writer.ts
@@ -24,7 +24,7 @@ export async function writeEditorialQueueRow(input: {
   notionDbId: string;
 }): Promise<void> {
   const { candidate, briefingDate, notionDbId } = input;
-  const token = process.env.NOTION_TOKEN;
+  const token = process.env.NOTION_TOKEN?.trim();
 
   if (!token) {
     throw new Error("NOTION_TOKEN is not configured.");
@@ -64,6 +64,14 @@ export async function writeEditorialQueueRow(input: {
 
   if (!response.ok) {
     const text = await response.text().catch(() => "(no body)");
-    throw new Error(`Notion write failed (${response.status}): ${text.slice(0, 500)}`);
+    let parsed: unknown;
+    try { parsed = JSON.parse(text); } catch { parsed = text; }
+    console.error("[notion-writer] write failed", {
+      status: response.status,
+      headline: input.candidate.headline.slice(0, 80),
+      notionDbId: input.notionDbId,
+      responseBody: parsed,
+    });
+    throw new Error(`Notion write failed (${response.status}): ${text}`);
   }
 }

--- a/src/lib/editorial-staging/runner.ts
+++ b/src/lib/editorial-staging/runner.ts
@@ -207,7 +207,7 @@ export async function runEditorialStaging(options: {
   const now = options.now ?? new Date();
   const timestamp = now.toISOString();
   const briefingDate = todayTaipei(now);
-  const notionDbId = process.env.NOTION_EDITORIAL_QUEUE_DB_ID;
+  const notionDbId = process.env.NOTION_EDITORIAL_QUEUE_DB_ID?.trim();
 
   if (!notionDbId) {
     return buildFailureResult(timestamp, briefingDate, "NOTION_EDITORIAL_QUEUE_DB_ID is not configured.");


### PR DESCRIPTION
## Summary
- `NOTION_EDITORIAL_QUEUE_DB_ID` and `NOTION_TOKEN` are trimmed at every read site (`runner.ts`, `notion-writer.ts`, `push-approved/route.ts`)
- Trailing newline in the Vercel env var was causing Notion API validation errors, resulting in `notionRowsWritten: 0` despite candidates being selected

## Test plan
- [ ] Deploy and hit `/api/editorial/test-stage` — confirm `notionRowsWritten` matches `candidateCount`
- [ ] Verify rows appear in Notion Editorial Queue DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)