### PR TITLE
feat: editorial flow testing — AI/Human provenance columns, Notion schema, Supabase migration (PRD-64)

### DIFF
--- a/docs/engineering/bug-fixes/push-approved-token-trim-2026-05-16.md
+++ b/docs/engineering/bug-fixes/push-approved-token-trim-2026-05-16.md
@@ -1,0 +1,34 @@
+# Bug Fix: push-approved 401 from untrimmed token query param
+
+**Date:** 2026-05-16
+**PR:** #240
+**Severity:** Blocking (editorial push flow non-functional)
+**PRD:** PRD-64 (Editorial Automation Pipeline)
+
+## Symptom
+
+`/api/editorial/push-approved?token=<secret>` returned 401 on every request
+even when the correct secret was supplied.
+
+## Root Cause
+
+`EDITORIAL_PUSH_SECRET` from the environment was trimmed with `.trim()`, but
+the `token` value read from `req.nextUrl.searchParams.get("token")` was not.
+A trailing whitespace or newline difference between the two strings caused the
+strict equality check to fail.
+
+## Fix
+
+Added `.trim()` to the incoming query param:
+
+```typescript
+const provided = url.searchParams.get("token")?.trim();
+const expected = process.env.EDITORIAL_PUSH_SECRET?.trim();
+if (!expected || provided !== expected) { ... }
+```
+
+## Pattern
+
+Same class of issue as the Notion env-var trailing-newline bug fixed in PR #239.
+Any secret comparison that reads from both an env var and an external source
+(query param, header, request body) must trim both sides.

--- a/src/app/api/editorial/push-approved/route.ts
+++ b/src/app/api/editorial/push-approved/route.ts
@@ -283,13 +283,13 @@ async function pushApprovedRow(
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
-  const token = url.searchParams.get("token");
-  const pushSecret = process.env.EDITORIAL_PUSH_SECRET?.trim();
+  const provided = url.searchParams.get("token")?.trim();
+  const expected = process.env.EDITORIAL_PUSH_SECRET?.trim();
 
-  if (!pushSecret || token !== pushSecret) {
+  if (!expected || provided !== expected) {
     logServerEvent("warn", "Editorial push: unauthorized request rejected", {
       route: "/api/editorial/push-approved",
-      hasSecret: Boolean(pushSecret),
+      hasSecret: Boolean(expected),
     });
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/src/app/api/editorial/push-approved/route.ts
+++ b/src/app/api/editorial/push-approved/route.ts
@@ -166,9 +166,16 @@ async function pushApprovedRow(
     const slotValue = getSelect(props["Slot"]);
     const finalSlateTier = slotValue === "Core" ? "core" : "context";
     const category = getSelect(props["Category"]);
-    const witm = getRichText(props["WITM"]);
-    const wlti = getRichText(props["WLTI"]);
-    const witc = getRichText(props["WITC"]);
+    // WITM: prefer human-edited; fall back to AI draft
+    const witmHuman = getRichText(props["WITM (Human)"]);
+    const witmAi    = getRichText(props["WITM (AI Draft)"]);
+    const witm      = witmHuman || witmAi;
+    // WITC + WLTI: separate AI draft and human columns → signal_posts
+    const witcAi    = getRichText(props["WITC (AI Draft)"]);
+    const witcHuman = getRichText(props["WITC (Human)"]);
+    const wltiAi    = getRichText(props["WLTI (AI Draft)"]);
+    const wltiHuman = getRichText(props["WLTI (Human)"]);
+    const editorialSource = getSelect(props["Editorial Source"]);
     const sourceUrl = getUrl(props["Source URL"]);
     const source = getRichText(props["Source"]);
     const articleBody = getRichText(props["Article Body"]);
@@ -187,8 +194,9 @@ async function pushApprovedRow(
       tags: category ? [category] : [],
       signal_score: null,
       selection_reason: "Editorial queue push — approved via Notion workflow.",
-      ai_why_it_matters: witm || "",
-      edited_why_it_matters: null,
+      // WITM — write AI draft to ai_why_it_matters; human override to edited_why_it_matters
+      ai_why_it_matters: witmAi || witm || "",
+      edited_why_it_matters: witmHuman || null,
       published_why_it_matters: null,
       why_it_matters_validation_status: witm
         ? "passed"
@@ -218,20 +226,20 @@ async function pushApprovedRow(
       witm_draft_generated_by: null,
       witm_draft_generated_at: null,
       witm_draft_model: null,
+      // WITC + WLTI provenance columns (new)
+      ai_what_it_connects_to: witcAi || null,
+      human_what_it_connects_to: witcHuman || null,
+      ai_what_led_to_it: wltiAi || null,
+      human_what_led_to_it: wltiHuman || null,
+      editorial_content_source: editorialSource?.toLowerCase() || null,
       created_at: now,
       updated_at: now,
     };
 
-    // Log non-mapped Notion fields that have no signal_posts column
-    const unmappedFields: string[] = [];
-    if (wlti) unmappedFields.push("WLTI (what_led_to_it — no column in signal_posts)");
-    if (witc) unmappedFields.push("WITC (what_it_connects_to — no column in signal_posts)");
-    if (newsletterCoOccurrence > 0) unmappedFields.push("Newsletter Co-occurrence (no column in signal_posts)");
-
-    if (unmappedFields.length > 0) {
-      logServerEvent("warn", "Editorial push: some Notion fields have no signal_posts mapping", {
+    if (newsletterCoOccurrence > 0) {
+      logServerEvent("info", "Editorial push: newsletter co-occurrence present (no signal_posts column)", {
         headline: headline.slice(0, 60),
-        unmappedFields,
+        newsletterCoOccurrence,
       });
     }
 

--- a/src/lib/editorial-staging/notion-writer.ts
+++ b/src/lib/editorial-staging/notion-writer.ts
@@ -39,6 +39,7 @@ export async function writeEditorialQueueRow(input: {
     "Briefing Date": { date: { start: briefingDate } },
     "Status": { select: { name: "raw" } },
     "Pushed to Supabase": { checkbox: false },
+    "Editorial Source": { select: { name: "AI" } },
   };
 
   if (candidate.url) {

--- a/src/lib/editorial-staging/runner.ts
+++ b/src/lib/editorial-staging/runner.ts
@@ -26,6 +26,7 @@ export type EditorialStagingRunSummary = {
   contextCount: number;
   categoryBreakdown: Record<string, number>;
   notionRowsWritten: number;
+  notionErrors: string[];
 };
 
 export type EditorialStagingRunResult = {
@@ -197,6 +198,7 @@ function buildFailureResult(
       contextCount: 0,
       categoryBreakdown: {},
       notionRowsWritten: 0,
+      notionErrors: [],
     },
   };
 }
@@ -257,12 +259,15 @@ export async function runEditorialStaging(options: {
 
   // Step F: Write to Notion Editorial Queue
   let notionRowsWritten = 0;
+  const notionErrors: string[] = [];
 
   for (const candidate of selected) {
     try {
       await writeEditorialQueueRow({ candidate, briefingDate, notionDbId });
       notionRowsWritten += 1;
     } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      notionErrors.push(`[${candidate.headline.slice(0, 40)}] ${msg}`);
       logServerEvent("error", "Editorial staging: Notion row write failed", {
         headline: candidate.headline.slice(0, 60),
         slot: candidate.slot,
@@ -320,6 +325,7 @@ export async function runEditorialStaging(options: {
       contextCount,
       categoryBreakdown,
       notionRowsWritten,
+      notionErrors,
     },
   };
 }


### PR DESCRIPTION
## Summary

End-to-end editorial flow validation PR. Do not merge until workflow is confirmed.

### Notion Editorial Queue schema
- Renamed `WITM` / `WITC` / `WLTI` → `WITM (Human)` / `WITC (Human)` / `WLTI (Human)`
- Added `WITM (AI Draft)`, `WITC (AI Draft)`, `WLTI (AI Draft)` (RICH_TEXT)
- Added `Editorial Source` select: `AI` / `Human` / `AI+Human`

### Supabase migration (`add_witc_wlti_ai_human_columns`) — already applied
- `ai_what_it_connects_to` / `human_what_it_connects_to`
- `ai_what_led_to_it` / `human_what_led_to_it`
- `editorial_content_source` constrained to `ai | human | ai+human`

### Code
- `push-approved/route.ts` — reads all 6 provenance Notion columns; routes AI drafts → `ai_*`, human edits → `human_*`; WITM human maps to `edited_why_it_matters`
- `notion-writer.ts` — auto-stamps `Editorial Source: AI` on every pipeline-staged row
- `runner.ts` — surfaces `notionErrors[]` in run summary so Notion write failures appear in the HTTP response (debug aid; remove after NOTION_TOKEN integration is connected)

## Remaining before merge
- [ ] Connect **NOTION_TOKEN** integration to Editorial Queue database in Notion (`...` → Connections → Add connections → NOTION_TOKEN)
- [ ] Hit `/api/editorial/test-stage` and confirm `notionRowsWritten` = 5 and `notionErrors` is empty
- [ ] Hit `/api/editorial/push-approved?token=<SECRET>` with an approved row and confirm Supabase insert + Notion `Pushed to Supabase` checkbox flips
- [ ] Remove `notionErrors` debug field from `runner.ts` summary (or keep — low risk)

## Test plan
- [ ] `notionRowsWritten` matches `candidateCount` after connecting the integration
- [ ] `editorial_content_source = 'ai'` on pipeline-staged rows in Supabase
- [ ] `WITM (AI Draft)` populated in Notion when AI generates it; `WITM (Human)` populated when BM edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)