### PR TITLE
fix: trim incoming token in push-approved auth check

### DIFF
--- a/src/app/api/editorial/push-approved/route.ts
+++ b/src/app/api/editorial/push-approved/route.ts
@@ -275,7 +275,7 @@ async function pushApprovedRow(
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
-  const token = url.searchParams.get("token");
+  const token = url.searchParams.get("token")?.trim();
   const pushSecret = process.env.EDITORIAL_PUSH_SECRET?.trim();
 
   if (!pushSecret || token !== pushSecret) {


### PR DESCRIPTION
## Summary
- One-line fix: `url.searchParams.get(\"token\")?.trim()` in `src/app/api/editorial/push-approved/route.ts`
- Mirrors the existing `process.env.EDITORIAL_PUSH_SECRET?.trim()` so a trailing newline on the calling side (e.g. shell var captured with `\n`) doesn't produce a spurious 401 against a value that's otherwise correct.

## Context
The env-var side was already trimmed since the route was created in #237. The asymmetry meant a clean env var + whitespace-tainted incoming token would still fail. This is the true analog of the notion-writer.ts trim fix.

## Test plan
- [ ] Re-run the cron / manual `GET /api/editorial/push-approved?token=$EDITORIAL_PUSH_SECRET` and confirm 200 instead of 401
- [ ] Verify `EDITORIAL_PUSH_SECRET` is set in Vercel production env (separate from this code fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)