### PR TITLE
fix: push-approved NOT NULL failures + NOTION_TOKEN trim + pool depth logging (PRD-64)

### DIFF
--- a/docs/engineering/bug-fixes/push-approved-notnull-and-token-trim-2026-05-16.md
+++ b/docs/engineering/bug-fixes/push-approved-notnull-and-token-trim-2026-05-16.md
@@ -1,0 +1,51 @@
+# Bug Fix: push-approved NOT NULL insert failures + NOTION_TOKEN trim gap
+
+**Date:** 2026-05-16
+**PR:** fix/editorial-pipeline-gaps
+**Severity:** Blocking (every push-approved insert would fail; Notion reads would fail on whitespace tokens)
+**PRD:** PRD-64 (Editorial Automation Pipeline)
+
+## Symptoms
+
+1. `POST /api/editorial/push-approved` — every `signal_posts` insert failed with a
+   Postgres NOT NULL constraint violation on `source_name` / `source_url`.
+2. Notion API calls inside `push-approved` (querying approved rows, marking rows pushed)
+   would fail if `NOTION_TOKEN` had a trailing newline — same class of bug fixed in
+   PR #239 for `notion-writer.ts`, but missed in the `notionRequest` helper.
+
+## Root Causes
+
+### Bug 1 — NOT NULL columns passed `null`
+`signal_posts.source_name` and `signal_posts.source_url` are both `NOT NULL`.
+The insert payload wrote:
+```typescript
+source_name: source || null,   // null when Notion Source field is blank
+source_url: sourceUrl || null, // null when Notion Source URL field is blank
+```
+Postgres rejected the insert with a NOT NULL constraint error on every row where
+either field was missing from the Notion record.
+
+### Bug 2 — NOTION_TOKEN not trimmed in `notionRequest`
+The `notionRequest` helper that handles all Notion API calls in `push-approved/route.ts`
+read the token without `.trim()`:
+```typescript
+const token = process.env.NOTION_TOKEN;  // trailing newline → 401 from Notion
+```
+PR #239 added `.trim()` to `notion-writer.ts` but not to this helper.
+
+## Fixes
+
+```typescript
+// Bug 1 — empty-string fallback for NOT NULL columns
+source_name: source || "",
+source_url: sourceUrl || "",
+
+// Bug 2 — trim NOTION_TOKEN at read site
+const token = process.env.NOTION_TOKEN?.trim();
+```
+
+## Pattern
+
+Any column with `is_nullable = 'NO'` in `signal_posts` must never receive `null`.
+Use `|| ""` for text columns and `|| []` for array columns.
+Any `process.env.*` read that feeds an external API header should call `.trim()`.

--- a/src/app/api/editorial/push-approved/route.ts
+++ b/src/app/api/editorial/push-approved/route.ts
@@ -58,7 +58,7 @@ async function notionRequest(
   method: string,
   body?: unknown,
 ): Promise<unknown> {
-  const token = process.env.NOTION_TOKEN;
+  const token = process.env.NOTION_TOKEN?.trim();
   if (!token) throw new Error("NOTION_TOKEN is not configured.");
 
   const response = await fetch(`https://api.notion.com/v1${path}`, {
@@ -188,8 +188,8 @@ async function pushApprovedRow(
       briefing_date: briefingDate,
       rank,
       title: headline,
-      source_name: source || null,
-      source_url: sourceUrl || null,
+      source_name: source || "",
+      source_url: sourceUrl || "",
       summary: articleBody || "",
       tags: category ? [category] : [],
       signal_score: null,

--- a/src/lib/editorial-staging/runner.ts
+++ b/src/lib/editorial-staging/runner.ts
@@ -254,6 +254,14 @@ export async function runEditorialStaging(options: {
   // Step D: Dedup across both batches
   const dedupedPool = deduplicateCandidates(newsletterCandidates, rssCandidates);
 
+  logServerEvent("info", "Editorial staging: candidate pool after dedup", {
+    briefingDate,
+    rssInputCount: rssCandidates.length,
+    newsletterInputCount: newsletterCandidates.length,
+    dedupedPoolSize: dedupedPool.length,
+    poolHeadlines: dedupedPool.slice(0, 10).map((c) => c.headline.slice(0, 60)),
+  });
+
   // Step E: Score and select top 7
   const selected = scoreAndSelect(dedupedPool);
 


### PR DESCRIPTION
## Summary
Three blocking fixes for the editorial automation pipeline:

**1. push-approved: NOT NULL insert failures (blocking)**
`signal_posts.source_name` and `source_url` are NOT NULL but the route passed `null` when Notion fields were blank. Every insert would fail. Fixed to `source || ""` and `sourceUrl || ""`.

**2. push-approved: NOTION_TOKEN not trimmed in notionRequest helper**
The Notion API helper that queries approved rows and marks them pushed read `NOTION_TOKEN` without `.trim()`. Same trailing-whitespace bug as PR #239 but missed in this code path.

**3. runner.ts: pool depth logging**
Adds `dedupedPool.length` log between Steps D and E so Context slot gaps are diagnosable without waiting for the next cron run.

## Test plan (preview required before merge)
- [ ] Hit `/api/editorial/test-stage` on preview URL — confirm `notionRowsWritten` matches `candidateCount` and `Article Body` is populated
- [ ] In Notion, set 1 row Status → `approved`, `Pushed to Supabase` = unchecked
- [ ] Hit `/api/editorial/push-approved?token=<secret>` on preview URL
- [ ] Confirm row appears in Supabase `signal_posts` with `is_live = false`, `editorial_status = needs_review`
- [ ] Confirm Notion row updated: `Pushed to Supabase = true`, `Supabase Row ID` populated
- [ ] Check Vercel logs for `Editorial staging: candidate pool after dedup` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)