### PR TITLE
fix: make source_url nullable for editorial rows without a URL

### DIFF
--- a/docs/engineering/bug-fixes/source-url-not-null-check-constraint-2026-05-16.md
+++ b/docs/engineering/bug-fixes/source-url-not-null-check-constraint-2026-05-16.md
@@ -1,0 +1,42 @@
+# Bug Fix: source_url NOT NULL + CHECK constraint conflict
+
+**Date:** 2026-05-16
+**PR:** fix/source-url-nullable
+**Severity:** Blocking (every push-approved insert for rows with no Source URL failed)
+**PRD:** PRD-64 (Editorial Automation Pipeline)
+
+## Symptom
+
+`POST /api/editorial/push-approved` — any Notion row without a Source URL produced:
+
+```
+signal_posts insert failed: new row for relation "signal_posts" violates
+check constraint "signal_posts_public_source_url_check"
+```
+
+## Root Cause
+
+`signal_posts.source_url` had two conflicting constraints:
+
+1. `NOT NULL DEFAULT ''` — no nulls, default to empty string
+2. `CHECK (btrim(source_url) <> '' AND source_url ~* '^https?://')` — rejects empty strings and non-URL values
+
+The default value `''` itself fails the CHECK, and the `|| ""` fallback added in PR #243 (to satisfy NOT NULL) also fails it. There was no valid way to represent "no URL" without a real `https://...` value.
+
+## Fix
+
+```sql
+ALTER TABLE signal_posts ALTER COLUMN source_url DROP NOT NULL;
+```
+
+With NOT NULL removed, `NULL` is the correct representation for "no URL". The CHECK constraint evaluates to UNKNOWN for NULL (which passes), so format enforcement still applies for any non-null value.
+
+Code updated: `source_url: sourceUrl || null` (reverted the `|| ""` fallback from PR #243).
+
+## Pattern
+
+Any column with both `NOT NULL` and a CHECK that rejects the empty string must either:
+- Allow NULL for the "absent" case, or
+- Have a meaningful non-empty default that satisfies the CHECK.
+
+The `is_nullable = 'NO'` + `DEFAULT ''` + CHECK combination is a schema anti-pattern. Use NULL for absent optional fields.

--- a/docs/product/prd/prd-64-editorial-automation-pipeline.md
+++ b/docs/product/prd/prd-64-editorial-automation-pipeline.md
@@ -34,3 +34,6 @@
 - `src/lib/editorial-staging/email.ts` — sends Resend completion email
 - `src/lib/editorial-staging/runner.ts` — orchestrates Steps B–G
 - `src/app/api/editorial/push-approved/route.ts` — approval promotion endpoint
+
+## Schema Notes
+- `signal_posts.source_url`: NOT NULL dropped (migration `20260516120000_source_url_drop_not_null.sql`). The column has a CHECK constraint requiring `https?://` format when non-null; Notion-originated editorial rows may have no source URL, so NULL is the correct representation. The CHECK still enforces format for any non-null value.

--- a/src/app/api/editorial/push-approved/route.ts
+++ b/src/app/api/editorial/push-approved/route.ts
@@ -189,7 +189,7 @@ async function pushApprovedRow(
       rank,
       title: headline,
       source_name: source || "",
-      source_url: sourceUrl || "",
+      source_url: sourceUrl || null,
       summary: articleBody || "",
       tags: category ? [category] : [],
       signal_score: null,

--- a/supabase/migrations/20260516120000_source_url_drop_not_null.sql
+++ b/supabase/migrations/20260516120000_source_url_drop_not_null.sql
@@ -1,0 +1,6 @@
+-- source_url has a CHECK constraint requiring a valid https?:// URL when non-null.
+-- The NOT NULL constraint prevented inserting editorial rows that have no source URL
+-- (e.g. Notion-originated content where the Source URL field is blank).
+-- Dropping NOT NULL lets the column be NULL for those rows; the CHECK still
+-- enforces format for any non-null value. source_name retains NOT NULL + default ''.
+ALTER TABLE signal_posts ALTER COLUMN source_url DROP NOT NULL;


### PR DESCRIPTION
## Summary

- `signal_posts.source_url` had `NOT NULL` + a `CHECK` constraint requiring a valid `https?://` URL — making it impossible to insert Notion-originated editorial rows where the Source URL field is blank
- Drops `NOT NULL` on `source_url`; the `CHECK` constraint still enforces valid URL format for any non-null value
- Updates `push-approved` to pass `null` (was `""` which also failed the check) when Notion Source URL is absent

## Root cause

The column had contradictory constraints: `NOT NULL DEFAULT ''` but `CHECK (btrim(source_url) <> '' AND source_url ~* '^https?://')`. The default `''` itself would fail the check, and `""` as a code fallback did too.

## Test plan

- [ ] Push endpoint returns `status: inserted` for test row with no Source URL
- [ ] Rows with a real URL still insert correctly
- [ ] Existing 113 `signal_posts` rows unaffected (zero had empty source_url)

🤖 Generated with [Claude Code](https://claude.com/claude-code)