### PR TITLE
infra: raise ingestion function timeout to 60s (Vercel Hobby max)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,5 +8,10 @@
       "path": "/api/cron/fetch-editorial-inputs",
       "schedule": "45 11 * * *"
     }
-  ]
+  ],
+  "functions": {
+    "src/app/api/cron/fetch-editorial-inputs/route.ts": {
+      "maxDuration": 60
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Adds a `functions` entry to `vercel.json` setting `maxDuration: 60` for the daily ingestion cron route (`src/app/api/cron/fetch-editorial-inputs/route.ts`).
- Vercel Hobby's default function timeout is 10s; the RSS branch alone can spend ~9s on a single slow source (6 items × 4500ms × 1 retry) before normalization, dedup, clustering, ranking, and the Notion write begin. The 10s ceiling is being silently hit, leaving Notion with zero rows and no surfaced error.
- 60s is the Vercel Hobby maximum and gives the pipeline real headroom while remaining within tier limits.

## What changed

`vercel.json`:

```diff
   ],
+  "functions": {
+    "src/app/api/cron/fetch-editorial-inputs/route.ts": {
+      "maxDuration": 60
+    }
+  }
 }
```

## Why the App Router path

The function key uses the source-file path (`src/app/.../route.ts`) rather than the Pages-style `api/cron/fetch-editorial-inputs.js` because this repo uses Next.js App Router — the route handler lives at `src/app/api/cron/fetch-editorial-inputs/route.ts`.

## Phase context

This is Phase 1 of the pipeline reliability migration (Phase 0 audited the cron surface; Phases 2–4 will add idempotency, a health check, and migrate scheduling to cron-job.org). No code paths change behavior — only the function ceiling is raised.

## Reviewer notes

- Existing `crons` entries are preserved untouched.
- No code changes; only `vercel.json`.
- Vercel will apply the new `maxDuration` on next deploy. No manual dashboard action required for the timeout itself. (Scheduling migration to cron-job.org is a later phase.)

## Test plan

- [ ] `vercel.json` parses as valid JSON (verified locally with `node -e`).
- [ ] After deploy, confirm in Vercel function logs that the function is configured for 60s (look at next scheduled run duration / `Max Duration` in the Function tab).
- [ ] Confirm next scheduled ingestion run (10:15 UTC or 11:45 UTC) writes the expected number of rows to the Notion Editorial Queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)