### PR TITLE
feat(notion): idempotent editorial queue writes — insert | update | skip (PRD-65 phase 3)

### DIFF
--- a/docs/engineering/protocols/editorial-automation-operating-guide.md
+++ b/docs/engineering/protocols/editorial-automation-operating-guide.md
@@ -44,3 +44,12 @@
 - Newsletter ingestion must run before RSS in the cron so that newsletter candidates can reserve rank slots before the RSS snapshot fills them.
 - Editorial staging is non-critical: cron success is determined by RSS and newsletter task results only.
 - A failed `NOTION_TOKEN` will cause staging to fail silently; check Vercel logs if Notion rows stop appearing.
+
+## Idempotency Contract (Branch C / Step E3 Notion writes)
+- Each write keys on `Headline + Briefing Date`. The runner queries the Editorial Queue database before each write and chooses one of three actions:
+  - **`inserted`** — no matching row exists. POST creates the row at `Status=raw`.
+  - **`updated`** — matching row exists at `Status=raw`. PATCH overwrites the AI-generated fields. The PATCH body intentionally omits `Status` so a write can never demote a row that may be about to be promoted.
+  - **`skipped_human_edited`** — matching row exists at any non-raw Status (including the defensive "unset" case). No write happens. BM's edits are preserved.
+- Every write logs `editorial_queue_row.action = <action>` on the event payload for operational visibility.
+- The run summary surfaces `notionRowsInserted`, `notionRowsUpdated`, and `notionRowsSkippedHumanEdited`. `notionRowsWritten` is defined as inserts + updates; skips are not counted as writes.
+- Result: a re-run with the same source set produces zero duplicates. cron-job.org transient retries and any future trigger overlap are safe at this layer.

--- a/src/lib/editorial-staging/notion-writer.test.ts
+++ b/src/lib/editorial-staging/notion-writer.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  writeEditorialQueueRow,
+  type EditorialCandidateForNotion,
+} from "@/lib/editorial-staging/notion-writer";
+
+const NOTION_DB_ID = "test-db-id";
+const BRIEFING_DATE = "2026-05-17";
+
+const baseCandidate: EditorialCandidateForNotion = {
+  headline: "Acme acquires Foo Corp",
+  source: "example.com",
+  body: "Acme paid $1B for Foo Corp.",
+  url: "https://example.com/acme-foo",
+  category: "Finance",
+  newsletterCoOccurrence: 2,
+  slot: "Core",
+};
+
+type RecordedFetch = { url: string; init: RequestInit | undefined };
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function emptyQueryResponse(): Response {
+  return jsonResponse(200, { results: [] });
+}
+
+function queryResponseWithMatch(pageId: string, statusName: string | null): Response {
+  return jsonResponse(200, {
+    results: [
+      {
+        id: pageId,
+        properties: {
+          Status: statusName === null ? { select: null } : { select: { name: statusName } },
+        },
+      },
+    ],
+  });
+}
+
+function createSuccessResponse(pageId: string): Response {
+  return jsonResponse(200, { id: pageId, object: "page" });
+}
+
+function updateSuccessResponse(pageId: string): Response {
+  return jsonResponse(200, { id: pageId, object: "page" });
+}
+
+describe("writeEditorialQueueRow — idempotent insert | update | skip", () => {
+  const calls: RecordedFetch[] = [];
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    calls.length = 0;
+    process.env.NOTION_TOKEN = "test-token";
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    delete process.env.NOTION_TOKEN;
+  });
+
+  it("inserts when no matching row exists", async () => {
+    fetchMock.mockReset();
+    fetchMock
+      .mockImplementationOnce(async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return emptyQueryResponse();
+      })
+      .mockImplementationOnce(async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return createSuccessResponse("new-page-1");
+      });
+
+    const result = await writeEditorialQueueRow({
+      candidate: baseCandidate,
+      briefingDate: BRIEFING_DATE,
+      notionDbId: NOTION_DB_ID,
+    });
+
+    expect(result).toEqual({ action: "inserted", pageId: "new-page-1" });
+    expect(calls).toHaveLength(2);
+    expect(calls[0].url).toBe(`https://api.notion.com/v1/databases/${NOTION_DB_ID}/query`);
+    expect(calls[1].url).toBe("https://api.notion.com/v1/pages");
+    expect(calls[1].init?.method).toBe("POST");
+  });
+
+  it("updates in place when a matching row exists at Status=raw", async () => {
+    fetchMock.mockReset();
+    fetchMock
+      .mockImplementationOnce(async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return queryResponseWithMatch("existing-page-7", "raw");
+      })
+      .mockImplementationOnce(async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return updateSuccessResponse("existing-page-7");
+      });
+
+    const result = await writeEditorialQueueRow({
+      candidate: baseCandidate,
+      briefingDate: BRIEFING_DATE,
+      notionDbId: NOTION_DB_ID,
+    });
+
+    expect(result).toEqual({ action: "updated", pageId: "existing-page-7" });
+    expect(calls).toHaveLength(2);
+    expect(calls[1].url).toBe("https://api.notion.com/v1/pages/existing-page-7");
+    expect(calls[1].init?.method).toBe("PATCH");
+    // Update must NOT overwrite Status — the field should be absent from the patch body.
+    const patchBody = JSON.parse((calls[1].init?.body as string) ?? "{}");
+    expect(patchBody.properties.Status).toBeUndefined();
+  });
+
+  it("skips entirely when the matching row has Status != raw", async () => {
+    fetchMock.mockReset();
+    fetchMock.mockImplementationOnce(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      return queryResponseWithMatch("touched-page-3", "Approved");
+    });
+
+    const result = await writeEditorialQueueRow({
+      candidate: baseCandidate,
+      briefingDate: BRIEFING_DATE,
+      notionDbId: NOTION_DB_ID,
+    });
+
+    expect(result).toEqual({
+      action: "skipped_human_edited",
+      pageId: "touched-page-3",
+      existingStatus: "Approved",
+    });
+    // Only the query call happened — no write.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe(`https://api.notion.com/v1/databases/${NOTION_DB_ID}/query`);
+  });
+
+  it("treats a row with an unset Status select as human-edited (defensive)", async () => {
+    fetchMock.mockReset();
+    fetchMock.mockImplementationOnce(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      return queryResponseWithMatch("orphan-page-99", null);
+    });
+
+    const result = await writeEditorialQueueRow({
+      candidate: baseCandidate,
+      briefingDate: BRIEFING_DATE,
+      notionDbId: NOTION_DB_ID,
+    });
+
+    expect(result.action).toBe("skipped_human_edited");
+    expect(result.pageId).toBe("orphan-page-99");
+    expect(result.existingStatus).toBe("(unset)");
+  });
+
+  it("filters the Notion query by both Headline AND Briefing Date", async () => {
+    fetchMock.mockReset();
+    fetchMock
+      .mockImplementationOnce(async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return emptyQueryResponse();
+      })
+      .mockImplementationOnce(async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return createSuccessResponse("new-page-2");
+      });
+
+    await writeEditorialQueueRow({
+      candidate: baseCandidate,
+      briefingDate: BRIEFING_DATE,
+      notionDbId: NOTION_DB_ID,
+    });
+
+    const queryBody = JSON.parse((calls[0].init?.body as string) ?? "{}");
+    expect(queryBody.filter.and).toHaveLength(2);
+    expect(queryBody.filter.and[0]).toEqual({
+      property: "Headline",
+      title: { equals: baseCandidate.headline },
+    });
+    expect(queryBody.filter.and[1]).toEqual({
+      property: "Briefing Date",
+      date: { equals: BRIEFING_DATE },
+    });
+  });
+
+  it("is idempotent: running twice with the same input produces one insert then one update", async () => {
+    fetchMock.mockReset();
+    fetchMock
+      // run 1: query (empty) -> create
+      .mockImplementationOnce(async () => emptyQueryResponse())
+      .mockImplementationOnce(async () => createSuccessResponse("page-XYZ"))
+      // run 2: query (returns the row we just created at raw) -> update
+      .mockImplementationOnce(async () =>
+        queryResponseWithMatch("page-XYZ", "raw"),
+      )
+      .mockImplementationOnce(async () => updateSuccessResponse("page-XYZ"));
+
+    const first = await writeEditorialQueueRow({
+      candidate: baseCandidate,
+      briefingDate: BRIEFING_DATE,
+      notionDbId: NOTION_DB_ID,
+    });
+    const second = await writeEditorialQueueRow({
+      candidate: baseCandidate,
+      briefingDate: BRIEFING_DATE,
+      notionDbId: NOTION_DB_ID,
+    });
+
+    expect(first.action).toBe("inserted");
+    expect(second.action).toBe("updated");
+    expect(second.pageId).toBe("page-XYZ");
+    // Two runs total = 4 API calls (2 queries + 1 create + 1 update). Zero
+    // duplicate-row writes.
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("throws a descriptive error when NOTION_TOKEN is unset", async () => {
+    delete process.env.NOTION_TOKEN;
+    await expect(
+      writeEditorialQueueRow({
+        candidate: baseCandidate,
+        briefingDate: BRIEFING_DATE,
+        notionDbId: NOTION_DB_ID,
+      }),
+    ).rejects.toThrow(/NOTION_TOKEN/);
+  });
+
+  it("surfaces a Notion query failure as a thrown error and does not write", async () => {
+    fetchMock.mockReset();
+    fetchMock.mockImplementationOnce(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      return jsonResponse(401, { message: "unauthorized" });
+    });
+
+    await expect(
+      writeEditorialQueueRow({
+        candidate: baseCandidate,
+        briefingDate: BRIEFING_DATE,
+        notionDbId: NOTION_DB_ID,
+      }),
+    ).rejects.toThrow(/Notion query failed \(401\)/);
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/src/lib/editorial-staging/notion-writer.ts
+++ b/src/lib/editorial-staging/notion-writer.ts
@@ -11,45 +11,119 @@ export type EditorialCandidateForNotion = {
   slot: Slot;
 };
 
+export type EditorialQueueWriteAction =
+  | "inserted"
+  | "updated"
+  | "skipped_human_edited";
+
+export type EditorialQueueWriteResult = {
+  action: EditorialQueueWriteAction;
+  /** The Notion page ID for the row (set for inserted/updated; also set for skipped). */
+  pageId: string;
+  /**
+   * Existing Status value seen when the action is `skipped_human_edited`. Omitted
+   * for inserts; for updates, this is always "raw" (otherwise we would skip).
+   */
+  existingStatus?: string;
+};
+
 const NOTION_API_VERSION = "2022-06-28";
 const NOTION_PAGES_URL = "https://api.notion.com/v1/pages";
+const NOTION_TITLE_MAX = 2000;
 
 function richText(content: string) {
-  return [{ text: { content: content.slice(0, 2000) } }];
+  return [{ text: { content: content.slice(0, NOTION_TITLE_MAX) } }];
 }
 
-export async function writeEditorialQueueRow(input: {
-  candidate: EditorialCandidateForNotion;
-  briefingDate: string;
-  notionDbId: string;
-}): Promise<void> {
-  const { candidate, briefingDate, notionDbId } = input;
-  const token = process.env.NOTION_TOKEN?.trim();
-
-  if (!token) {
-    throw new Error("NOTION_TOKEN is not configured.");
-  }
-
+function buildProperties(
+  candidate: EditorialCandidateForNotion,
+  briefingDate: string,
+  options: { includeStatus: boolean },
+): Record<string, unknown> {
   const properties: Record<string, unknown> = {
-    "Headline": { title: richText(candidate.headline) },
-    "Source": { rich_text: richText(candidate.source) },
+    Headline: { title: richText(candidate.headline) },
+    Source: { rich_text: richText(candidate.source) },
     "Article Body": { rich_text: richText(candidate.body) },
     "Newsletter Co-occurrence": { number: candidate.newsletterCoOccurrence },
-    "Slot": { select: { name: candidate.slot } },
+    Slot: { select: { name: candidate.slot } },
     "Briefing Date": { date: { start: briefingDate } },
-    "Status": { select: { name: "raw" } },
     "Pushed to Supabase": { checkbox: false },
     "Editorial Source": { select: { name: "AI" } },
   };
+
+  if (options.includeStatus) {
+    properties.Status = { select: { name: "raw" } };
+  }
 
   if (candidate.url) {
     properties["Source URL"] = { url: candidate.url };
   }
 
   if (candidate.category) {
-    properties["Category"] = { select: { name: candidate.category } };
+    properties.Category = { select: { name: candidate.category } };
   }
 
+  return properties;
+}
+
+type NotionFindMatch = {
+  pageId: string;
+  status: string | null;
+};
+
+async function findExistingRow(
+  notionDbId: string,
+  headline: string,
+  briefingDate: string,
+  token: string,
+): Promise<NotionFindMatch | null> {
+  const headlineForQuery = headline.slice(0, NOTION_TITLE_MAX);
+  const response = await fetch(
+    `https://api.notion.com/v1/databases/${notionDbId}/query`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "Notion-Version": NOTION_API_VERSION,
+      },
+      body: JSON.stringify({
+        filter: {
+          and: [
+            { property: "Headline", title: { equals: headlineForQuery } },
+            { property: "Briefing Date", date: { equals: briefingDate } },
+          ],
+        },
+        page_size: 5,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "(no body)");
+    throw new Error(`Notion query failed (${response.status}): ${text}`);
+  }
+
+  const data = (await response.json()) as {
+    results?: Array<{
+      id?: string;
+      properties?: { Status?: { select?: { name?: string } | null } };
+    }>;
+  };
+
+  const first = data.results?.[0];
+  if (!first?.id) return null;
+
+  const statusName = first.properties?.Status?.select?.name ?? null;
+  return { pageId: first.id, status: statusName };
+}
+
+async function createRow(
+  notionDbId: string,
+  candidate: EditorialCandidateForNotion,
+  briefingDate: string,
+  token: string,
+): Promise<string> {
   const response = await fetch(NOTION_PAGES_URL, {
     method: "POST",
     headers: {
@@ -59,20 +133,111 @@ export async function writeEditorialQueueRow(input: {
     },
     body: JSON.stringify({
       parent: { database_id: notionDbId },
-      properties,
+      properties: buildProperties(candidate, briefingDate, { includeStatus: true }),
     }),
   });
 
   if (!response.ok) {
     const text = await response.text().catch(() => "(no body)");
     let parsed: unknown;
-    try { parsed = JSON.parse(text); } catch { parsed = text; }
-    console.error("[notion-writer] write failed", {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+    console.error("[notion-writer] create failed", {
       status: response.status,
-      headline: input.candidate.headline.slice(0, 80),
-      notionDbId: input.notionDbId,
+      headline: candidate.headline.slice(0, 80),
+      notionDbId,
       responseBody: parsed,
     });
-    throw new Error(`Notion write failed (${response.status}): ${text}`);
+    throw new Error(`Notion create failed (${response.status}): ${text}`);
   }
+
+  const data = (await response.json()) as { id?: string };
+  if (!data.id) {
+    throw new Error("Notion create response did not contain a page id.");
+  }
+  return data.id;
+}
+
+async function updateRow(
+  pageId: string,
+  candidate: EditorialCandidateForNotion,
+  briefingDate: string,
+  token: string,
+): Promise<void> {
+  // Do not overwrite Status — the row already exists at status=raw and we
+  // never want a write to demote a row that may be about to be promoted.
+  const response = await fetch(`https://api.notion.com/v1/pages/${pageId}`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "Notion-Version": NOTION_API_VERSION,
+    },
+    body: JSON.stringify({
+      properties: buildProperties(candidate, briefingDate, { includeStatus: false }),
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "(no body)");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+    console.error("[notion-writer] update failed", {
+      status: response.status,
+      headline: candidate.headline.slice(0, 80),
+      pageId,
+      responseBody: parsed,
+    });
+    throw new Error(`Notion update failed (${response.status}): ${text}`);
+  }
+}
+
+/**
+ * Idempotent write to the Notion Editorial Queue, keyed on Headline +
+ * Briefing Date:
+ *  - inserts when no matching row exists,
+ *  - updates in place when a matching row exists with Status="raw",
+ *  - skips entirely when a matching row exists with any other Status
+ *    (the row has been touched by the human editor).
+ */
+export async function writeEditorialQueueRow(input: {
+  candidate: EditorialCandidateForNotion;
+  briefingDate: string;
+  notionDbId: string;
+}): Promise<EditorialQueueWriteResult> {
+  const { candidate, briefingDate, notionDbId } = input;
+  const token = process.env.NOTION_TOKEN?.trim();
+
+  if (!token) {
+    throw new Error("NOTION_TOKEN is not configured.");
+  }
+
+  const existing = await findExistingRow(
+    notionDbId,
+    candidate.headline,
+    briefingDate,
+    token,
+  );
+
+  if (existing) {
+    if (existing.status !== "raw") {
+      return {
+        action: "skipped_human_edited",
+        pageId: existing.pageId,
+        existingStatus: existing.status ?? "(unset)",
+      };
+    }
+    await updateRow(existing.pageId, candidate, briefingDate, token);
+    return { action: "updated", pageId: existing.pageId };
+  }
+
+  const pageId = await createRow(notionDbId, candidate, briefingDate, token);
+  return { action: "inserted", pageId };
 }

--- a/src/lib/editorial-staging/runner.ts
+++ b/src/lib/editorial-staging/runner.ts
@@ -25,7 +25,11 @@ export type EditorialStagingRunSummary = {
   coreCount: number;
   contextCount: number;
   categoryBreakdown: Record<string, number>;
+  /** Total Notion writes that mutated state — inserts + updates. Skips are not counted. */
   notionRowsWritten: number;
+  notionRowsInserted: number;
+  notionRowsUpdated: number;
+  notionRowsSkippedHumanEdited: number;
   notionErrors: string[];
 };
 
@@ -198,6 +202,9 @@ function buildFailureResult(
       contextCount: 0,
       categoryBreakdown: {},
       notionRowsWritten: 0,
+      notionRowsInserted: 0,
+      notionRowsUpdated: 0,
+      notionRowsSkippedHumanEdited: 0,
       notionErrors: [],
     },
   };
@@ -265,14 +272,29 @@ export async function runEditorialStaging(options: {
   // Step E: Score and select top 7
   const selected = scoreAndSelect(dedupedPool);
 
-  // Step F: Write to Notion Editorial Queue
-  let notionRowsWritten = 0;
+  // Step F: Write to Notion Editorial Queue (idempotent — insert | update | skip)
+  let notionRowsInserted = 0;
+  let notionRowsUpdated = 0;
+  let notionRowsSkippedHumanEdited = 0;
   const notionErrors: string[] = [];
 
   for (const candidate of selected) {
     try {
-      await writeEditorialQueueRow({ candidate, briefingDate, notionDbId });
-      notionRowsWritten += 1;
+      const result = await writeEditorialQueueRow({ candidate, briefingDate, notionDbId });
+      if (result.action === "inserted") notionRowsInserted += 1;
+      else if (result.action === "updated") notionRowsUpdated += 1;
+      else notionRowsSkippedHumanEdited += 1;
+
+      logServerEvent("info", "editorial_queue_row write", {
+        briefingDate,
+        headline: candidate.headline.slice(0, 60),
+        slot: candidate.slot,
+        editorial_queue_row: {
+          action: result.action,
+          pageId: result.pageId,
+          ...(result.existingStatus ? { existingStatus: result.existingStatus } : {}),
+        },
+      });
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       notionErrors.push(`[${candidate.headline.slice(0, 40)}] ${msg}`);
@@ -283,6 +305,8 @@ export async function runEditorialStaging(options: {
       });
     }
   }
+
+  const notionRowsWritten = notionRowsInserted + notionRowsUpdated;
 
   const coreCount = selected.filter((c) => c.slot === "Core").length;
   const contextCount = selected.filter((c) => c.slot === "Context").length;
@@ -320,6 +344,9 @@ export async function runEditorialStaging(options: {
     coreCount,
     contextCount,
     notionRowsWritten,
+    notionRowsInserted,
+    notionRowsUpdated,
+    notionRowsSkippedHumanEdited,
   });
 
   return {
@@ -333,6 +360,9 @@ export async function runEditorialStaging(options: {
       contextCount,
       categoryBreakdown,
       notionRowsWritten,
+      notionRowsInserted,
+      notionRowsUpdated,
+      notionRowsSkippedHumanEdited,
       notionErrors,
     },
   };


### PR DESCRIPTION
## Summary

Phase 3 of [PRD-65](docs/product/prd/prd-65-pipeline-reliability-external-cron-migration.md) — makes Branch C "Write to Notion" (Step E3) idempotent. Before each write the runner queries the Notion Editorial Queue by `Headline + Briefing Date` and picks one of three actions:

| Action | When | API call |
| --- | --- | --- |
| `inserted` | no matching row exists | `POST /v1/pages` at `Status=raw` |
| `updated` | matching row exists at `Status=raw` | `PATCH /v1/pages/{id}` — Status intentionally omitted from the patch body |
| `skipped_human_edited` | matching row exists at any non-`raw` Status (incl. defensive "unset" case) | no write — BM's edits preserved |

Each write logs `editorial_queue_row.action = <action>` for operational visibility.

## Why

cron-job.org will retry on transient failures, and migrating off Vercel Hobby Cron does not fully eliminate the overlap window between the two scheduled runs. Without idempotency at this layer, two runs on the same day produced 2× rows in Notion and forced BM to hand-deduplicate before review.

`Status != "raw"` means BM has touched the row. Anything from `Drafting` through `Approved` is human work — overwriting it would silently lose edits or revert approvals.

## What changed

| File | Change |
| --- | --- |
| [`src/lib/editorial-staging/notion-writer.ts`](src/lib/editorial-staging/notion-writer.ts) | `writeEditorialQueueRow` now returns `{ action, pageId, existingStatus? }` and routes through `findExistingRow` → `createRow` \| `updateRow` \| no-op. The PATCH body intentionally omits `Status`. |
| [`src/lib/editorial-staging/runner.ts`](src/lib/editorial-staging/runner.ts) | Aggregates per-action counts; logs each write's action; summary surfaces `notionRowsInserted`, `notionRowsUpdated`, `notionRowsSkippedHumanEdited`. `notionRowsWritten` is now defined as inserts + updates. |
| [`src/lib/editorial-staging/notion-writer.test.ts`](src/lib/editorial-staging/notion-writer.test.ts) | New file. 8 tests cover insert, update (asserts Status absent from PATCH), skip on non-raw, defensive skip on unset Status, filter shape sent to Notion, end-to-end idempotency across two runs (insert then update → 0 duplicates), missing `NOTION_TOKEN`, and Notion query failure propagation. |
| [`docs/engineering/protocols/editorial-automation-operating-guide.md`](docs/engineering/protocols/editorial-automation-operating-guide.md) | New "Idempotency Contract" section documenting the action contract and rationale. Satisfies the protocol-lane requirement for the release-governance-gate. |

## Constraint compliance

- No changes to Branch A (newsletter ingestion), Branch B (RSS) clustering / ranking, or the Supabase push path.
- No new dependencies.
- Logger pattern matches existing `logServerEvent` conventions in the runner.

## Acceptance check

| Criterion | Met |
| --- | --- |
| Running ingestion twice with the same source set produces the same row count in Notion, not double | ✅ (test: "is idempotent: running twice ... produces one insert then one update") |
| Rows with `Status != raw` are never modified | ✅ (tests: skip on non-raw, defensive skip on unset; the PATCH path is only reached when Status === "raw") |
| Each Notion write logs which action was taken | ✅ (`logServerEvent("info", "editorial_queue_row write", { … editorial_queue_row: { action, pageId, … } })`) |

## Local QA

- [x] `npm run lint` — clean
- [x] `npx vitest run src/lib/editorial-staging/notion-writer.test.ts` — 8/8 pass
- [x] `npm test` — full suite 97 files / 701 tests pass
- [x] `npm run build` — clean

## Phase context

| Phase | Status |
| --- | --- |
| Phase 0 — Audit | Done (no code) |
| Phase 1 — 60 s function timeout | Done ([#246](https://github.com/brandonma25/bootupnews/pull/246)) |
| Phase 2 — Decouple from Vercel Cron + `x-cron-secret` auth | Done ([#247](https://github.com/brandonma25/bootupnews/pull/247)) |
| Sync tooling — cron-job.org IaC | Done ([#248](https://github.com/brandonma25/bootupnews/pull/248)) |
| **Phase 3 — Branch C E3 idempotency** | **This PR** |
| Phase 4 — Health endpoint + Notion pipeline log | Pending |
| Phase 4.5 — Source circuit breaker + Sentry filter | Pending |
| Phase 5 — Architecture / runbook / observability docs | Pending |

## Test plan

- [x] Unit tests pass locally
- [x] Full suite pass locally
- [x] Lint pass locally
- [x] Build pass locally
- [ ] CI: pr-lint, pr-unit-tests, pr-build, pr-e2e-chromium, pr-e2e-webkit, pr-summary, feature-system-csv-validation, release-governance-gate
- [ ] Vercel preview deploy
- [ ] Post-merge: confirm during next scheduled ingestion run that the Notion Pipeline Log (Phase 4) or Vercel function log shows non-zero `notionRowsUpdated` on the second run of the day (this is the live signal that idempotency is firing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)