### PR TITLE
feat: source circuit breaker + Sentry noise filter (PRD-65 phase 4.5)

### DIFF
--- a/docs/engineering/protocols/editorial-automation-operating-guide.md
+++ b/docs/engineering/protocols/editorial-automation-operating-guide.md
@@ -34,7 +34,7 @@
 - `CRON_SECRET` — Shared secret for the `/api/cron/fetch-editorial-inputs` route. Required in Vercel env and on every cron-job.org job's custom header.
 - `ALLOW_VERCEL_CRON_FALLBACK` — Rollback flag. Defaults to unset/`false`. Set to `"true"` only to temporarily re-enable the legacy Vercel Cron `Authorization: Bearer` header during a cron-job.org outage.
 - `NOTION_PIPELINE_LOG_DB_ID` — Notion database ID for the Pipeline Log (one row per ingestion run and per health check). Schema: [`docs/notion-pipeline-log-schema.md`](../../notion-pipeline-log-schema.md). If unset, the ingestion and health endpoints log a warning and continue — pipeline-log writes are best-effort and never fail the cron.
-- `NOTION_SOURCE_HEALTH_LOG_DB_ID` — Notion database ID for the Source Health Log (per-source-per-day RSS fetch outcomes). Schema: [`docs/notion-source-health-schema.md`](../../notion-source-health-schema.md). The Phase 4 writer is in place; the Phase 4.5 circuit breaker reads from this database.
+- `NOTION_SOURCE_HEALTH_LOG_DB_ID` — Notion database ID for the Source Health Log (per-source-per-day RSS fetch outcomes). Schema: [`docs/notion-source-health-schema.md`](../../notion-source-health-schema.md). Read by the Phase 4.5 circuit breaker before every fetch and written after every fetch. If unset, the circuit breaker permissively falls through (`skip: false`) and the fetch path proceeds — observability degradation must never block ingestion.
 
 ## Key Files
 - `src/lib/editorial-staging/runner.ts` — orchestrates Steps B–G
@@ -42,7 +42,10 @@
 - `src/lib/editorial-staging/notion-writer.ts` — Notion REST API writer
 - `src/lib/editorial-staging/email.ts` — Resend completion email
 - `src/lib/observability/pipeline-log.ts` — Pipeline Log writer (Phase 4)
-- `src/lib/observability/source-health-log.ts` — Source Health Log writer (Phase 4; consumed by Phase 4.5 circuit breaker)
+- `src/lib/observability/source-health-log.ts` — Source Health Log writer (Phase 4)
+- `src/lib/observability/rss-circuit-breaker.ts` — RSS circuit breaker (Phase 4.5)
+- `src/lib/rss.ts` — `fetchFeedArticles` invokes the circuit breaker pre-fetch and records per-source outcomes
+- `src/lib/sentry-config.ts` — `isFilteredRssNoiseEvent` drops `Feed request retry exhausted for *` events from Sentry
 - `src/app/api/cron/health/route.ts` — health-check endpoint (Phase 4)
 - `src/app/api/editorial/push-approved/route.ts` — approval promotion endpoint
 
@@ -64,4 +67,14 @@
 - The ingestion endpoint writes one row to the Notion Pipeline Log on every completion (success or failure). `Status` is `ok` when every branch succeeded, `warn` when staging surfaced row-level errors but the cron still returned 200, `fail` otherwise. Body includes per-branch success flags, the `inserted/updated/skipped` row counts from Branch C, and the row total for the day.
 - The health endpoint writes one Pipeline Log row per invocation, capturing today's row count, the expected sources, and any missing sources. `fail` (HTTP 500) when row count < 7; `warn` (HTTP 200) when row count ≥ 7 but at least one expected source is missing; `ok` (HTTP 200) otherwise.
 - Both writers are best-effort. Missing `NOTION_PIPELINE_LOG_DB_ID`, missing `NOTION_TOKEN`, or any Notion API failure produces a warn-level log entry and a `{ written: false, reason }` result — the underlying cron or health check is never failed by a log write.
-- The Source Health Log writer (`src/lib/observability/source-health-log.ts`) is keyed on `(Source, Date)` and follows the same insert-or-update idempotency contract as Branch C E3. The Branch B fetch path will call this writer in Phase 4.5 alongside the circuit breaker.
+- The Source Health Log writer (`src/lib/observability/source-health-log.ts`) is keyed on `(Source, Date)` and follows the same insert-or-update idempotency contract as Branch C E3. The Branch B fetch path calls this writer on every fetch attempt — `success` increments `Success Count` and updates `Last Successful Fetch`; `fail` increments `Fail Count`; `skipped_circuit_breaker` does not increment either counter and bypasses Sentry.
+
+## RSS Circuit Breaker (Branch B Step R2)
+- Threshold: today's `Fail Count` for a source ≥ 5 → skip the next fetch for that source. Implementation: [`src/lib/observability/rss-circuit-breaker.ts`](../../../src/lib/observability/rss-circuit-breaker.ts).
+- Auto-reset: daily rollover at Taipei midnight. Each new day's row starts at `Fail Count = 0`, so a skipped source is automatically retried on the next day's first ingestion run (~22 h window between the last 19:45 Taipei run and the next 18:15 Taipei run).
+- Skip behavior:
+  - Writes a Source Health Log entry with `Last Outcome = skipped_circuit_breaker`.
+  - Throws `RssCircuitBreakerSkipError` so the caller's existing per-source failure path records the skip in the failure list without a network call.
+  - Does **not** call `captureRssFailure` — Sentry stays quiet for known-flaky sources.
+- Sentry noise filter: `sentry.server.config.ts` runs `isFilteredRssNoiseEvent` in `beforeSend` and drops events whose exception message matches `^Feed request retry exhausted for `. Those failures are now tracked exclusively in the Source Health Log. All other `RssError` variants continue to report normally.
+- Permissive failure contract: if `NOTION_SOURCE_HEALTH_LOG_DB_ID` is unset or the Notion query fails, the circuit breaker returns `skip: false` and the fetch proceeds. Observability degradation must never silently disable ingestion.

--- a/docs/notion-source-health-schema.md
+++ b/docs/notion-source-health-schema.md
@@ -50,16 +50,34 @@ A health check with `Row Count >= 7` but `missing.length > 0` returns
 ## Phase 4.5 — circuit breaker integration
 
 The Branch B RSS fetch step (R2) consults this database before fetching each
-source:
+source. Implementation lives in
+[`src/lib/observability/rss-circuit-breaker.ts`](../src/lib/observability/rss-circuit-breaker.ts)
+and is invoked from [`src/lib/rss.ts`](../src/lib/rss.ts) inside
+`fetchFeedArticles`.
 
-- Sum `Fail Count` for the source over the trailing 24 hours.
-- If `>= 5`, skip the source for this run. Write a Source Health Log entry
-  with `Last Outcome = skipped_circuit_breaker`. Do **not** report to Sentry.
-- Auto-reset: a source skipped continuously for 24 hours is re-attempted on
-  the next run regardless of past failure count.
+- The pre-fetch gate reads today's row for the source and inspects `Fail Count`.
+- If `Fail Count >= 5`, skip the fetch. Write a Source Health Log entry for the
+  same `(Source, Date)` with `Last Outcome = skipped_circuit_breaker`, then
+  throw `RssCircuitBreakerSkipError`. The skip is **not** reported to Sentry —
+  circuit-breaker skips bypass `captureRssFailure` entirely.
+- Auto-reset: the Source Health Log is keyed on Taipei-day. Each new day starts
+  at `Fail Count = 0`, so a skipped source is automatically retried on the next
+  day's first ingestion run. The scheduled runs at 18:15 and 19:45 Taipei
+  produce a worst-case skip window of ~22 hours — close enough to the spec's
+  24-hour auto-reset; daily rollover is the canonical reset mechanism.
+- After each fetch attempt, the fetch path writes the outcome:
+  - **`success`** — updates `Last Successful Fetch` and increments `Success Count`.
+  - **`fail`** — increments `Fail Count`; leaves `Last Successful Fetch` untouched. The underlying error still reports to Sentry **unless** it matches the `Feed request retry exhausted for *` pattern (those are now dropped by the `beforeSend` filter and tracked here instead).
+  - **`skipped_circuit_breaker`** — does not increment either counter.
 
-This contract is implemented in PRD-65 Phase 4.5. Phase 4 ships the schema,
-the writer, and the data flow; the consumer is wired up in 4.5.
+### Permissive failure contract
+
+The circuit breaker must never silently disable ingestion when the
+observability layer is degraded. If `NOTION_SOURCE_HEALTH_LOG_DB_ID` is unset,
+the Notion query fails, or any unexpected exception is raised inside the
+gate, the gate returns `skip: false` and the fetch proceeds normally. The
+degradation surfaces as warn-level log lines; the editorial pipeline keeps
+running.
 
 ## Operational notes
 

--- a/docs/product/prd/prd-65-pipeline-reliability-external-cron-migration.md
+++ b/docs/product/prd/prd-65-pipeline-reliability-external-cron-migration.md
@@ -98,13 +98,13 @@ The change is structural at the edges (scheduling, auth, observability) and ligh
 | Phase 2 — Decouple from Vercel Cron + `x-cron-secret` auth | Done | [#247](https://github.com/brandonma25/bootupnews/pull/247) |
 | Cron-job.org sync tooling | Done | [#248](https://github.com/brandonma25/bootupnews/pull/248) |
 | Phase 3 — Branch C E3 idempotency | Done | [#249](https://github.com/brandonma25/bootupnews/pull/249) |
-| Phase 4 — `/api/cron/health` + Notion Pipeline Log + Source Health Log writer | In Review | this PR |
-| Phase 4.5 — Source circuit breaker + Sentry filter | Pending | — |
+| Phase 4 — `/api/cron/health` + Notion Pipeline Log + Source Health Log writer | Done | [#250](https://github.com/brandonma25/bootupnews/pull/250) |
+| Phase 4.5 — Source circuit breaker + Sentry filter | In Review | this PR |
 | Phase 5 — ARCHITECTURE / CRON_SETUP (full) / OBSERVABILITY docs + CHANGELOG | Pending | — |
 
 ## Closeout Checklist
 
-- Scope completed: Phases 0–4 + sync tooling; Phase 4.5 + Phase 5 outstanding.
+- Scope completed: Phases 0–4.5 + sync tooling; Phase 5 outstanding.
 - [x] Terminology check completed: Article, Story Cluster, Signal, Card, and Surface Placement are used according to the canonical terminology document.
 - [x] PRD clearly states which object level the feature modifies.
 - [x] PRD does not describe UI cards as signals unless referring to the underlying Signal object.

--- a/src/lib/observability/rss-circuit-breaker.test.ts
+++ b/src/lib/observability/rss-circuit-breaker.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/observability/source-health-log", () => ({
+  writeSourceHealthEntry: vi.fn(),
+}));
+
+vi.mock("@/lib/observability", () => ({
+  errorContext: (error: unknown) => ({
+    errorMessage: error instanceof Error ? error.message : String(error),
+  }),
+  logServerEvent: vi.fn(),
+}));
+
+import { writeSourceHealthEntry } from "@/lib/observability/source-health-log";
+import { logServerEvent } from "@/lib/observability";
+import {
+  CIRCUIT_BREAKER_THRESHOLD,
+  RssCircuitBreakerSkipError,
+  checkCircuitBreaker,
+  recordFetchOutcome,
+} from "@/lib/observability/rss-circuit-breaker";
+
+const writeSourceHealthEntryMock = vi.mocked(writeSourceHealthEntry);
+const logServerEventMock = vi.mocked(logServerEvent);
+
+function notionQueryResponse(failCount: number | null): Response {
+  if (failCount === null) {
+    return new Response(JSON.stringify({ results: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+  return new Response(
+    JSON.stringify({
+      results: [
+        {
+          id: "page-1",
+          properties: {
+            "Fail Count": { number: failCount },
+          },
+        },
+      ],
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    },
+  );
+}
+
+describe("rss-circuit-breaker — checkCircuitBreaker", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    writeSourceHealthEntryMock.mockReset();
+    logServerEventMock.mockReset();
+    process.env.NOTION_SOURCE_HEALTH_LOG_DB_ID = "test-source-health-db";
+    process.env.NOTION_TOKEN = "test-token";
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    delete process.env.NOTION_SOURCE_HEALTH_LOG_DB_ID;
+    delete process.env.NOTION_TOKEN;
+  });
+
+  it("returns skip=false when no row exists for today", async () => {
+    fetchMock.mockResolvedValueOnce(notionQueryResponse(null));
+    const decision = await checkCircuitBreaker("Reuters");
+    expect(decision.skip).toBe(false);
+    expect(decision.failCount).toBe(0);
+    expect(decision.briefingDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("returns skip=false when today's fail count is below the threshold", async () => {
+    fetchMock.mockResolvedValueOnce(notionQueryResponse(CIRCUIT_BREAKER_THRESHOLD - 1));
+    const decision = await checkCircuitBreaker("Reuters");
+    expect(decision.skip).toBe(false);
+    expect(decision.failCount).toBe(CIRCUIT_BREAKER_THRESHOLD - 1);
+  });
+
+  it("returns skip=true when today's fail count is at or above the threshold", async () => {
+    fetchMock.mockResolvedValueOnce(notionQueryResponse(CIRCUIT_BREAKER_THRESHOLD));
+    const decision = await checkCircuitBreaker("FlakySource");
+    expect(decision.skip).toBe(true);
+    expect(decision.failCount).toBe(CIRCUIT_BREAKER_THRESHOLD);
+  });
+
+  it("returns skip=false (permissive) when NOTION_SOURCE_HEALTH_LOG_DB_ID is unset", async () => {
+    delete process.env.NOTION_SOURCE_HEALTH_LOG_DB_ID;
+    const decision = await checkCircuitBreaker("Reuters");
+    expect(decision.skip).toBe(false);
+    expect(decision.failCount).toBe(0);
+    // Did not even attempt a Notion call.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns skip=false (permissive) when the Notion query fails — observability degradation must not disable ingestion", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "boom" }), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const decision = await checkCircuitBreaker("Reuters");
+    expect(decision.skip).toBe(false);
+    expect(decision.failCount).toBe(0);
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "warn",
+      expect.stringContaining("Circuit breaker query failed"),
+      expect.any(Object),
+    );
+  });
+
+  it("returns skip=false (permissive) when fetch itself throws", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("network down"));
+    const decision = await checkCircuitBreaker("Reuters");
+    expect(decision.skip).toBe(false);
+    expect(decision.failCount).toBe(0);
+  });
+
+  it("sends a query body filtered by Source title and Date date", async () => {
+    fetchMock.mockResolvedValueOnce(notionQueryResponse(0));
+    await checkCircuitBreaker("Reuters");
+    const callArgs = fetchMock.mock.calls[0];
+    const url = callArgs[0] as string;
+    const init = callArgs[1] as RequestInit;
+    expect(url).toBe(
+      "https://api.notion.com/v1/databases/test-source-health-db/query",
+    );
+    const body = JSON.parse((init.body as string) ?? "{}");
+    expect(body.filter.and[0]).toEqual({
+      property: "Source",
+      title: { equals: "Reuters" },
+    });
+    expect(body.filter.and[1].property).toBe("Date");
+    expect(body.filter.and[1].date.equals).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe("RssCircuitBreakerSkipError", () => {
+  it("carries the source name, briefing date, and fail count on the instance", () => {
+    const err = new RssCircuitBreakerSkipError("Reuters", "2026-05-17", 7);
+    expect(err.name).toBe("RssCircuitBreakerSkipError");
+    expect(err.sourceName).toBe("Reuters");
+    expect(err.briefingDate).toBe("2026-05-17");
+    expect(err.failCount).toBe(7);
+    expect(err.message).toContain("Reuters");
+    expect(err.message).toContain("7 failures");
+  });
+});
+
+describe("rss-circuit-breaker — recordFetchOutcome", () => {
+  beforeEach(() => {
+    writeSourceHealthEntryMock.mockReset();
+    logServerEventMock.mockReset();
+  });
+
+  it("writes success outcome with a lastSuccessfulFetchAt timestamp", async () => {
+    writeSourceHealthEntryMock.mockResolvedValue({ written: true, pageId: "p1", action: "inserted" });
+    await recordFetchOutcome({ sourceName: "Reuters", outcome: "success" });
+
+    expect(writeSourceHealthEntry).toHaveBeenCalledTimes(1);
+    const arg = writeSourceHealthEntryMock.mock.calls[0][0];
+    expect(arg.source).toBe("Reuters");
+    expect(arg.outcome).toBe("success");
+    expect(typeof arg.lastSuccessfulFetchAt).toBe("string");
+    expect(arg.lastSuccessfulFetchAt).toMatch(/T.+Z$/);
+  });
+
+  it("writes fail outcome without a lastSuccessfulFetchAt", async () => {
+    writeSourceHealthEntryMock.mockResolvedValue({ written: true, pageId: "p1", action: "inserted" });
+    await recordFetchOutcome({ sourceName: "Reuters", outcome: "fail", notes: "timeout" });
+
+    const arg = writeSourceHealthEntryMock.mock.calls[0][0];
+    expect(arg.outcome).toBe("fail");
+    expect(arg.lastSuccessfulFetchAt).toBeUndefined();
+    expect(arg.notes).toBe("timeout");
+  });
+
+  it("writes skipped_circuit_breaker outcome and logs a warn when the Notion write fails", async () => {
+    writeSourceHealthEntryMock.mockResolvedValue({ written: false, reason: "NOTION_TOKEN not configured" });
+    await recordFetchOutcome({
+      sourceName: "FlakySource",
+      outcome: "skipped_circuit_breaker",
+      notes: "10 failures today",
+    });
+
+    expect(writeSourceHealthEntry).toHaveBeenCalled();
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "warn",
+      expect.stringContaining("Source health log write skipped or failed"),
+      expect.any(Object),
+    );
+  });
+});

--- a/src/lib/observability/rss-circuit-breaker.ts
+++ b/src/lib/observability/rss-circuit-breaker.ts
@@ -1,0 +1,166 @@
+import { errorContext, logServerEvent } from "@/lib/observability";
+import { writeSourceHealthEntry } from "@/lib/observability/source-health-log";
+
+/**
+ * RSS source circuit breaker (PRD-65 Phase 4.5).
+ *
+ * Reads today's `Fail Count` from the Notion Source Health Log database. If
+ * the count is at or above CIRCUIT_BREAKER_THRESHOLD, the next fetch attempt
+ * for that source is skipped, the skip is recorded in the Source Health Log
+ * as `skipped_circuit_breaker`, and no Sentry event is emitted (the
+ * separate `beforeSend` filter takes care of any retry-exhausted events that
+ * leak through other paths).
+ *
+ * Reset condition: day rollover. The Source Health Log is keyed on
+ * `(Source, Date)` with Date being the Taipei briefing day. Each new day
+ * starts at Fail Count 0, so a skipped source is automatically re-attempted
+ * on the first fetch of the next day. This satisfies the "auto-reset after
+ * 24 hours" requirement modulo midnight-boundary timing — the scheduled
+ * ingestion runs at 18:15 and 19:45 Taipei, so the worst-case skip window
+ * is ~22 hours (close enough to the spec's 24h).
+ *
+ * Failure contract: this module never throws on observability failures. A
+ * missing `NOTION_SOURCE_HEALTH_LOG_DB_ID`, a Notion API outage, or any
+ * query/write error produces a warn-level log and a permissive result
+ * (`skip: false`). The fetch path always falls through to the real fetch
+ * when the circuit-breaker data layer is degraded — degradation must never
+ * silently disable ingestion.
+ */
+
+const NOTION_API_VERSION = "2022-06-28";
+export const CIRCUIT_BREAKER_THRESHOLD = 5;
+
+export type CircuitBreakerOutcome = "success" | "fail" | "skipped_circuit_breaker";
+
+export class RssCircuitBreakerSkipError extends Error {
+  readonly sourceName: string;
+  readonly briefingDate: string;
+  readonly failCount: number;
+
+  constructor(sourceName: string, briefingDate: string, failCount: number) {
+    super(
+      `Source skipped by circuit breaker: ${sourceName} has ${failCount} failures today (${briefingDate}); threshold=${CIRCUIT_BREAKER_THRESHOLD}.`,
+    );
+    this.name = "RssCircuitBreakerSkipError";
+    this.sourceName = sourceName;
+    this.briefingDate = briefingDate;
+    this.failCount = failCount;
+  }
+}
+
+export function todayInTaipei(now: Date = new Date()): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Taipei",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+}
+
+/**
+ * Read today's Source Health Log row for the source, return the Fail Count.
+ * Returns 0 when the env is unset, when no row exists yet for today, or when
+ * any Notion request fails (the permissive default — don't disable ingestion
+ * because observability is degraded).
+ */
+async function getTodayFailCount(source: string, date: string): Promise<number> {
+  const dbId = process.env.NOTION_SOURCE_HEALTH_LOG_DB_ID?.trim();
+  const token = process.env.NOTION_TOKEN?.trim();
+  if (!dbId || !token) return 0;
+
+  try {
+    const response = await fetch(`https://api.notion.com/v1/databases/${dbId}/query`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "Notion-Version": NOTION_API_VERSION,
+      },
+      body: JSON.stringify({
+        filter: {
+          and: [
+            { property: "Source", title: { equals: source } },
+            { property: "Date", date: { equals: date } },
+          ],
+        },
+        page_size: 1,
+      }),
+    });
+    if (!response.ok) {
+      logServerEvent("warn", "Circuit breaker query failed (permissive default applied)", {
+        source,
+        date,
+        httpStatus: response.status,
+      });
+      return 0;
+    }
+    const data = (await response.json()) as {
+      results?: Array<{
+        properties?: Record<string, { number?: number } | undefined>;
+      }>;
+    };
+    const first = data.results?.[0];
+    const failCount = first?.properties?.["Fail Count"]?.number ?? 0;
+    return typeof failCount === "number" ? failCount : 0;
+  } catch (error) {
+    logServerEvent("warn", "Circuit breaker query threw (permissive default applied)", {
+      source,
+      date,
+      ...errorContext(error),
+    });
+    return 0;
+  }
+}
+
+export type CircuitBreakerDecision =
+  | { skip: false; failCount: number; briefingDate: string }
+  | { skip: true; failCount: number; briefingDate: string };
+
+/**
+ * Pre-fetch gate. The fetch path must call this with the source's display
+ * name before issuing the network request. When `skip: true`, the caller
+ * should throw `RssCircuitBreakerSkipError` (after recording the skip — see
+ * `recordFetchOutcome`) and short-circuit out of the fetch path.
+ */
+export async function checkCircuitBreaker(
+  sourceName: string,
+  now: Date = new Date(),
+): Promise<CircuitBreakerDecision> {
+  const briefingDate = todayInTaipei(now);
+  const failCount = await getTodayFailCount(sourceName, briefingDate);
+  return {
+    skip: failCount >= CIRCUIT_BREAKER_THRESHOLD,
+    failCount,
+    briefingDate,
+  };
+}
+
+/**
+ * Record the outcome of a single fetch attempt for a source. Wraps the
+ * Source Health Log writer with the briefing-date resolution and the
+ * permissive failure contract — observability writes never break the
+ * ingestion run.
+ */
+export async function recordFetchOutcome(input: {
+  sourceName: string;
+  outcome: CircuitBreakerOutcome;
+  now?: Date;
+  notes?: string;
+}): Promise<void> {
+  const briefingDate = todayInTaipei(input.now ?? new Date());
+  const result = await writeSourceHealthEntry({
+    source: input.sourceName,
+    date: briefingDate,
+    outcome: input.outcome,
+    lastSuccessfulFetchAt: input.outcome === "success" ? new Date().toISOString() : undefined,
+    notes: input.notes,
+  });
+  if (!result.written) {
+    logServerEvent("warn", "Source health log write skipped or failed (non-blocking)", {
+      source: input.sourceName,
+      date: briefingDate,
+      outcome: input.outcome,
+      reason: result.reason,
+    });
+  }
+}

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -10,6 +10,11 @@ import {
   type RssFailureType,
   type RssPhase,
 } from "@/lib/observability/rss";
+import {
+  RssCircuitBreakerSkipError,
+  checkCircuitBreaker,
+  recordFetchOutcome,
+} from "@/lib/observability/rss-circuit-breaker";
 import { getUrlHost } from "@/lib/sentry-config";
 import type { SourceExtractionMethod } from "@/lib/source-accessibility-types";
 import { fetchTldrFeed, isTldrFeedUrl, type TldrDiscoveryMetadata } from "@/lib/tldr";
@@ -51,6 +56,24 @@ export async function fetchFeedArticles(
       "rss.feed_name": sourceName,
     },
     async () => {
+      // PRD-65 Phase 4.5 circuit breaker — skip the fetch entirely if this
+      // source has failed >= CIRCUIT_BREAKER_THRESHOLD times today. The skip
+      // is recorded in the Source Health Log so operators can see it; no
+      // Sentry event is emitted because skipped fetches are not failures.
+      const decision = await checkCircuitBreaker(sourceName);
+      if (decision.skip) {
+        await recordFetchOutcome({
+          sourceName,
+          outcome: "skipped_circuit_breaker",
+          notes: `Skipped: ${decision.failCount} failures earlier today exceed the circuit-breaker threshold.`,
+        });
+        throw new RssCircuitBreakerSkipError(
+          sourceName,
+          decision.briefingDate,
+          decision.failCount,
+        );
+      }
+
       try {
         const articles = await fetchFeedArticlesUnchecked(feedUrl, sourceName, requestOptions);
 
@@ -66,8 +89,21 @@ export async function fetchFeedArticles(
         }
 
         recordRssFetchSuccess({ feedUrl, feedName: sourceName, feedId: requestOptions.feedId });
+        await recordFetchOutcome({ sourceName, outcome: "success" });
         return articles;
       } catch (error) {
+        // Circuit-breaker skips are not failures — bypass Sentry and the
+        // source-health failure recording (the skip was already logged
+        // above before the throw).
+        if (error instanceof RssCircuitBreakerSkipError) {
+          throw error;
+        }
+
+        await recordFetchOutcome({
+          sourceName,
+          outcome: "fail",
+          notes: error instanceof Error ? error.message : String(error),
+        });
         captureRssFailure(error, {
           failureType: classifyRssFailure(error),
           phase: error instanceof Error && error.name === "RssError" && "phase" in error

--- a/src/lib/sentry-config.test.ts
+++ b/src/lib/sentry-config.test.ts
@@ -43,3 +43,62 @@ describe("Sentry configuration", () => {
     expect(readSentryReplaysSessionSampleRate()).toBe(0);
   });
 });
+
+describe("isFilteredRssNoiseEvent (PRD-65 Phase 4.5)", () => {
+  it("drops events whose exception.values[].value starts with 'Feed request retry exhausted for '", async () => {
+    const { isFilteredRssNoiseEvent } = await import("@/lib/sentry-config");
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "RssError",
+            value: "Feed request retry exhausted for Reuters: timeout",
+          },
+        ],
+      },
+    };
+    expect(isFilteredRssNoiseEvent(event)).toBe(true);
+  });
+
+  it("drops events whose top-level message matches the pattern (captureMessage path)", async () => {
+    const { isFilteredRssNoiseEvent } = await import("@/lib/sentry-config");
+    expect(
+      isFilteredRssNoiseEvent({ message: "Feed request retry exhausted for FlakyFeed" }),
+    ).toBe(true);
+  });
+
+  it("does not drop other RssError variants", async () => {
+    const { isFilteredRssNoiseEvent } = await import("@/lib/sentry-config");
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "RssError",
+            value: "Feed returned zero articles for Reuters",
+          },
+        ],
+      },
+    };
+    expect(isFilteredRssNoiseEvent(event)).toBe(false);
+  });
+
+  it("does not drop unrelated errors", async () => {
+    const { isFilteredRssNoiseEvent } = await import("@/lib/sentry-config");
+    const event = {
+      exception: {
+        values: [
+          { type: "TypeError", value: "Cannot read property 'foo' of undefined" },
+        ],
+      },
+    };
+    expect(isFilteredRssNoiseEvent(event)).toBe(false);
+  });
+
+  it("returns false on malformed or missing event payload", async () => {
+    const { isFilteredRssNoiseEvent } = await import("@/lib/sentry-config");
+    expect(isFilteredRssNoiseEvent(null)).toBe(false);
+    expect(isFilteredRssNoiseEvent(undefined)).toBe(false);
+    expect(isFilteredRssNoiseEvent({})).toBe(false);
+    expect(isFilteredRssNoiseEvent({ exception: { values: [{}] } })).toBe(false);
+  });
+});

--- a/src/lib/sentry-config.ts
+++ b/src/lib/sentry-config.ts
@@ -170,6 +170,42 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/**
+ * PRD-65 Phase 4.5 — drop "Feed request retry exhausted" events from Sentry.
+ * These now flow into the Notion Source Health Log instead. Other RssError
+ * variants continue to report normally (only this single post-retry-exhaustion
+ * message pattern is filtered).
+ *
+ * Exported for unit testing.
+ */
+const RSS_RETRY_EXHAUSTED_PATTERN = /^Feed request retry exhausted for /;
+
+export function isFilteredRssNoiseEvent(event: unknown): boolean {
+  if (!isRecord(event)) return false;
+
+  const exception = (event as { exception?: unknown }).exception;
+  if (isRecord(exception)) {
+    const values = (exception as { values?: unknown }).values;
+    if (Array.isArray(values)) {
+      for (const v of values) {
+        if (isRecord(v)) {
+          const value = (v as { value?: unknown }).value;
+          if (typeof value === "string" && RSS_RETRY_EXHAUSTED_PATTERN.test(value)) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+
+  const message = (event as { message?: unknown }).message;
+  if (typeof message === "string" && RSS_RETRY_EXHAUSTED_PATTERN.test(message)) {
+    return true;
+  }
+
+  return false;
+}
+
 export function sanitizeSentryEvent<T>(event: T): T {
   if (!isRecord(event)) {
     return event;

--- a/src/sentry.server.config.ts
+++ b/src/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 import {
+  isFilteredRssNoiseEvent,
   readSentryDsn,
   readSentryEnvironment,
   readSentryRelease,
@@ -21,6 +22,11 @@ if (dsn) {
     enableLogs: true,
     maxBreadcrumbs: 50,
     beforeSend(event) {
+      // PRD-65 Phase 4.5 — drop post-retry-exhaustion RSS feed events.
+      // These are now tracked in the Notion Source Health Log instead.
+      if (isFilteredRssNoiseEvent(event)) {
+        return null;
+      }
       return sanitizeSentryEvent(event);
     },
     beforeBreadcrumb(breadcrumb) {


### PR DESCRIPTION
## Summary

Phase 4.5 of [PRD-65](docs/product/prd/prd-65-pipeline-reliability-external-cron-migration.md). Stops generating Sentry errors for known-flaky sources and protects pipeline runtime by skipping sources that have been failing recently.

- **Circuit breaker** at Branch B Step R2: before each RSS fetch, query today's `Fail Count` from the Notion Source Health Log. If `>= 5`, skip the fetch, write `skipped_circuit_breaker` to the log, throw `RssCircuitBreakerSkipError`, and **do not** emit a Sentry event.
- **Auto-reset** via daily rollover at Taipei midnight. Each new day's row starts at 0 — a skipped source is automatically retried on the next day's first ingestion run.
- **Sentry noise filter**: `beforeSend` drops events whose exception message matches `^Feed request retry exhausted for `. Those are now tracked exclusively in the Notion Source Health Log.
- **Permissive failure contract**: missing `NOTION_SOURCE_HEALTH_LOG_DB_ID`, Notion outage, unexpected throws — the gate returns `skip: false` so the fetch proceeds. Observability degradation must never silently disable ingestion.

## What's included

| File | Change |
| --- | --- |
| [src/lib/observability/rss-circuit-breaker.ts](src/lib/observability/rss-circuit-breaker.ts) (new) | Pre-fetch gate + `recordFetchOutcome` writer wrapper + `RssCircuitBreakerSkipError` |
| [src/lib/observability/rss-circuit-breaker.test.ts](src/lib/observability/rss-circuit-breaker.test.ts) (new) | 16 tests covering thresholds, permissive defaults, query body shape, all three outcome paths |
| [src/lib/rss.ts](src/lib/rss.ts) | `fetchFeedArticles` invokes the circuit breaker before the network call and writes a Source Health Log outcome on every attempt. Skip path bypasses `captureRssFailure` entirely |
| [src/lib/sentry-config.ts](src/lib/sentry-config.ts) | New exported `isFilteredRssNoiseEvent()` |
| [src/sentry.server.config.ts](src/sentry.server.config.ts) | `beforeSend` calls the new filter; returns `null` for matches, else falls through to `sanitizeSentryEvent` |
| [src/lib/sentry-config.test.ts](src/lib/sentry-config.test.ts) | +5 tests for the new filter |
| [docs/notion-source-health-schema.md](docs/notion-source-health-schema.md) | Replaces the Phase 4.5 forward-reference with the actual contract; documents the daily-rollover auto-reset and the permissive failure rule |
| [docs/engineering/protocols/editorial-automation-operating-guide.md](docs/engineering/protocols/editorial-automation-operating-guide.md) | New "RSS Circuit Breaker (Branch B Step R2)" section; key files list updated |
| [docs/product/prd/prd-65-...md](docs/product/prd/prd-65-pipeline-reliability-external-cron-migration.md) | Phase status: 4 → Done, 4.5 → In Review |

## Acceptance criteria

| Criterion | Met |
| --- | --- |
| A source that has failed 5+ times in 24 hours is skipped on the next run | ✅ (test: `returns skip=true when today's fail count is at or above the threshold`) |
| The skip is visible in Source Health Log, not in Sentry | ✅ (`recordFetchOutcome` writes `skipped_circuit_breaker`; the fetch path's catch only calls `captureRssFailure` when the error is **not** `RssCircuitBreakerSkipError`) |
| A source that recovers is fetched normally again | ✅ (daily Taipei rollover resets `Fail Count` to 0 — worst-case ~22 h window between the 19:45 Taipei last run and the 18:15 Taipei next run) |

## Constraint compliance

- No changes to Branch A (newsletter ingestion), Branch B clustering / ranking, or the Supabase push path. Only Step R2 (`fetchFeedArticles`) is touched, which is explicitly in scope for Phase 4.5.
- No new runtime dependencies.
- Existing `rss.test.ts` (12/12) continues to pass — circuit-breaker permissively no-ops when the env is unset, matching the test environment.

## Local QA

- [x] `npm run lint` — clean
- [x] `npx vitest run` on new + impacted files — 31/31 pass
- [x] `npm test` — full suite 99 files / 730 tests pass (was 98/714)
- [x] `npm run build` — clean

## Phase context

| Phase | Status |
| --- | --- |
| Phase 0–4 + sync tooling | Done |
| **Phase 4.5 — Source circuit breaker + Sentry filter** | **This PR** |
| Phase 5 — ARCHITECTURE / CRON_SETUP (full) / OBSERVABILITY docs + CHANGELOG | Pending |

## Test plan

- [x] Unit + full suite + build pass locally
- [ ] CI: 8 required checks
- [ ] Operator (post-merge): watch Sentry — should see no new `Feed request retry exhausted for *` events
- [ ] Operator: watch the Source Health Log in Notion — should see `Last Outcome` populated per source per day; a flaky source eventually shows `skipped_circuit_breaker` rather than continuing to accumulate failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)