### PR TITLE
fix(cron): consolidate ingestion to single 12:00 UTC trigger + cron_runs run-lock (Path A Task 1)

### DIFF
--- a/docs/engineering/ARCHITECTURE.md
+++ b/docs/engineering/ARCHITECTURE.md
@@ -49,12 +49,12 @@ Detailed contracts:
 
 ```mermaid
 flowchart LR
-    SCHED["cron-job.org<br/>(scheduler)"] -->|"10:15 UTC<br/>(18:15 Taipei)"| ING1["GET /api/cron/fetch-editorial-inputs<br/>x-cron-secret"]
-    SCHED -->|"11:45 UTC<br/>(19:45 Taipei)"| ING2["GET /api/cron/fetch-editorial-inputs<br/>x-cron-secret"]
+    SCHED["cron-job.org<br/>(scheduler)"] -->|"12:00 UTC<br/>(20:00 Taipei)"| ING["GET /api/cron/fetch-editorial-inputs<br/>x-cron-secret"]
     SCHED -->|"12:15 UTC<br/>(20:15 Taipei)"| HEAL["GET /api/cron/health<br/>x-cron-secret"]
 
-    ING1 --> PIPE["Ingestion pipeline<br/>(see Pipeline overview)"]
-    ING2 --> PIPE
+    ING --> LOCK{"cron_runs lock<br/>(briefing_date PK)"}
+    LOCK -->|"first call:<br/>acquired"| PIPE["Ingestion pipeline<br/>(see Pipeline overview)"]
+    LOCK -->|"duplicate call:<br/>HTTP 200 status=skipped"| NOOP[/No pipeline work/]
     PIPE --> PLOG["Notion Pipeline Log<br/>run_type=ingestion"]
 
     HEAL --> QUERY["Query Notion<br/>Editorial Queue<br/>for today's rows"]
@@ -74,9 +74,8 @@ flowchart LR
 
 | UTC | Taipei | Job | Purpose |
 | --- | --- | --- | --- |
-| 10:15 | 18:15 | `bootup-ingestion-1015-utc` | First ingestion run (early evening, gives time for re-runs before editor review) |
-| 11:45 | 19:45 | `bootup-ingestion-1145-utc` | Second ingestion run (catches any sources slow to publish in the first window) |
-| 12:15 | 20:15 | `bootup-health-check-1215-utc` | Health check 30 minutes after the second ingestion run; HTTP 500 triggers an email alert |
+| 12:00 | 20:00 | `bootup-ingestion-1200-utc` | Sole ingestion run; cross-run idempotency via `cron_runs(briefing_date PK)` so a duplicate cronjob.org fire (or a Vercel Hobby double-delivery during the rollback escape hatch) no-ops with `HTTP 200 status=skipped` |
+| 12:15 | 20:15 | `bootup-health-check-1215-utc` | Health check 15 minutes after the ingestion run; HTTP 500 triggers an email alert |
 
 Source-of-truth for the schedule is [`scripts/cron-jobs.config.ts`](../../scripts/cron-jobs.config.ts). Apply changes with `npm run cron:sync` (see [`docs/engineering/CRON_SETUP.md`](CRON_SETUP.md)).
 

--- a/docs/engineering/CRON_SETUP.md
+++ b/docs/engineering/CRON_SETUP.md
@@ -72,11 +72,11 @@ production:    https://bootupnews.com
 api key:       <len=…>
 cron secret:   <len=…>
 
-TITLE                       ACTION  DETAIL
---------------------------------------------------------------
-bootup-ingestion-1015-utc   create  would create GET https://…/api/cron/fetch-editorial-inputs @ 10:15 Etc/UTC
-bootup-ingestion-1145-utc   create  would create GET https://…/api/cron/fetch-editorial-inputs @ 11:45 Etc/UTC
-Would create 2 jobs: bootup-ingestion-1015-utc, bootup-ingestion-1145-utc
+TITLE                            ACTION  DETAIL
+-------------------------------------------------------------------
+bootup-ingestion-1200-utc        create  would create GET https://…/api/cron/fetch-editorial-inputs @ 12:00 Etc/UTC
+bootup-health-check-1215-utc     create  would create GET https://…/api/cron/health             @ 12:15 Etc/UTC
+Would create 2 jobs: bootup-ingestion-1200-utc, bootup-health-check-1215-utc
 
 summary: created=0 updated=0 skipped=0 orphans=0 pruned=0 failed=0
 ```
@@ -89,15 +89,35 @@ If output looks right, apply for real:
 npm run cron:sync
 ```
 
-After this, sign in to <https://console.cron-job.org> and confirm both jobs
-appear in the dashboard, are enabled, and have the schedules
-`15 10 * * *` and `45 11 * * *` in UTC.
+After this, sign in to <https://console.cron-job.org> and confirm the ingestion
+and health-check jobs appear in the dashboard, are enabled, and have the
+schedules `0 12 * * *` and `15 12 * * *` in UTC.
+
+### Migrating from the legacy two-ingestion schedule
+
+If the account previously hosted the pre-PRD-65-followup pair
+(`bootup-ingestion-1015-utc` + `bootup-ingestion-1145-utc`), run the sync with
+the `--prune` flag so they are removed alongside the single
+`bootup-ingestion-1200-utc` create:
+
+```bash
+npm run cron:sync:prune
+```
+
+Expected diff: `delete 2 jobs (1015, 1145), create 1 job (1200)`. The new
+schedule's cross-run idempotency lives in the Supabase `cron_runs` table
+(migration `20260521120000_cron_runs_and_source_url_idempotency.sql`), so a
+duplicate cronjob.org fire on the same briefing_date no-ops with
+`HTTP 200 status=skipped` rather than running the pipeline twice.
 
 **Test each job once.** Use the "Test run" button on each cron-job.org job
-page. Expected response: **HTTP 200** from
-`/api/cron/fetch-editorial-inputs`. If you get **HTTP 401**, the
-`x-cron-secret` value on cron-job.org doesn't match `CRON_SECRET` in Vercel
-production env — re-set them so both match, then re-run `npm run cron:sync`.
+page. Expected response: **HTTP 202** from `/api/cron/fetch-editorial-inputs`
+on the first call of the day (ingestion accepted and scheduled), then
+**HTTP 200 with `status: "skipped"`** on any subsequent call for the same
+briefing_date (the `cron_runs` row already exists, so the run-lock declines).
+If you get **HTTP 401**, the `x-cron-secret` value on cron-job.org doesn't
+match `CRON_SECRET` in Vercel production env — re-set them so both match,
+then re-run `npm run cron:sync`.
 
 ---
 
@@ -162,13 +182,15 @@ temporarily:
 2. Re-add the `crons` block to `vercel.json` on a hotfix branch:
    ```json
    "crons": [
-     { "path": "/api/cron/fetch-editorial-inputs", "schedule": "15 10 * * *" },
-     { "path": "/api/cron/fetch-editorial-inputs", "schedule": "45 11 * * *" }
+     { "path": "/api/cron/fetch-editorial-inputs", "schedule": "0 12 * * *" }
    ]
    ```
 3. Merge and redeploy. Vercel Cron will now fire on its own ±59 min window
    schedule, sending the legacy `Authorization: Bearer <CRON_SECRET>` header,
-   which the endpoint accepts when the fallback flag is set.
+   which the endpoint accepts when the fallback flag is set. The Supabase
+   `cron_runs` run-lock still protects against Vercel double-delivery —
+   the second call within the briefing_date returns HTTP 200 status=skipped
+   without running the pipeline.
 4. On cron-job.org, disable the jobs (set `enabled: false` in config and
    re-sync) so the two schedulers don't double-fire.
 

--- a/docs/product/prd/prd-65-pipeline-reliability-external-cron-migration.md
+++ b/docs/product/prd/prd-65-pipeline-reliability-external-cron-migration.md
@@ -101,7 +101,30 @@ The change is structural at the edges (scheduling, auth, observability) and ligh
 | Phase 4 — `/api/cron/health` + Notion Pipeline Log + Source Health Log writer | Done | [#250](https://github.com/brandonma25/bootupnews/pull/250) |
 | Phase 4.5 — Source circuit breaker + Sentry filter | Done | [#251](https://github.com/brandonma25/bootupnews/pull/251) |
 | Phase 5 — ARCHITECTURE / CRON_SETUP (full) / OBSERVABILITY docs + CHANGELOG | Done | [#252](https://github.com/brandonma25/bootupnews/pull/252) |
-| Phase 6 — Activate `bootup-health-check-1215-utc` in `scripts/cron-jobs.config.ts` | In Review | this PR |
+| Phase 6 — Activate `bootup-health-check-1215-utc` in `scripts/cron-jobs.config.ts` | Done | [#258](https://github.com/brandonma25/bootupnews/pull/258) |
+| Phase 7 (Path-A Task 1) — Consolidate ingestion to one 12:00 UTC trigger + Supabase `cron_runs` run-lock + `(briefing_date, source_url)` upsert | In Review | this PR |
+
+### Phase 7 — Operational history (Path-A Task 1, 2026-05-21)
+
+The dual-ingestion schedule (10:15 + 11:45 UTC) shipped in Phase 4 was the
+root cause of the 5–7× duplicate-rows-per-article symptom in the Notion
+Editorial Queue: both runs succeeded daily, and the Notion writes were not
+cross-run idempotent. Path A of the May 21 execution handoff collapsed the
+schedule to a single canonical run at 20:00 Asia/Taipei (= `0 12 * * *` UTC)
+and introduced a Supabase `cron_runs(briefing_date PK)` guard table that the
+cron handler claims with `INSERT … ON CONFLICT DO NOTHING` before scheduling
+`after(executePipelineWork)`. A second cronjob.org HTTP fire — or a Vercel
+Hobby double-delivery during the rollback escape hatch — sees the existing
+claim and responds `HTTP 200 status=skipped` without scheduling pipeline
+work. As a second line of defense, both `signal_posts` writer paths
+(`persistSignalPostCandidates` and `/api/editorial/push-approved`) now
+upsert on `(briefing_date, source_url)`; the partial unique index that backs
+this is created in the same migration, alongside a small cleanup that
+removed 7 legacy garbage rows on 2026-05-17 (Axios webfont CDN URLs +
+Politico tracking redirectors the pre-`isValidPublicSourceUrl` writer
+captured as "stories"). The health-check job at 12:15 UTC stays as-is and
+gives the single ingestion 15 minutes to settle before the alertable check
+fires.
 
 ## Closeout Checklist
 

--- a/scripts/cron-jobs.config.ts
+++ b/scripts/cron-jobs.config.ts
@@ -43,27 +43,24 @@ const BASE = process.env.BOOTUP_PRODUCTION_URL;
 // run time and prints a clear error listing every missing variable.
 
 export const cronJobs: CronJobConfig[] = [
+  // Sole authoritative ingestion trigger at 20:00 Asia/Taipei (= 12:00 UTC).
+  // Path-A Task 1 collapsed the previous 10:15 + 11:45 UTC dual-trigger into a
+  // single run; cross-run idempotency lives in the cron_runs guard table (see
+  // migration 20260521120000_cron_runs_and_source_url_idempotency.sql). Apply
+  // this change to cron-job.org with `npm run cron:sync:prune` so the two
+  // legacy ingestion jobs are removed alongside the create.
   {
-    title: "bootup-ingestion-1015-utc",
+    title: "bootup-ingestion-1200-utc",
     url: `${BASE ?? "<BOOTUP_PRODUCTION_URL>"}/api/cron/fetch-editorial-inputs`,
     method: "GET",
-    schedule: { timezone: "Etc/UTC", hours: [10], minutes: [15] },
-    headers: { "x-cron-secret": SECRET ?? "" },
-    enabled: true,
-    notifyOnFailure: true,
-  },
-  {
-    title: "bootup-ingestion-1145-utc",
-    url: `${BASE ?? "<BOOTUP_PRODUCTION_URL>"}/api/cron/fetch-editorial-inputs`,
-    method: "GET",
-    schedule: { timezone: "Etc/UTC", hours: [11], minutes: [45] },
+    schedule: { timezone: "Etc/UTC", hours: [12], minutes: [0] },
     headers: { "x-cron-secret": SECRET ?? "" },
     enabled: true,
     notifyOnFailure: true,
   },
 
   // Health-check job — PRD-65 Phase 4 shipped /api/cron/health (see CHANGELOG).
-  // Fires 30 minutes after the second ingestion run; a non-2xx response
+  // Fires 15 minutes after the single ingestion run; a non-2xx response
   // triggers an email alert via cron-job.org's notifyOnFailure.
   {
     title: "bootup-health-check-1215-utc",

--- a/src/app/api/cron/fetch-editorial-inputs/route.test.ts
+++ b/src/app/api/cron/fetch-editorial-inputs/route.test.ts
@@ -7,6 +7,7 @@ const logServerEvent = vi.fn();
 const writePipelineLogEntry = vi.fn();
 const sentryCaptureException = vi.fn();
 const sentryFlush = vi.fn(async () => true);
+const createSupabaseServiceRoleClient = vi.fn();
 
 let capturedAfterCallback: (() => void | Promise<void>) | null = null;
 
@@ -47,6 +48,46 @@ vi.mock("@/lib/observability", () => ({
 vi.mock("@/lib/observability/pipeline-log", () => ({
   writePipelineLogEntry,
 }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServiceRoleClient,
+}));
+
+/**
+ * Build a tiny supabase-client double exposing only the surface the cron route
+ * uses: `client.from('cron_runs').insert(...).select(...)` and
+ * `.from('cron_runs').update(...).eq(...)`.
+ *
+ * `lockAcquired === true`  → insert succeeds (fresh row).
+ * `lockAcquired === false` → insert rejects with Postgres unique_violation
+ *                            code 23505 (lock already held).
+ * `lockAcquired === 'error'` → insert rejects with a generic DB error
+ *                              (fall-through best-effort path).
+ */
+function buildSupabaseLockClient(lockAcquired: true | false | "error") {
+  const insertResult =
+    lockAcquired === true
+      ? { data: [{ briefing_date: "2026-05-12" }], error: null }
+      : lockAcquired === false
+        ? { data: null, error: { code: "23505", message: "duplicate key value violates unique constraint \"cron_runs_pkey\"" } }
+        : { data: null, error: { code: "08006", message: "connection reset" } };
+
+  return {
+    from: vi.fn((table: string) => {
+      if (table === "cron_runs") {
+        return {
+          insert: vi.fn(() => ({
+            select: vi.fn(async () => insertResult),
+          })),
+          update: vi.fn(() => ({
+            eq: vi.fn(async () => ({ data: null, error: null })),
+          })),
+        };
+      }
+      throw new Error(`Unexpected supabase table in test: ${table}`);
+    }),
+  };
+}
 
 type RequestAuth = { header?: "x-cron-secret" | "authorization"; secret?: string };
 
@@ -105,6 +146,8 @@ describe("/api/cron/fetch-editorial-inputs", () => {
       },
     });
     writePipelineLogEntry.mockResolvedValue({ written: true, pageId: "log-1" });
+    // Default: lock acquires cleanly. Individual tests override.
+    createSupabaseServiceRoleClient.mockReturnValue(buildSupabaseLockClient(true));
   });
 
   it("rejects unauthorized requests without scheduling the pipeline", async () => {
@@ -327,5 +370,68 @@ describe("/api/cron/fetch-editorial-inputs", () => {
     const response = await GET(buildRequest("local-cron-secret"));
     const body = await response.json();
     expect(JSON.stringify(body)).not.toContain("local-cron-secret");
+  });
+
+  describe("run-lock (cron_runs)", () => {
+    it("first call acquires the lock and schedules the pipeline via after()", async () => {
+      createSupabaseServiceRoleClient.mockReturnValue(buildSupabaseLockClient(true));
+
+      const { GET } = await import("@/app/api/cron/fetch-editorial-inputs/route");
+      const response = await GET(buildRequest("local-cron-secret"));
+      const body = await response.json();
+
+      expect(response.status).toBe(202);
+      expect(body.success).toBe(true);
+      expect(body.status).toBeUndefined(); // "skipped" only appears on the no-op response.
+      expect(typeof body.briefing_date).toBe("string");
+      expect(capturedAfterCallback).not.toBeNull();
+    });
+
+    it("second call within the same briefing_date no-ops with HTTP 200 status=skipped and does NOT schedule after()", async () => {
+      createSupabaseServiceRoleClient.mockReturnValue(buildSupabaseLockClient(false));
+
+      const { GET } = await import("@/app/api/cron/fetch-editorial-inputs/route");
+      const response = await GET(buildRequest("local-cron-secret"));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        success: true,
+        status: "skipped",
+        reason: "already_ran",
+      });
+      expect(typeof body.briefing_date).toBe("string");
+      // Critical: the pipeline must NOT be scheduled on the no-op branch,
+      // otherwise the second cronjob.org fire still produces a duplicate run.
+      expect(capturedAfterCallback).toBeNull();
+      expect(runDailyNewsCron).not.toHaveBeenCalled();
+      expect(runNewsletterIngestion).not.toHaveBeenCalled();
+      expect(runEditorialStaging).not.toHaveBeenCalled();
+    });
+
+    it("falls through and runs the pipeline (best-effort) when the lock table is unreachable", async () => {
+      // A generic DB error (not Postgres unique_violation 23505) means we cannot
+      // tell whether a prior run claimed today's slot. We prefer one duplicate
+      // run over a missed run, so we proceed.
+      createSupabaseServiceRoleClient.mockReturnValue(buildSupabaseLockClient("error"));
+
+      const { GET } = await import("@/app/api/cron/fetch-editorial-inputs/route");
+      const response = await GET(buildRequest("local-cron-secret"));
+
+      expect(response.status).toBe(202);
+      expect(capturedAfterCallback).not.toBeNull();
+      await runCapturedAfter();
+      expect(runDailyNewsCron).toHaveBeenCalledTimes(1);
+      expect(runNewsletterIngestion).toHaveBeenCalledTimes(1);
+      expect(runEditorialStaging).toHaveBeenCalledTimes(1);
+
+      const warnLog = logServerEvent.mock.calls.find(
+        ([level, message]) =>
+          level === "warn" &&
+          typeof message === "string" &&
+          message.includes("Run-lock acquire failed"),
+      );
+      expect(warnLog).toBeTruthy();
+    });
   });
 });

--- a/src/app/api/cron/fetch-editorial-inputs/route.ts
+++ b/src/app/api/cron/fetch-editorial-inputs/route.ts
@@ -6,6 +6,84 @@ import { runNewsletterIngestion, type NewsletterIngestionRunResult } from "@/lib
 import { runEditorialStaging, type EditorialStagingRunResult } from "@/lib/editorial-staging/runner";
 import { errorContext, logServerEvent } from "@/lib/observability";
 import { writePipelineLogEntry } from "@/lib/observability/pipeline-log";
+import { createSupabaseServiceRoleClient } from "@/lib/supabase/server";
+
+const CRON_NAME = "fetch-editorial-inputs";
+
+/**
+ * Briefing-date the run-lock keys on. Mirrors the Taipei-calendar logic in
+ * src/lib/editorial-staging/runner.ts so a run-lock claim and the editorial
+ * staging step that follows always agree on which day is "today".
+ */
+function todayTaipei(now: Date): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Taipei",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+}
+
+type RunLockResult =
+  | { acquired: true; briefingDate: string; reason?: "lock_check_failed" }
+  | { acquired: false; briefingDate: string; reason: "already_ran" };
+
+/**
+ * Claim the run-lock for today's briefing_date. Returns acquired=true on a
+ * fresh row, acquired=false when a prior run already claimed it, or
+ * acquired=true with reason='lock_check_failed' as a best-effort fallthrough
+ * when the lock table itself is unreachable — we prefer one duplicate run over
+ * a missed run.
+ */
+async function tryAcquireRunLock(briefingDate: string): Promise<RunLockResult> {
+  const client = createSupabaseServiceRoleClient();
+  if (!client) {
+    logServerEvent("warn", "Run-lock skipped: Supabase service role client unavailable", {
+      route: "/api/cron/fetch-editorial-inputs",
+      briefingDate,
+    });
+    return { acquired: true, briefingDate, reason: "lock_check_failed" };
+  }
+
+  const result = await client
+    .from("cron_runs")
+    .insert({ briefing_date: briefingDate, cron_name: CRON_NAME })
+    .select("briefing_date");
+
+  if (result.error) {
+    // Postgres unique_violation = 23505. Supabase surfaces this as `code`.
+    const code = (result.error as { code?: string }).code;
+    if (code === "23505") {
+      return { acquired: false, briefingDate, reason: "already_ran" };
+    }
+    logServerEvent("warn", "Run-lock acquire failed; running anyway (best-effort)", {
+      route: "/api/cron/fetch-editorial-inputs",
+      briefingDate,
+      error: result.error.message,
+      code,
+    });
+    return { acquired: true, briefingDate, reason: "lock_check_failed" };
+  }
+
+  return { acquired: true, briefingDate };
+}
+
+/**
+ * Mark the run-lock terminal. Best-effort — never throws or blocks the cron.
+ * No-op when the lock was never acquired (lock_check_failed fallthrough).
+ */
+async function finalizeRunLock(briefingDate: string, status: "ok" | "fail" | "timeout"): Promise<void> {
+  try {
+    const client = createSupabaseServiceRoleClient();
+    if (!client) return;
+    await client
+      .from("cron_runs")
+      .update({ finished_at: new Date().toISOString(), status })
+      .eq("briefing_date", briefingDate);
+  } catch {
+    /* best-effort */
+  }
+}
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -124,11 +202,12 @@ async function runIngestionPipeline(stageRef: { current: EditorialInputTaskName 
   return { newsletter, rss, editorialStaging };
 }
 
-async function executePipelineWork() {
+async function executePipelineWork(briefingDate: string) {
   const stageRef: { current: EditorialInputTaskName } = { current: "newsletter" };
 
   logServerEvent("info", "Combined editorial input cron pipeline started", {
     route: "/api/cron/fetch-editorial-inputs",
+    briefingDate,
     internalTimeoutMs: INTERNAL_PIPELINE_TIMEOUT_MS,
   });
 
@@ -165,6 +244,7 @@ async function executePipelineWork() {
         stage: error.stage,
         internalTimeoutMs: error.timeoutMs,
       });
+      await finalizeRunLock(briefingDate, "timeout");
       return;
     }
 
@@ -182,6 +262,7 @@ async function executePipelineWork() {
       route: "/api/cron/fetch-editorial-inputs",
       ...errorContext(error),
     });
+    await finalizeRunLock(briefingDate, "fail");
     return;
   }
 
@@ -238,6 +319,12 @@ async function executePipelineWork() {
       route: "/api/cron/fetch-editorial-inputs",
     });
   }
+
+  // Use the lock's briefingDate (from todayTaipei at request time) rather than
+  // briefingDateForLog so the finalize keys to the same row that tryAcquireRunLock
+  // claimed. They will agree under normal operation; this guards against drift
+  // if editorial staging ever resolves a different Taipei calendar day.
+  await finalizeRunLock(briefingDate, pipelineLogStatus === "fail" ? "fail" : "ok");
 }
 
 export async function GET(request: Request) {
@@ -260,22 +347,55 @@ export async function GET(request: Request) {
   }
 
   const acceptedAt = new Date().toISOString();
+  const briefingDate = todayTaipei(new Date(acceptedAt));
+
+  // Run-lock claim happens synchronously, BEFORE after() schedules the pipeline.
+  // The second cronjob.org HTTP fire (or a Vercel Hobby double-delivery during
+  // the rollback escape hatch) must see the existing claim immediately and
+  // no-op — otherwise both runs would race past the gate and produce
+  // duplicate ingestion work. Finalize happens inside executePipelineWork.
+  const lock = await tryAcquireRunLock(briefingDate);
+
+  if (!lock.acquired) {
+    logServerEvent("info", "Combined editorial input cron skipped (already ran today)", {
+      route: "/api/cron/fetch-editorial-inputs",
+      briefingDate,
+      acceptedAt,
+      reason: lock.reason,
+    });
+    return NextResponse.json(
+      {
+        success: true,
+        timestamp: acceptedAt,
+        briefing_date: briefingDate,
+        status: "skipped",
+        reason: lock.reason,
+        summary: {
+          message: `Ingestion skipped: a run for briefing_date=${briefingDate} already started today.`,
+        },
+      },
+      { status: 200 },
+    );
+  }
 
   logServerEvent("info", "Combined editorial input cron accepted (running async via after())", {
     route: "/api/cron/fetch-editorial-inputs",
+    briefingDate,
     acceptedAt,
+    lockReason: lock.reason ?? "acquired",
   });
 
   // Run the ingestion pipeline after the response is sent. Vercel keeps the
   // function alive up to its maxDuration (60s in vercel.json) for `after()`
   // work, which gives the pipeline its full budget without making
   // cron-job.org wait — the 30s external HTTP timeout no longer applies.
-  after(executePipelineWork);
+  after(() => executePipelineWork(briefingDate));
 
   return NextResponse.json(
     {
       success: true,
       timestamp: acceptedAt,
+      briefing_date: briefingDate,
       summary: {
         message: "Ingestion accepted; running asynchronously. Observe completion via Sentry, Notion Pipeline Log, and the 12:15 UTC /api/cron/health check.",
       },

--- a/src/app/api/editorial/push-approved/route.ts
+++ b/src/app/api/editorial/push-approved/route.ts
@@ -138,7 +138,7 @@ type PushRowResult = {
   headline: string;
   notionPageId: string;
   supabaseId: string | null;
-  status: "inserted" | "failed";
+  status: "inserted" | "skipped_existing" | "failed";
   error?: string;
 };
 
@@ -253,17 +253,50 @@ async function pushApprovedRow(
       });
     }
 
-    const insertResult = await db
+    // Upsert on (briefing_date, source_url) so re-pushing an already-pushed
+    // approved row (or a different Notion row that points at the same article)
+    // does not duplicate. Backing index: signal_posts_briefing_date_source_url_key
+    // (migration 20260521120000). ignoreDuplicates returns the empty array
+    // when the row already exists; we then look up the existing supabase id
+    // so the Notion writeback still records the correct Supabase Row ID.
+    const upsertResult = await db
       .from("signal_posts")
-      .insert(insertPayload)
-      .select("id")
-      .single();
+      .upsert(insertPayload, {
+        onConflict: "briefing_date,source_url",
+        ignoreDuplicates: true,
+      })
+      .select("id");
 
-    if (insertResult.error) {
-      throw new Error(`signal_posts insert failed: ${insertResult.error.message}`);
+    if (upsertResult.error) {
+      throw new Error(`signal_posts upsert failed: ${upsertResult.error.message}`);
     }
 
-    const supabaseId = (insertResult.data as { id: string }).id;
+    const upsertRows = (upsertResult.data ?? []) as Array<{ id: string }>;
+    let supabaseId: string;
+    let status: "inserted" | "skipped_existing";
+
+    if (upsertRows.length > 0) {
+      supabaseId = upsertRows[0].id;
+      status = "inserted";
+    } else {
+      // ignoreDuplicates returned 0 rows → the (briefing_date, source_url)
+      // pair already exists. Look it up so we can still mirror Supabase Row ID
+      // back to Notion and flip Pushed to Supabase=true.
+      const existing = await db
+        .from("signal_posts")
+        .select("id")
+        .eq("briefing_date", briefingDate)
+        .eq("source_url", sourceUrl)
+        .maybeSingle();
+
+      if (existing.error || !existing.data) {
+        throw new Error(
+          `signal_posts upsert reported no insert and existing lookup failed: ${existing.error?.message ?? "no row found"}`,
+        );
+      }
+      supabaseId = (existing.data as { id: string }).id;
+      status = "skipped_existing";
+    }
 
     await markNotionRowPushed(page.id, supabaseId);
 
@@ -271,7 +304,7 @@ async function pushApprovedRow(
       headline,
       notionPageId: page.id,
       supabaseId,
-      status: "inserted",
+      status,
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -341,12 +374,14 @@ export async function GET(request: Request) {
   }
 
   const pushed = rows.filter((r) => r.status === "inserted").length;
+  const skipped = rows.filter((r) => r.status === "skipped_existing").length;
   const failed = rows.filter((r) => r.status === "failed").length;
 
   logServerEvent("info", "Editorial push: completed", {
     route: "/api/editorial/push-approved",
     briefingDate,
     pushed,
+    skipped,
     failed,
   });
 
@@ -354,6 +389,7 @@ export async function GET(request: Request) {
     success: true,
     briefing_date: briefingDate,
     pushed,
+    skipped,
     failed,
     rows: rows.map((r) => ({
       headline: r.headline,

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -463,6 +463,30 @@ function createSupabaseMock(
 
           return builder;
         },
+        // The upsert mock mirrors insert because the test fixtures never seed
+        // pre-existing rows that would actually conflict on
+        // (briefing_date, source_url). Real conflict behavior is covered by the
+        // route-level cron run-lock test (the partial unique index is enforced
+        // by Postgres, not this mock).
+        upsert(values: Partial<TestRow> | Array<Partial<TestRow>>, _options?: unknown) {
+          operation = "insert";
+          const insertError = options.insertErrors?.[tableName];
+
+          if (insertError) {
+            selectError = { message: insertError };
+            return builder;
+          }
+
+          insertedRows = [];
+          const normalizedValues = Array.isArray(values) ? values : [values];
+          normalizedValues.forEach((value, index) => {
+            const row = createInsertedRow(tableName, value as Record<string, unknown>, index);
+            tableRows.push(row);
+            insertedRows.push(row);
+          });
+
+          return builder;
+        },
         update(values: Record<string, unknown>) {
           operation = "update";
           updateValues = values;

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -1313,7 +1313,14 @@ async function persistSignalPostCandidates(
 
   const now = new Date().toISOString();
 
-  const insertResult = await client.from("signal_posts").insert(
+  // Upsert on (briefing_date, source_url) so a second ingestion run (e.g. the
+  // rollback escape hatch dual-trigger, or any future re-fire) is a no-op
+  // rather than a duplicate insert. The partial unique index backing this
+  // conflict target is signal_posts_briefing_date_source_url_key (migration
+  // 20260521120000). All rows in missingCandidates are pre-filtered by
+  // isValidPublicSourceUrl(), so source_url is non-null and matches the
+  // partial index predicate.
+  const insertResult = await client.from("signal_posts").upsert(
     missingCandidates.map((post) => ({
       briefing_date: briefingDate,
       rank: post.rank,
@@ -1344,6 +1351,7 @@ async function persistSignalPostCandidates(
       created_at: now,
       updated_at: now,
     })),
+    { onConflict: "briefing_date,source_url", ignoreDuplicates: true },
   ).select("id");
 
   if (insertResult.error) {

--- a/supabase/migrations/20260521120000_cron_runs_and_source_url_idempotency.sql
+++ b/supabase/migrations/20260521120000_cron_runs_and_source_url_idempotency.sql
@@ -1,0 +1,60 @@
+-- Task 1 (PRD-65 follow-up): cron consolidation + idempotency.
+--
+-- 1. New guard table `cron_runs` keyed on briefing_date. The ingestion handler
+--    claims today's run with `INSERT … ON CONFLICT (briefing_date) DO NOTHING`
+--    before scheduling `after(executePipelineWork)`. A second cronjob.org HTTP
+--    fire (or a Vercel Hobby double-delivery during the rollback escape hatch)
+--    sees the existing row and no-ops, so exactly one ingestion run executes
+--    per briefing_date.
+--
+-- 2. Belt-and-suspenders: dedupe legacy garbage on 2026-05-17 (Axios font CDN
+--    assets + Politico tracking redirector URLs the legacy writer captured as
+--    "stories" — confirmed 7 second-rank rows to delete) so the new partial
+--    unique index can build. The current code path filters source URLs via
+--    isValidPublicSourceUrl(), so these were inserted before that filter
+--    landed; no new rows of this shape are produced today.
+--
+-- 3. Add `UNIQUE (briefing_date, source_url) WHERE source_url IS NOT NULL` so
+--    both writer paths (legacy `persistSignalPostCandidates` and the v2
+--    `push-approved` bridge) can upsert idempotently against the same
+--    briefing_date if invoked twice.
+--
+-- See plan: ~/.claude/plans/playful-tumbling-yeti.md (Task 1).
+
+-- 1. cron_runs guard table
+CREATE TABLE IF NOT EXISTS public.cron_runs (
+  briefing_date  date PRIMARY KEY,
+  cron_name      text NOT NULL DEFAULT 'fetch-editorial-inputs',
+  started_at     timestamptz NOT NULL DEFAULT now(),
+  finished_at    timestamptz,
+  status         text NOT NULL DEFAULT 'running'
+                 CHECK (status IN ('running','ok','fail','timeout'))
+);
+
+ALTER TABLE public.cron_runs ENABLE ROW LEVEL SECURITY;
+-- Service-role-only access. Intentionally no policies: the only readers/writers
+-- are server-side handlers using the service-role key, which bypasses RLS.
+
+-- 2. Dedupe legacy spurious (briefing_date, source_url) duplicates so step 3
+--    can build the unique index. Keeps the lowest-rank row per
+--    (briefing_date, source_url); deletes the rest. Confirmed pre-flight: this
+--    removes exactly 7 rows on 2026-05-17 (Axios webfont assets + Politico
+--    redirector URLs misclassified as stories).
+WITH ranked AS (
+  SELECT id,
+         row_number() OVER (
+           PARTITION BY briefing_date, source_url
+           ORDER BY rank ASC, created_at ASC
+         ) AS rn
+  FROM public.signal_posts
+  WHERE source_url IS NOT NULL
+)
+DELETE FROM public.signal_posts s
+USING ranked r
+WHERE s.id = r.id AND r.rn > 1;
+
+-- 3. Partial unique index for upsert. NULL source_urls (Notion-originated rows
+--    without a URL) are excluded so they don't collide on the NULL singleton.
+CREATE UNIQUE INDEX IF NOT EXISTS signal_posts_briefing_date_source_url_key
+  ON public.signal_posts (briefing_date, source_url)
+  WHERE source_url IS NOT NULL;


### PR DESCRIPTION
## Summary

Path A Task 1 of the May 21 execution handoff. Collapses the dual cronjob.org ingestion schedule (10:15 + 11:45 UTC) into a single canonical run at 20:00 Asia/Taipei (= 0 12 * * * UTC), and introduces cross-run idempotency at two layers so a duplicate cronjob.org fire — or a Vercel Hobby double-delivery during the rollback escape hatch — no longer produces duplicate Notion / signal_posts writes.

The dual-ingestion schedule was the root cause of the 5–7× duplicate-rows-per-article symptom in the Notion Editorial Queue: both runs succeeded daily and Notion writes were not cross-run idempotent. The 12:15 UTC health-check job is unchanged and still alertable.

- **Layer 1 — run-lock:** new `public.cron_runs` table keyed on `briefing_date PK`. The cron handler claims today's run synchronously (`INSERT … ON CONFLICT (briefing_date) DO NOTHING`) before scheduling `after(executePipelineWork)`. A second HTTP fire responds `HTTP 200 status=skipped` without scheduling pipeline work. Lock-table failures fall through to running the pipeline (best-effort — one duplicate run preferred over a missed run).
- **Layer 2 — upsert:** both `signal_posts` writer paths (legacy `persistSignalPostCandidates` + `/api/editorial/push-approved`) now upsert on `(briefing_date, source_url)` with `ignoreDuplicates`. `push-approved` gains a new `"skipped_existing"` status so Notion writeback still flips `Pushed to Supabase=true` even when the underlying row was already present.
- **Cleanup:** the migration dedupes 7 legacy garbage rows on 2026-05-17 (Axios webfont CDN assets + Politico tracking redirector URLs the pre-`isValidPublicSourceUrl` writer captured as "stories") so the partial unique index that backs the upsert can build.

## Test plan

- [x] `npx vitest run` — 735/735 green, including 3 new run-lock scenarios in `src/app/api/cron/fetch-editorial-inputs/route.test.ts` (acquire success, duplicate-call skip, lock-table-error fall-through).
- [x] `npx tsc --noEmit` — zero new type errors vs. main (pre-existing errors in unrelated `source-manifest.test.ts` / `why-it-matters.test.ts` / `signals-editorial.test.ts` fixtures remain).
- [x] `npx eslint` on changed files — clean.

## Operator action after merge

1. **Apply the migration** via the Supabase MCP (project `fwkqjeumreaznfhnlzev`), file `supabase/migrations/20260521120000_cron_runs_and_source_url_idempotency.sql`. Spot-check: `SELECT * FROM cron_runs` (empty), 7-row reduction on `briefing_date='2026-05-17'`, and `\d signal_posts` shows the new partial unique index.
2. **Sync cron-job.org:** `CRONJOB_API_KEY=… CRON_SECRET=… BOOTUP_PRODUCTION_URL=https://bootupnews.com npm run cron:sync:prune`. Expected diff: delete 2 jobs (`bootup-ingestion-1015-utc`, `bootup-ingestion-1145-utc`), create 1 job (`bootup-ingestion-1200-utc`), no change to `bootup-health-check-1215-utc`.
3. **Double-fire test:** from cron-job.org dashboard, click "Test run" on `bootup-ingestion-1200-utc` twice within ~10 s. Expect first response `202`, second response `200 { status: "skipped", reason: "already_ran" }`. Confirm one Resend email, one Pipeline Log entry, no duplicate Notion rows.

## Out of scope (next PRs in this initiative)

- Per-feed isolation, France24 XML, Foreign Affairs UA, soften `>=5` floor → Task 2.
- Kill / relabel the legacy template generator that's still writing 100% of production rows → Task 3.
- Push-approved mapping (Hook → selection_reason, rank+tier pair, provenance, Notion-markdown normalize, writeback) → Task 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)