### PR TITLE
docs(cron): record cron-job.org burst-write throttle + final consolidated state

### DIFF
--- a/docs/engineering/CRON_SETUP.md
+++ b/docs/engineering/CRON_SETUP.md
@@ -244,6 +244,18 @@ cron-job.org's REST API allows **100 requests/day** on the free tier. A normal `
 
 So a full sync is ~6–10 API calls. Far under the cap. Don't run the sync in a tight loop or from CI on every push.
 
+#### Burst-rate gotcha (observed 2026-05-22)
+
+On a sync that simultaneously creates jobs AND prunes orphans, the call ordering can interleave reads and writes tightly enough to trip an apparent **per-window write throttle** that returns `HTTP 429` even when the daily 100-request cap is nowhere near exhausted. Observed during the first real consolidation: 2 creates + 3 deletes interleaved with their pre-flight reads → the second write (`PUT /jobs` for the health-check job) bounced with `HTTP 429: null`; a single direct `PUT /jobs` from `curl` a few seconds later succeeded immediately. The summary line reports this accurately as `created=N failed=1`.
+
+Practical workarounds:
+
+- **Retry the sync once.** A second `npm run cron:sync` (no further config changes) will see the missed job as a `create` again and complete it; the script is idempotent on success.
+- **Or fix the single missed job by hand.** Use a direct `PUT /jobs` with the job body you can pull from the dry-run output. This costs 1 API call instead of the sync's 3–5.
+- **Cooling-off:** the per-window throttle clears in well under a minute; you don't need to wait until the daily reset.
+
+Don't infer "the cron is broken" from a `failed=1` line on a high-churn sync — it usually means one write hit the burst limit, not a config error. Always verify final state via a direct `GET https://api.cron-job.org/jobs` with the same `Authorization: Bearer $CRONJOB_API_KEY` header.
+
 ---
 
 ## 7. Why infrastructure-as-code

--- a/docs/product/prd/prd-65-pipeline-reliability-external-cron-migration.md
+++ b/docs/product/prd/prd-65-pipeline-reliability-external-cron-migration.md
@@ -177,6 +177,29 @@ Test coverage in `src/app/api/cron/fetch-editorial-inputs/route.test.ts`
 service-role client never schedules the pipeline + emits Sentry + returns
 HTTP 503.
 
+### Phase 7.2 — cron-job.org consolidation actually applied (2026-05-22)
+
+PR #266 shipped the run-lock fix but the live cron-job.org state was still
+diverged from the repo config: three legacy jobs (`bootup-ingestion-1015-utc`,
+`bootup-ingestion-1145-utc`, an undocumented `bootup-health-check-1100-utc`
+that the As-Built had silently aged out of sync) kept firing, and the two
+config-defined jobs (`bootup-ingestion-1200-utc`, `bootup-health-check-1215-utc`)
+didn't exist yet. The first `npm run cron:sync:prune` consumed the new
+`CRONJOB_API_KEY` operator value, deleted all three orphans, created the
+ingestion job, and **bounced off cron-job.org's burst-write throttle on the
+second create with `HTTP 429: null`** — the summary correctly reported
+`created=1 failed=1`. A direct `PUT /jobs` from `curl` a few seconds later
+created the health-check job (jobId 7646665) without further issue.
+
+Final live state confirmed via `GET https://api.cron-job.org/jobs`:
+
+| UTC | Job | Endpoint | jobId | Header |
+| --- | --- | --- | --- | --- |
+| 12:00 | `bootup-ingestion-1200-utc` | `/api/cron/fetch-editorial-inputs` | 7646662 | rotated `x-cron-secret` ✓ |
+| 12:15 | `bootup-health-check-1215-utc` | `/api/cron/health` | 7646665 | rotated `x-cron-secret` ✓ |
+
+Operational lesson captured in [`docs/engineering/CRON_SETUP.md` §6 → Burst-rate gotcha](../../engineering/CRON_SETUP.md#burst-rate-gotcha-observed-2026-05-22): high-churn syncs (multiple creates + multiple deletes) can interleave reads and writes tightly enough to trip an apparent per-window throttle even when the daily 100-request cap is nowhere near exhausted. The script's `failed=N` summary line accurately reflects this; the workaround is either re-running the sync (idempotent) or a single direct `PUT` for the missed job.
+
 ## Closeout Checklist
 
 - Scope completed: all phases (0–5) plus the cron-job.org sync tooling landing.


### PR DESCRIPTION
Doc-only follow-up to PR #266 + the 2026-05-22 `cron:sync:prune` apply session. Captures two operationally useful findings so future operators (or future-me) don't have to re-discover them.

## What changed

1. **`docs/engineering/CRON_SETUP.md` §6 — "Burst-rate gotcha (observed 2026-05-22)"** under the existing API rate-limit section. High-churn syncs (multiple creates + multiple deletes) can interleave reads and writes tightly enough to trip an apparent **per-window write throttle** (`HTTP 429: null`) even when the daily 100-request cap is nowhere near exhausted. The script's `failed=N` line accurately surfaces this; workarounds are: (a) re-run `npm run cron:sync` (idempotent, picks up the missed job), or (b) one direct `PUT /jobs` from `curl` (1 API call instead of 3–5).
2. **PRD-65 Phase 7.2 operational-history entry** closes the consolidation loop with the actual live cron-job.org state confirmed via `GET /jobs`: two jobs alive (`bootup-ingestion-1200-utc` jobId 7646662, `bootup-health-check-1215-utc` jobId 7646665), both carrying the rotated `x-cron-secret` header, three orphans deleted including an undocumented `bootup-health-check-1100-utc` that had aged out of sync with the repo config.

## Why these belong in committed docs

- The 429 looked like a real failure during the apply — without the note, the next operator may panic or assume the script is broken.
- The PRD-65 Phase 7.1 entry described the run-lock fix but not the actual application of the prune; without this entry, the As-Built diverges again the moment anyone audits.

## Test plan

- [x] `npx eslint` — N/A (docs only)
- [x] `npx vitest run` — N/A (no code changes); 795/795 still green on main
- [x] Markdown rendering checked in GitHub preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)