### PR TITLE
fix(signals): rewrite persistSignalPostCandidates to select-then-decide (3-day prod outage fix)

### DIFF
--- a/docs/engineering/bug-fixes/partial-index-onconflict-mismatch-2026-05-23.md
+++ b/docs/engineering/bug-fixes/partial-index-onconflict-mismatch-2026-05-23.md
@@ -1,0 +1,55 @@
+# Partial-Index ON CONFLICT Mismatch — 3-Day Production Ingestion Outage - Bug-Fix Record
+
+## Summary
+- Problem addressed: Boot Up News ingestion silently failed every cron fire for 3 consecutive days (2026-05-21 → 2026-05-23). Zero `signal_posts` rows were written between 2026-05-21 10:15Z (the last fire under pre-PR-260 code) and the fix landing. `cron_runs.status='fail'` recorded each day; Sentry surfaced BOOT-UP-WEB-6 and BOOT-UP-WEB-7 but those wrappers carried no Postgres-side error message, so the failures looked like transient persistence issues until the third day's diagnostic deep-dive.
+- Root cause: PR #260 created `signal_posts_briefing_date_source_url_key` as a **partial** unique index (`WHERE source_url IS NOT NULL`) and simultaneously switched `persistSignalPostCandidates` to `.upsert(rows, { onConflict: "briefing_date,source_url", ignoreDuplicates: true })`. supabase-js translates this to a bare `ON CONFLICT (briefing_date, source_url) DO NOTHING` with no `WHERE` predicate. Postgres requires the partial-index's predicate to be repeated in the conflict-inference clause — without it the planner cannot match any unique index and aborts the entire INSERT batch with `SQLSTATE 42P10`. The vitest mock at `signals-editorial.test.ts:~478` implements `.upsert()` as a JS stand-in that does NOT enforce ON CONFLICT inference semantics; 795 green tests passed against a bug that fails 100% of the time in production.
+- Affected object level: Card (signal_posts is the Card storage layer).
+- **Related PRD:** PRD-65 (`docs/product/prd/prd-65-pipeline-reliability-external-cron-migration.md`)
+
+## Fix
+- Exact change (4 parts):
+
+  **Part 1 — App fix.** `src/lib/signals-editorial.ts:persistSignalPostCandidates` rewritten to select-then-decide:
+
+  ```ts
+  // SELECT existing source_url values for the briefing_date.
+  // Filter candidates to those whose URL isn't already present.
+  // Plain .insert() — no .upsert(), no ON CONFLICT.
+  ```
+
+  Mirrors the pattern PR #266 used for `pushApprovedRow`. The SELECT → INSERT race is closed at the orchestration layer by the `cron_runs` run-lock from PRs #260 + #266.
+
+  **Part 2 — Writer audit.** Every signal_posts writer enumerated:
+  - `persistSignalPostCandidates` — broken; fixed by Part 1.
+  - `pushApprovedRow` — already select-then-decide via PR #266; safe.
+  - `promoteNewsletterStoryToCandidate` (`src/lib/newsletter-ingestion/promotion.ts:406`) — plain `.insert()`; safe.
+  - No other writers found via `grep '.upsert(' src --include='*.ts' | grep -v .test`.
+
+  **Part 3 — Index decision.** The partial unique index `signal_posts_briefing_date_source_url_key` is **kept as a passive data-integrity guard**. After Part 1, no writer uses it for `ON CONFLICT` inference, so the partial predicate no longer creates a footgun. It still prevents duplicate non-NULL `(briefing_date, source_url)` pairs from any future writer, with zero behavior cost. Decision documented in PRD-65 Phase 7.3.
+
+  **Part 4 — Test gap.** New file `src/lib/signal-posts-writers.guard.test.ts` scans all production `.ts` files and fails if any calls `.upsert(...)` against `signal_posts`. Relax-the-rule conditions ((a) all relevant indexes non-partial, AND (b) integration test against real Postgres) are documented in the test file's header so deleting the rule forces the review conversation. Mock at `signals-editorial.test.ts:~478` gains an explicit `KNOWN GAP (issue #268)` comment documenting what it does NOT enforce.
+
+- Related PRDs: PRD-65 Phase 7.3 operational-history entry.
+- PR: TBD on merge.
+- Branch: `claude/fix-partial-index-onconflict`
+- GitHub source-of-truth status: Canonical bug-fix record; details mirrored in PR description, PRD-65 Phase 7.3, and the guard test's header comment.
+- External references reviewed: Live Supabase repro on 2026-05-23 confirmed `SQLSTATE 42P10` with the literal message "there is no unique or exclusion constraint matching the ON CONFLICT specification". A separate live repro confirmed that adding the partial predicate to `ON CONFLICT` (`... WHERE source_url IS NOT NULL`) makes the upsert succeed. supabase-js's `.upsert({onConflict})` API does not expose the WHERE predicate, so the fix had to be at the call-site, not the index.
+- Branch cleanup status: branch will be deleted on merge via `gh pr merge --delete-branch`.
+
+## Terminology Requirement
+- Before implementation, read `docs/engineering/BOOTUPNEWS_CANONICAL_TERMINOLOGY.md`.
+- [x] Confirmed object level: Card.
+- [x] No new variable, file, function, component, or database terminology was introduced. The guard test's "writer" terminology refers to code that performs `INSERT`/`UPDATE`/`UPSERT` operations against signal_posts — a code-organization term, not editorial.
+- [x] Legacy column naming asymmetry preserved; no schema rename.
+
+## Validation
+- Automated checks: `npx vitest run` — **797/797 green** (+2 vs main: the guard's two cases). `npx eslint` on touched files — clean. `npx tsc --noEmit` on touched files — zero new errors.
+- Live-DB repro pre-fix: the legacy `.upsert(...,{onConflict:'briefing_date,source_url',ignoreDuplicates:true})` produced SQLSTATE 42P10 in a sentinel-briefing_date test against the actual prod schema.
+- Live-DB verification of the fix: a plain `.insert()` of the same payload against the sentinel briefing_date succeeded. (The full end-to-end production fire is deferred to the post-merge operator verification step, per the brief's "STOP after opening the PR; do not self-merge" rule.)
+- Human checks: the 5 days of `cron_runs.status='fail'` rows on prod, paired with Sentry BOOT-UP-WEB-6/-7 events from the same timestamps, were the diagnostic anchor.
+
+## Remaining Risks / Follow-up
+- **Test infrastructure gap remains.** The lint-style guard prevents `.upsert()` reintroduction on signal_posts, but doesn't catch other classes of partial-index/ON-CONFLICT issues if a future PR adds a partial index against a DIFFERENT table that supabase-js code targets. The deeper solution is a real-Postgres integration harness (Supabase test branch or ephemeral DB) — not in scope for this PR but called out as the right next step.
+- **Sentry alerting for `cron_runs.status='fail'`** would have surfaced the failure as a page on day 1 rather than day 3. The wrapper errors (BOOT-UP-WEB-6/-7) DID reach Sentry but were not configured as alerting rules — they sat in the issue list unnoticed. A follow-up should either set up Sentry issue alerts on these specific issue types OR have the cron handler emit a Sentry message with `level: "fatal"` when `cron_runs.status='fail'` is set, to surface the failure with higher signal.
+- **The 2026-05-22 and 2026-05-23 `cron_runs` rows with `status='fail'`** stay in place; the run-lock from PR #266 means future fires for OTHER briefing_dates aren't blocked. The 05-22/-23 dates themselves will simply have no editorial queue for those days. No remediation needed unless BM wants to retroactively run those dates (a one-shot manual fire after the fix is live + a `DELETE` of the stale `cron_runs` row would do it).
+- **Documentation gap**: supabase-js's `.upsert({onConflict})` does not support adding a `WHERE` predicate, and this is not called out in supabase-js's docs (only Postgres's docs mention the requirement). Worth filing an upstream feature request or doc improvement at https://github.com/supabase/supabase-js if not already tracked.

--- a/docs/product/prd/prd-65-pipeline-reliability-external-cron-migration.md
+++ b/docs/product/prd/prd-65-pipeline-reliability-external-cron-migration.md
@@ -200,6 +200,23 @@ Final live state confirmed via `GET https://api.cron-job.org/jobs`:
 
 Operational lesson captured in [`docs/engineering/CRON_SETUP.md` §6 → Burst-rate gotcha](../../engineering/CRON_SETUP.md#burst-rate-gotcha-observed-2026-05-22): high-churn syncs (multiple creates + multiple deletes) can interleave reads and writes tightly enough to trip an apparent per-window throttle even when the daily 100-request cap is nowhere near exhausted. The script's `failed=N` summary line accurately reflects this; the workaround is either re-running the sync (idempotent) or a single direct `PUT` for the missed job.
 
+### Phase 7.3 — Partial-index ON CONFLICT mismatch (issue #268, 3-day production outage 2026-05-21 → 2026-05-23)
+
+**Severity:** load-bearing. Production ingestion silently failed every cron fire for 3 consecutive days. Zero `signal_posts` rows were written between 2026-05-21 10:15Z (the last fire under pre-PR-260 code) and the fix landing. `cron_runs.status='fail'` every day; Sentry surfaced BOOT-UP-WEB-6 (RSS signal post persistence failed during daily refresh) and BOOT-UP-WEB-7 (Current RSS Top 5 snapshot could not be persisted for editing) but those wrappers carried no Postgres-side error message.
+
+**Root cause:** PR #260's migration `20260521120000_cron_runs_and_source_url_idempotency.sql` created `signal_posts_briefing_date_source_url_key` as a **partial** unique index (`WHERE source_url IS NOT NULL`). The same PR switched `persistSignalPostCandidates` to `.upsert(rows, { onConflict: "briefing_date,source_url", ignoreDuplicates: true })`. supabase-js translates this to a bare `ON CONFLICT (briefing_date, source_url) DO NOTHING` with no `WHERE` predicate. Postgres requires the partial-index's predicate to be repeated in the conflict-inference clause; without it the planner cannot match any unique index and aborts the entire INSERT batch with `SQLSTATE 42P10: there is no unique or exclusion constraint matching the ON CONFLICT specification`. The vitest mock at `signals-editorial.test.ts:~478` implements `.upsert()` as a JS stand-in that does NOT enforce ON CONFLICT inference semantics, so 795 green tests never caught the bug.
+
+**Why detection lagged 3 days:** the new consolidated 12:00 UTC schedule didn't start firing until 2026-05-22 (after `cron:sync:prune` ran), so the first failing run under post-PR-260 code was 05-22 12:00. Sentry events landed but were classified as transient feed/persistence issues. `cron_runs` rows showed `status='fail'` with duration ~25–30s — within budget, ruling out the timeout hypothesis only on the third day's diagnostic deep-dive.
+
+**Fix (PR #268-fix):** four parts, one PR.
+
+1. **App** — `persistSignalPostCandidates` rewritten to a select-then-decide flow (mirrors PR #266's `pushApprovedRow`): SELECT existing `source_url`s for the briefing_date → filter candidate rows to non-present → plain `.insert()` for the rest. No `.upsert()`, no `ON CONFLICT`. The SELECT → INSERT race window is closed at the orchestration layer by the `cron_runs` run-lock from PRs #260 + #266.
+2. **Audit** — every signal_posts writer enumerated. `pushApprovedRow` already uses `.insert()`/`.update()` via PR #266. `promoteNewsletterStoryToCandidate` uses plain `.insert()` (no upsert). No other writers exist.
+3. **Index decision** — the partial unique index `signal_posts_briefing_date_source_url_key` is **kept as a passive data-integrity guard**. After Part 1, no writer uses it for `ON CONFLICT` inference, so the partial predicate no longer creates a footgun. It still prevents duplicate non-NULL `(briefing_date, source_url)` pairs from any future writer, with zero behavior cost.
+4. **Test gap** — new lint-style guard at `src/lib/signal-posts-writers.guard.test.ts` scans all production `.ts` files and fails if any production code calls `.upsert(...)` against `signal_posts`. The relax-the-rule conditions ((a) all relevant indexes non-partial, and (b) integration test against real Postgres) are documented in the test file's header so deleting the rule forces the review conversation. Additionally, the mock's known gap is now explicitly documented at `signals-editorial.test.ts:~478` so future editors know what the mock does NOT enforce.
+
+**Operational lesson:** supabase-js's `.upsert({onConflict})` cannot match partial unique indexes. Any future migration adding a partial unique index that a JS-client upsert needs to target MUST be paired with either (a) a non-partial sibling index, or (b) a switch to select-then-decide / RPC. The guard test enforces this at PR review time.
+
 ## Closeout Checklist
 
 - Scope completed: all phases (0–5) plus the cron-job.org sync tooling landing.

--- a/src/lib/signal-posts-writers.guard.test.ts
+++ b/src/lib/signal-posts-writers.guard.test.ts
@@ -1,0 +1,131 @@
+/**
+ * signal_posts writers guard — regression guard for issue #268.
+ *
+ * Background:
+ *   PR #260 introduced `signal_posts_briefing_date_source_url_key`, a PARTIAL
+ *   unique index (`WHERE source_url IS NOT NULL`). It also switched
+ *   `persistSignalPostCandidates` to call
+ *     `.upsert(rows, { onConflict: "briefing_date,source_url", ignoreDuplicates: true })`.
+ *   supabase-js translates that to a bare
+ *     `ON CONFLICT (briefing_date, source_url) DO NOTHING`
+ *   with NO `WHERE` predicate. Postgres requires the partial-index predicate
+ *   to be repeated in the conflict-inference clause, so it returned SQLSTATE
+ *   42P10 ("there is no unique or exclusion constraint matching the ON
+ *   CONFLICT specification") — aborting the entire INSERT batch. Production
+ *   ingestion was silently down for 3 days; cron_runs.status='fail' fired
+ *   every day, signal_posts received zero new rows.
+ *
+ *   The vitest supabase mock at signals-editorial.test.ts:~478 implements
+ *   `.upsert(...)` as a JS stand-in that does NOT enforce Postgres's ON
+ *   CONFLICT inference rules against partial indexes. 795 unit tests went
+ *   green; the bug only surfaced in production.
+ *
+ * Rule enforced here:
+ *   Production code MUST NOT call `.upsert(...)` against `signal_posts`. Use
+ *   the select-then-decide pattern instead — see:
+ *     - src/lib/signals-editorial.ts → persistSignalPostCandidates
+ *     - src/app/api/editorial/push-approved/route.ts → pushApprovedRow
+ *
+ *   This rule can be relaxed ONLY when:
+ *     (a) every unique index on signal_posts referenced by the upsert is
+ *         NON-partial (no `WHERE` clause), so supabase-js's bare
+ *         `ON CONFLICT (cols)` can match it, AND
+ *     (b) the change is accompanied by an integration test against a real
+ *         Postgres (Supabase test branch / ephemeral DB) that exercises the
+ *         upsert against the actual deployed index schema.
+ *
+ *   If you need to relax it, edit this file + delete the rule + replace it
+ *   with the integration test. The deletion is the gate that forces the
+ *   review conversation about (a) and (b).
+ */
+
+import { readdir, readFile } from "node:fs/promises";
+import { resolve, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const PROJECT_ROOT = resolve(__dirname, "..", "..");
+const SRC_ROOT = resolve(__dirname, "..");
+
+async function listProductionTsFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const out: string[] = [];
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // Skip the harness-managed worktree caches; some hold stale code.
+      if (entry.name === "node_modules" || entry.name === ".next") continue;
+      out.push(...(await listProductionTsFiles(full)));
+    } else if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Find every `.upsert(` token that appears within `windowChars` characters
+ * AFTER a `.from("signal_posts")` call in the same source string. Returns
+ * `file:line` strings for each offender so the test failure points at the
+ * exact location to fix.
+ */
+function findUpsertsTargetingSignalPosts(file: string, src: string, windowChars = 800): string[] {
+  const fromPattern = /\.from\(\s*["'`]signal_posts["'`]\s*\)/g;
+  const offenders: string[] = [];
+  for (const m of src.matchAll(fromPattern)) {
+    if (m.index === undefined) continue;
+    const window = src.slice(m.index, m.index + windowChars);
+    // Match `.upsert(` but not `.upsertOptions` or method names that begin
+    // with the same chars. A `(` follows when it's a real call.
+    if (/\.upsert\s*\(/.test(window)) {
+      const lineNumber = src.slice(0, m.index).split("\n").length;
+      offenders.push(`${file.replace(PROJECT_ROOT + "/", "")}:${lineNumber}`);
+    }
+  }
+  return offenders;
+}
+
+describe("signal_posts writers guard (issue #268)", () => {
+  it("no production code calls .upsert() against signal_posts", async () => {
+    const files = await listProductionTsFiles(SRC_ROOT);
+    const offenders: string[] = [];
+    for (const file of files) {
+      const src = await readFile(file, "utf8");
+      offenders.push(...findUpsertsTargetingSignalPosts(file, src));
+    }
+    expect(
+      offenders,
+      [
+        "Found production code calling .upsert() against signal_posts.",
+        "",
+        "This pattern silently failed in production for 3 days (issue #268)",
+        "because supabase-js emits a bare ON CONFLICT clause that cannot",
+        "match the PARTIAL unique index signal_posts_briefing_date_source_url_key.",
+        "",
+        "Use select-then-decide instead:",
+        "  - src/lib/signals-editorial.ts → persistSignalPostCandidates",
+        "  - src/app/api/editorial/push-approved/route.ts → pushApprovedRow",
+        "",
+        "If you really need .upsert() here, see the comment at the top of",
+        "src/lib/signal-posts-writers.guard.test.ts for the relax-the-rule",
+        "conditions (both (a) and (b) required).",
+        "",
+        "Offenders:",
+        ...offenders.map((o) => `  - ${o}`),
+      ].join("\n"),
+    ).toEqual([]);
+  });
+
+  it("vitest scanning is wired up correctly (sanity: at least one signal_posts .from() exists)", async () => {
+    // If the scanner regresses to find zero .from('signal_posts') sites, the
+    // .upsert() check would also become a no-op. This sanity test asserts the
+    // scanner actually finds the signal_posts touchpoints we expect.
+    const files = await listProductionTsFiles(SRC_ROOT);
+    let totalFromCalls = 0;
+    for (const file of files) {
+      const src = await readFile(file, "utf8");
+      const matches = src.match(/\.from\(\s*["'`]signal_posts["'`]\s*\)/g);
+      if (matches) totalFromCalls += matches.length;
+    }
+    expect(totalFromCalls).toBeGreaterThan(5);
+  });
+});

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -479,9 +479,20 @@ function createSupabaseMock(
         },
         // The upsert mock mirrors insert because the test fixtures never seed
         // pre-existing rows that would actually conflict on
-        // (briefing_date, source_url). Real conflict behavior is covered by the
-        // route-level cron run-lock test (the partial unique index is enforced
-        // by Postgres, not this mock).
+        // (briefing_date, source_url).
+        //
+        // KNOWN GAP (issue #268): this mock does NOT enforce Postgres's
+        // ON CONFLICT inference rules against partial unique indexes. PR
+        // #260 passed all tests using `{onConflict:'briefing_date,source_url',
+        // ignoreDuplicates:true}` even though Postgres would have rejected
+        // the bare ON CONFLICT clause with SQLSTATE 42P10 against the
+        // PARTIAL `signal_posts_briefing_date_source_url_key` index — and
+        // production was down for 3 days as a result. The lint-style guard
+        // at src/lib/signal-posts-writers.guard.test.ts forbids any new
+        // `.upsert()` against signal_posts to prevent recurrence. Do not
+        // delete this comment without addressing the gap (either by
+        // extending the mock to model index inference, or by adding a
+        // real-Postgres integration harness).
         upsert(values: Partial<TestRow> | Array<Partial<TestRow>>, _options?: unknown) {
           operation = "insert";
           const insertError = options.insertErrors?.[tableName];

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -1313,45 +1313,94 @@ async function persistSignalPostCandidates(
 
   const now = new Date().toISOString();
 
-  // Upsert on (briefing_date, source_url) so a second ingestion run (e.g. the
-  // rollback escape hatch dual-trigger, or any future re-fire) is a no-op
-  // rather than a duplicate insert. The partial unique index backing this
-  // conflict target is signal_posts_briefing_date_source_url_key (migration
-  // 20260521120000). All rows in missingCandidates are pre-filtered by
-  // isValidPublicSourceUrl(), so source_url is non-null and matches the
-  // partial index predicate.
+  // Select-then-decide persistence (issue #268 — production was down for 3 days
+  // because the previous `.upsert(..., { onConflict: "briefing_date,source_url",
+  // ignoreDuplicates: true })` could not match the PARTIAL unique index
+  // `signal_posts_briefing_date_source_url_key WHERE source_url IS NOT NULL`).
   //
+  // supabase-js emits a bare `ON CONFLICT (briefing_date, source_url) DO NOTHING`
+  // with no WHERE predicate; Postgres requires the partial index's predicate
+  // to be repeated in the conflict-inference clause, so it returned SQLSTATE
+  // 42P10 "there is no unique or exclusion constraint matching the ON CONFLICT
+  // specification" — aborting the entire INSERT batch on every run since PR
+  // #260 + the consolidated schedule went live. Test mocks didn't enforce
+  // index-inference semantics so 795 green vitest cases never caught it.
+  //
+  // The fix mirrors PR #266's `pushApprovedRow` rewrite: SELECT the existing
+  // source_url values for the briefing_date, filter the candidate batch to
+  // those whose source_url isn't already present, and INSERT only the missing
+  // rows via plain `.insert()`. No `ON CONFLICT`. The select-then-insert
+  // window is not atomic, but the run-lock from PR #260 + #266 (`cron_runs`
+  // PK with status-aware reclaim) prevents concurrent cron fires from
+  // racing into the same briefing_date — so the race window is already
+  // closed at the orchestration layer.
+  //
+  // Task 3 provenance stamps (PR #262) are preserved verbatim below.
+  const candidateUrls = missingCandidates
+    .map((c) => c.sourceUrl)
+    .filter((u): u is string => typeof u === "string" && u.length > 0);
+  const existingUrlsResult = await client
+    .from("signal_posts")
+    .select("source_url")
+    .eq("briefing_date", briefingDate)
+    .in("source_url", candidateUrls);
+
+  if (existingUrlsResult.error) {
+    captureRssEditorialStorageFailure({
+      failureType: "rss_cache_read_failed",
+      phase: "store",
+      operation: "preflight_existing_source_urls",
+      briefingDate,
+      message: "RSS signal snapshot pre-flight existing-URL check failed.",
+    });
+    return {
+      ok: false,
+      briefingDate,
+      insertedCount: 0,
+      skippedCandidates,
+      message: `Pre-flight failed; could not check existing source_urls: ${existingUrlsResult.error.message}`,
+    };
+  }
+
+  const existingUrlSet = new Set(
+    ((existingUrlsResult.data ?? []) as Array<{ source_url: string | null }>)
+      .map((r) => r.source_url)
+      .filter((u): u is string => typeof u === "string"),
+  );
+
+  const candidatesToInsert = missingCandidates.filter(
+    (c) => !existingUrlSet.has(c.sourceUrl),
+  );
+
+  if (candidatesToInsert.length === 0) {
+    return {
+      ok: true,
+      briefingDate,
+      insertedCount: 0,
+      insertedPostIds: [],
+      skippedCandidates,
+      mode,
+      message: "The daily signal snapshot already exists for this briefing date (all candidate URLs already present).",
+    };
+  }
+
   // Task 3 — Legacy template generator provenance stamps. The witm_draft_*
   // columns were left NULL on every legacy-path row in production, making the
-  // boilerplate output indistinguishable from the (future) v2 LLM bridge
-  // rows. Stamping them at write time means any post-deploy query can tell
-  // legacy heuristic copy from v2 LLM copy by provenance alone, and the v2
-  // bridge (Task 4) gets a deterministic predicate to overwrite legacy rows
-  // when the editor approves a real draft.
-  //
-  // Per-column rationale:
-  //   - witm_draft_generated_by='deterministic_template' — CHECK constraint
-  //     allows {llm, deterministic_template, human}; this is the legacy bucket.
-  //   - witm_draft_model='heuristic_template_v1' — free-text identifier for
-  //     the summarizer + why-it-matters template builder
-  //     (src/lib/why-it-matters.ts → buildEventTypeSpecificWhyThisMatters,
-  //     summarizer.ts → generateWhyThisMattersHeuristically).
+  // boilerplate output indistinguishable from v2 LLM bridge rows. Stamping
+  // them at write time means any post-deploy query can tell legacy heuristic
+  // copy from v2 LLM copy by `witm_draft_generated_by` alone:
+  //   - 'deterministic_template' — CHECK allows {llm, deterministic_template, human}.
+  //   - 'heuristic_template_v1' — free-text identifier for the summarizer +
+  //     why-it-matters template builder (src/lib/why-it-matters.ts →
+  //     buildEventTypeSpecificWhyThisMatters; summarizer.ts →
+  //     generateWhyThisMattersHeuristically).
   //   - editorial_content_source='ai' — closest fit under the
-  //     {ai, human, ai+human} CHECK. The heuristic is structurally an
-  //     AI-shaped synthetic generator (not human-edited); 'ai' will be the
-  //     same value the v2 LLM bridge uses, so callers must combine it with
-  //     witm_draft_generated_by to distinguish the two paths.
-  //   - why_it_matters_validation_status: see Task 6 — still defaults to
-  //     'passed' from the CHECK default because the legacy validator's
-  //     enum doesn't yet model "not_run". Task 6 lands the enum change.
-  //
-  // The legacy path NEVER overwrites a v2 bridge row: the upsert uses
-  // ignoreDuplicates, so any existing (briefing_date, source_url) row —
-  // whether legacy or v2 — wins. Task 4 will need to invert this for the
-  // bridge so v2 rows can overwrite stale deterministic_template rows when
-  // BM approves a real draft for the same article URL.
-  const insertResult = await client.from("signal_posts").upsert(
-    missingCandidates.map((post) => ({
+  //     {ai, human, ai+human} CHECK. v2 LLM bridge writes the same value, so
+  //     callers must combine it with witm_draft_generated_by to distinguish.
+  //   - why_it_matters_validation_status: still defaults to 'passed' from the
+  //     CHECK default. Task 6 lands the 'not_run' enum addition.
+  const insertResult = await client.from("signal_posts").insert(
+    candidatesToInsert.map((post) => ({
       briefing_date: briefingDate,
       rank: post.rank,
       title: post.title,
@@ -1386,7 +1435,6 @@ async function persistSignalPostCandidates(
       created_at: now,
       updated_at: now,
     })),
-    { onConflict: "briefing_date,source_url", ignoreDuplicates: true },
   ).select("id");
 
   if (insertResult.error) {


### PR DESCRIPTION
**Severity:** load-bearing. Production ingestion silently failed every cron fire from 2026-05-21 → 2026-05-23. **Zero `signal_posts` rows were written for 3 consecutive days.** `cron_runs.status='fail'` recorded each day; Sentry surfaced BOOT-UP-WEB-6 + BOOT-UP-WEB-7 but they were buried as transient persistence noise until the third day's deep dive.

## Root cause (verified against live schema via SQLSTATE repro)

PR #260 created a **partial** unique index:
```sql
CREATE UNIQUE INDEX signal_posts_briefing_date_source_url_key
  ON public.signal_posts (briefing_date, source_url)
  WHERE source_url IS NOT NULL;   -- partial predicate
```
…and switched `persistSignalPostCandidates` to:
```ts
.upsert(rows, { onConflict: "briefing_date,source_url", ignoreDuplicates: true })
```

supabase-js translates that to a **bare** `ON CONFLICT (briefing_date, source_url) DO NOTHING` with no `WHERE` predicate. Postgres requires the partial-index's predicate to be repeated in the conflict-inference clause — without it the planner cannot match any unique index and aborts the entire INSERT with `SQLSTATE 42P10: there is no unique or exclusion constraint matching the ON CONFLICT specification`. The vitest mock at `signals-editorial.test.ts:~478` implements `.upsert()` as a JS stand-in that does NOT enforce ON CONFLICT inference semantics, so 795 green tests passed against a bug that fails 100% of the time in production.

## Fix — 4 parts, one PR

### Part 1 — App fix
`persistSignalPostCandidates` rewritten to **select-then-decide** (mirrors PR #266's `pushApprovedRow`):
```
SELECT existing source_urls for briefing_date
  → filter candidate rows to non-present
  → plain .insert() — no .upsert(), no ON CONFLICT
```
The SELECT → INSERT race window is closed at the orchestration layer by the `cron_runs` run-lock from PRs #260 + #266 (no concurrent fires for the same `briefing_date` can race past the gate). All current behavior preserved: `deterministic_template` / `heuristic_template_v1` / `editorial_content_source='ai'` stamps from PR #262, `isValidPublicSourceUrl` non-NULL filter, final_slate tier+rank pairing, display rank.

### Part 2 — Writer audit
Every `signal_posts` writer enumerated:
| Writer | Status |
| --- | --- |
| `persistSignalPostCandidates` (`src/lib/signals-editorial.ts:~1353`) | ❌ Broken — fixed by Part 1 |
| `pushApprovedRow` (`src/app/api/editorial/push-approved/route.ts:497,553`) | ✅ Safe — PR #266 rewrote it to `.update()` / `.insert()` select-then-decide; **no `.upsert()` call** |
| `promoteNewsletterStoryToCandidate` (`src/lib/newsletter-ingestion/promotion.ts:406`) | ✅ Safe — plain `.insert()`; does its own pre-flight dedup at lines 108/128/146 |
| Anything else | Verified via `grep '.upsert(' src --include='*.ts' \| grep -v .test`; only the one offender existed |

### Part 3 — Index decision (kept as guard)
`signal_posts_briefing_date_source_url_key` is **kept as a passive data-integrity guard**. After Part 1, no writer uses it for `ON CONFLICT` inference, so the partial predicate no longer creates a footgun. It still prevents duplicate non-NULL `(briefing_date, source_url)` pairs from any future writer, with zero behavior cost. Default per the brief.

### Part 4 — Test gap closure
- New `src/lib/signal-posts-writers.guard.test.ts` scans every production `.ts` file and **fails if any production code calls `.upsert(...)` against `signal_posts`**. Relax-the-rule conditions ((a) all relevant indexes non-partial, AND (b) integration test against real Postgres) are documented in the test file's header so deleting the rule forces the review conversation.
- Mock at `signals-editorial.test.ts:~478` gains an explicit `KNOWN GAP (issue #268)` comment documenting what it does NOT enforce, so future editors know.
- I chose the static-guard fallback over a real-Postgres integration harness because (a) the harness needs CI infrastructure that's out of scope, (b) the guard catches THIS class of bug 100% at PR review time, and (c) the bug-fix record's "Remaining Risks" section calls out the harness as the right next step in a follow-up PR.

## Test plan

- [x] `npx vitest run` — **797/797 green** (+2 vs main).
- [x] `npx eslint` on changed files — clean (the one warning predates this PR).
- [x] `npx tsc --noEmit` on changed files — zero new errors.
- [x] Live-DB pre-fix repro: bare `ON CONFLICT (briefing_date, source_url)` against a sentinel `briefing_date='1971-01-02'` returned `SQLSTATE 42P10`.
- [x] Live-DB fix-shape repro: plain `.insert()` of the same payload (5 rows) against `briefing_date='1971-01-03'` succeeded with `inserted=2`. Cleaned up immediately.

## Operator verification AFTER merge (the real end-to-end this PR can't do for itself)

The brief's "STOP after opening the PR; do not self-merge" rule means the **live prod fire** belongs in your hands:

```bash
# 1. Confirm cron_runs is empty for today (Taipei date)
psql -c "select * from cron_runs where briefing_date = current_date;"
# (or use Supabase MCP)

# 2. Fire ingestion once with the rotated x-cron-secret
SECRET=$(python3 -c "import re;f=open('.env.prod.local');print([m.group(1).strip('\"').strip(\"'\") for m in (re.match(r'^CRON_SECRET=(.*)\$',l.rstrip()) for l in f) if m][0],end='')")
curl -sS -G "https://bootupnews.com/api/cron/fetch-editorial-inputs" -H "x-cron-secret: $SECRET"
unset SECRET

# 3. Wait ~30s, then verify
```

Expected (post-merge) Supabase state:
```sql
-- cron_runs: status='ok' (NOT 'fail'); duration ~25–30s
select status, started_at, finished_at from cron_runs where briefing_date = current_date;

-- signal_posts: today has the day's rows; all stamped deterministic_template
select count(*) total,
       count(*) filter (where witm_draft_generated_by='deterministic_template') legacy_stamped,
       count(*) filter (where witm_draft_model='heuristic_template_v1') model_stamped,
       count(*) filter (where editorial_content_source='ai') source_stamped
from signal_posts where briefing_date = current_date;

-- no duplicates
select briefing_date, source_url, count(*) from signal_posts
where briefing_date = current_date group by 1,2 having count(*) > 1;
-- expect zero rows

-- bridge row and 4 live rows untouched
select id, witm_draft_generated_by from signal_posts where id = '995958fe-78df-46ce-b1fc-fe449c6717a2';
-- expect witm_draft_generated_by='llm'
select count(*) from signal_posts where is_live = true;
-- expect 4
```

If `cron_runs.status='fail'` again after merge, repeat the sentinel-briefing_date INSERT repro I used during diagnosis — that'll capture the actual Postgres error and we can iterate.

After clean verification, **resolve Sentry BOOT-UP-WEB-6 + BOOT-UP-WEB-7** with a comment linking this PR.

## Acceptance criteria mapping

| Brief criterion | Status |
| --- | --- |
| `persistSignalPostCandidates` persists rows against the REAL prod index | ✅ via select-then-decide; live INSERT-shape repro confirms |
| Every signal_posts writer audited; no mismatched ON CONFLICT against partial index | ✅ table in Part 2 above |
| Index's role decided and documented (kept-as-guard) | ✅ Part 3 + PRD-65 Phase 7.3 |
| A test exists that fails if this class of bug is reintroduced | ✅ `signal-posts-writers.guard.test.ts` |
| Full vitest green; lint + tsc clean | ✅ 797/797; lint clean; zero new tsc errors |
| PRD operational-history + bug-fix record | ✅ PRD-65 Phase 7.3 + `docs/engineering/bug-fixes/partial-index-onconflict-mismatch-2026-05-23.md` |
| Resolve BOOT-UP-WEB-6/-7 | ⏳ post-merge after clean live fire |

🤖 Generated with [Claude Code](https://claude.com/claude-code)