### PR TITLE
fix(witm-validator): citation markers + decimals/abbreviations no longer false-fail (#270)

### DIFF
--- a/docs/engineering/bug-fixes/witm-validator-v2-false-positives-2026-05-24.md
+++ b/docs/engineering/bug-fixes/witm-validator-v2-false-positives-2026-05-24.md
@@ -1,0 +1,102 @@
+# WITM Validator False-Positives on v2 Content — Bug-Fix Record
+
+## Summary
+- **Problem addressed:** Every v2 LLM-drafted card landed in the prod editorial cockpit (`/dashboard/signals/editorial-review`) with `why_it_matters_validation_status='requires_human_rewrite'` + `editorial_decision='rewrite_requested'`. That dual state hard-locked the assign-to-slot dropdown ("Blocked · rewrite first") and disabled "Publish slate". The first real end-to-end editorial cycle (`briefing_date='2026-05-24'`) staged 4 LLM rows; all 4 false-failed within ~80 minutes of the bridge fire, blocking the entire slate from publishing.
+- **Root cause:** Two rules in `src/lib/why-it-matters-quality-gate.ts` were scoped to v1 deterministic-template output and false-positive on v2 framework content:
+  1. `UNRESOLVED_VARIABLE_PATTERN`'s third alternation branch `\[[a-z][a-z0-9_\s-]*\]` plus the `/gi` flag matches v2 framework §5.2 citation markers `[A]`, `[A1]`, `[P#]`, `[F#]`, `[V#]`. `detectTemplatePlaceholderLanguage` then added a `template_placeholder_language` failure per marker. These markers are REQUIRED content per the editorial framework, not unfilled template tokens.
+  2. `getSentences` split on every `.` with zero guards: `value.match(/[^.!?]+[.!?]+|[^.!?]+$/g)`. Decimals like `1.8` produced fragments `"...to 1."` + `"8 standard deviations above its average [A]."`; abbreviations like `U.S.` produced fragments `"U."` + `"S."`. `detectIncompleteSentence`'s 8-word floor then flagged the short fragments.
+- The bridge (`src/app/api/editorial/push-approved/route.ts:422`) hardcodes `validation_status='passed'` and does NOT call `validateWhyItMatters`, so the row state is correct immediately after the bridge fires. The false-positive only fires LATER, on the first interactive action that re-validates (`resetSignalPostToAiDraft` `signals-editorial.ts:2466`, or approve/save-draft). DB confirms: today's 4 LLM rows flipped at ~08:40 UTC, ~80 min after the ~07:20 bridge fire — every `validated_at` matches `updated_at` to the second, consistent with an interactive UI mutation.
+- **Affected object level:** Card (WITM is per-`signal_posts` row).
+- **Related issue:** #270 (blocker).
+
+## Fix
+Two surgical changes in `src/lib/why-it-matters-quality-gate.ts`.
+
+**Part 1 — Citation-marker exclusion (rule 1).** Added a constant and a one-line post-filter inside `detectTemplatePlaceholderLanguage`:
+
+```ts
+const CITATION_MARKER_PATTERN = /^\[[A-Z]\d*\]$/;
+
+const unresolvedVariables = (value.match(UNRESOLVED_VARIABLE_PATTERN) ?? []).filter(
+  (variable) => !CITATION_MARKER_PATTERN.test(variable),
+);
+```
+
+The regex itself is untouched; the filter drops citation-marker shapes (single uppercase letter optionally followed by digits, bracketed) AFTER matching. Real lowercase placeholders like `[topic]` and `[category]` still match `[A-Z]` test = false → still flagged.
+
+**`TEMPLATE_PLACEHOLDER_PHRASES` is NOT touched.** That string-include path (line ~88) catches forbidden vocab like `"individual decision-making"` and `"could move expectations"` and remains the load-bearing detector for editorial framework §1 violations.
+
+**Part 2 — Sentence-splitter guards (rule 2).** Added a sentinel-based protect/restore wrapper around `getSentences`:
+
+```ts
+const SENTENCE_GUARD_SENTINEL = "";
+const SENTENCE_SPLITTER_ABBREVIATIONS = [
+  "U.S.A.", "Ph.D.", "U.S.", "U.K.", "E.U.",
+  "e.g.", "i.e.", "etc.", "vs.", "No.",
+  "Inc.", "Ltd.", "Corp.",
+  "Mrs.", "Mr.", "Ms.", "Dr.", "Jr.", "Sr.",
+  "Mt.", "St.",
+];
+
+function protectSentenceSplitterEdgeCases(value) {
+  let protectedValue = value.replace(/(\d)\.(\d)/g, `$1${SENTENCE_GUARD_SENTINEL}$2`);
+  for (const abbreviation of SENTENCE_SPLITTER_ABBREVIATIONS) {
+    const pattern = new RegExp(escapeRegExp(abbreviation), "gi");
+    protectedValue = protectedValue.replace(pattern, (match) =>
+      match.replace(/\./g, SENTENCE_GUARD_SENTINEL),
+    );
+  }
+  return protectedValue;
+}
+
+function getSentences(value) {
+  const protectedValue = protectSentenceSplitterEdgeCases(value);
+  const matches = protectedValue.match(/[^.!?]+[.!?]+|[^.!?]+$/g) ?? [];
+  return matches
+    .map((sentence) => restoreSentenceSplitterEdgeCases(sentence).trim())
+    .filter(Boolean);
+}
+```
+
+The abbreviation list is sorted longest-first so multi-period entries match before their prefixes (`U.S.A.` before `U.S.`, `Ph.D.` before `Dr.`). `U+0001` is a control char that does not appear in editorial text. The 8-word `incomplete_sentence` floor is unchanged — genuine sub-8-word sentences with no decimals/abbreviations still fail.
+
+## Tests
+Six new characterization tests in `src/lib/why-it-matters-quality-gate.test.ts` under `describe("v2 content (issue #270)")`:
+- **A** (fix): a Signal with `U.S.`, `1.8`, and `[A]` returns `passed=true`.
+- **B** (fix): real 2026-05-24 supply-chain card text triggers neither `incomplete_sentence` nor `template_placeholder_language`.
+- **C** (fix): `[A]`, `[A1]`, `[P2]`, `[F1]`, `[V1]` all bypass `template_placeholder_language`.
+- **D** (guardrail): `{company}` and `[topic]` still flagged.
+- **E** (guardrail): `"could move expectations"` and `"individual decision-making"` still flagged.
+- **F** (guardrail): genuine sub-8-word sentence still flagged.
+
+**Test-first sequencing**: ran the suite BEFORE the fix and confirmed A/B/C failed exactly as predicted (3 failed, 24 passed). After the fix: 27/27 passed. Full repo suite: **803/803 across 102 files**, no regressions.
+
+**Logical pre-deploy acceptance** against the actual `ai_why_it_matters` text for `briefing_date='2026-05-24'`:
+
+| rank | drafter | passed | failures |
+|---|---|---|---|
+| 1 | llm | ✅ true | `[]` |
+| 2 | llm | ✅ true | `[]` |
+| 3 | deterministic_template | ❌ false | `["unsupported_structural_claim"]` |
+| 4 | llm | ✅ true | `[]` |
+| 5 | llm | ✅ true | `[]` |
+
+Card 3 (the listicle "Economic Letter Countdown") correctly STILL fails on `unsupported_structural_claim` only — that one is a legitimate retrospective/meta-story failure, not the bug we're fixing.
+
+## Operator follow-up (post-deploy)
+Validation columns and `editorial_decision` are not auto-updated by deploying the fix. The path that re-runs `validateWhyItMatters` AND resets `editorial_decision` off `rewrite_requested` is `resetSignalPostToAiDraft` (`src/lib/signals-editorial.ts:2434`), exposed in the prod admin UI as **"Reset to AI draft"** on each `CandidateRow`.
+
+After this PR ships, BM should:
+1. Open `/dashboard/signals/editorial-review` for `briefing_date='2026-05-24'`.
+2. For each of the **4 LLM rows** (NOT Card 3), expand the rewrite panel and click **Reset to AI draft**.
+3. Verify each row flips to `validation_status='passed'`, `editorial_decision='pending_review'`, and the assign-to-slot dropdown unlocks.
+
+Brief explicitly forbade bypassing the app's transition logic with a direct DB write.
+
+## Why production didn't catch this earlier
+The full v2 pipeline (Notion drafting → bridge → admin cockpit → publish) ran end-to-end for the first time on 2026-05-24. Prior v2 bridge fires (e.g. 2026-05-21) wrote 1 LLM row that was not interactively re-validated before BM left it. The combination "bridge wrote needs_review with `validation_status='passed'`" + "first interactive action re-validates and writes `requires_human_rewrite`" only surfaces when the editor actually opens the cockpit and acts on the row — which today was the first time at slate scale.
+
+## Not addressed by this fix (filed separately)
+- **#271 (umbrella):** consolidate editorial review into one cockpit; remove duplicate approval gate between Notion and prod admin UI.
+- **#272:** cron false-fail when Gmail newsletter leg returns 0 emails.
+- **#269:** ranking-within-tier is processing-order, not editor intent.

--- a/src/lib/why-it-matters-quality-gate.test.ts
+++ b/src/lib/why-it-matters-quality-gate.test.ts
@@ -330,4 +330,97 @@ describe("why-it-matters quality gate", () => {
     expect(card.whyItMattersValidation.passed).toBe(false);
     expect(card.reviewFailureReasons.length).toBeGreaterThan(1);
   });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // v2-content characterization (issue #270).
+  //
+  // These tests pin down two false-positives the validator emitted against
+  // the v2 LLM drafts on 2026-05-24. The v2 editorial framework permits:
+  //   - inline citation markers like [A], [A1], [P2], [F1], [V1] (§5.2)
+  //   - decimals (1.8) and abbreviations (U.S., e.g., i.e., etc., No., vs.)
+  //
+  // Tests A/B/C: SHOULD pass after the fix (currently fail).
+  // Tests D/E/F: SHOULD still fail after the fix (guardrails — real
+  //              placeholders, forbidden vocab, genuine short fragments).
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe("v2 content (issue #270)", () => {
+    it("A: passes a Signal containing U.S., a 1.8 decimal, and a [A] citation marker", () => {
+      const result = validateWhyItMatters(
+        "The U.S. Federal Reserve raised the policy rate by 1.8 percentage points this cycle, lifting borrowing costs to a 22-year high [A].",
+      );
+
+      expect(result.passed).toBe(true);
+      expect(result.failures).toEqual([]);
+    });
+
+    it("B: real 2026-05-24 supply-chain card text triggers neither incomplete_sentence nor template_placeholder_language", () => {
+      const result = validateWhyItMatters(
+        "The Federal Reserve flagged a third global supply shock in six years [A]. The Global Supply Chain Pressure Index jumped 1.3 points in two months, to 1.8 standard deviations above its average [A].",
+      );
+
+      expect(result.failures).not.toContain("incomplete_sentence");
+      expect(result.failures).not.toContain("template_placeholder_language");
+    });
+
+    it("C: bracketed citation markers [A], [A1], [P2], [F1], [V1] do not trigger template_placeholder_language", () => {
+      const markers = ["[A]", "[A1]", "[P2]", "[F1]", "[V1]"];
+      for (const marker of markers) {
+        const result = validateWhyItMatters(
+          `The Federal Reserve raised the policy rate by 25 basis points last week ${marker}.`,
+        );
+        expect(
+          result.failures,
+          `marker ${marker} should not trigger template_placeholder_language`,
+        ).not.toContain("template_placeholder_language");
+      }
+    });
+
+    it("D (guardrail): genuine lowercase placeholders {company} and [topic] are still flagged", () => {
+      const curly = validateWhyItMatters(
+        "The Federal Reserve decision matters because {company} now controls how borrowing costs feed into demand.",
+      );
+      const square = validateWhyItMatters(
+        "The Federal Reserve decision matters because investors are repricing [topic] across the curve.",
+      );
+
+      expect(curly.failures).toContain("template_placeholder_language");
+      expect(curly.failureDetails).toEqual(
+        expect.arrayContaining([
+          'template_placeholder_language: Contains unresolved template variable: "{company}"',
+        ]),
+      );
+      expect(square.failures).toContain("template_placeholder_language");
+      expect(square.failureDetails).toEqual(
+        expect.arrayContaining([
+          'template_placeholder_language: Contains unresolved template variable: "[topic]"',
+        ]),
+      );
+    });
+
+    it("E (guardrail): forbidden-vocab phrases from TEMPLATE_PLACEHOLDER_PHRASES are still flagged", () => {
+      const expectationsResult = validateWhyItMatters(
+        "The Federal Reserve hold could move expectations across the curve next quarter.",
+      );
+      const individualResult = validateWhyItMatters(
+        "The Federal Reserve decision is mainly useful for individual decision-making across U.S. households.",
+      );
+
+      expect(expectationsResult.failures).toContain("template_placeholder_language");
+      expect(individualResult.failures).toContain("template_placeholder_language");
+    });
+
+    it("F (guardrail): genuine sub-8-word sentence (no decimal, no abbreviation) is still flagged incomplete_sentence", () => {
+      const result = validateWhyItMatters(
+        "The Federal Reserve raised the policy rate by 25 basis points last week. Markets fell sharply.",
+      );
+
+      expect(result.failures).toContain("incomplete_sentence");
+      expect(result.failureDetails).toEqual(
+        expect.arrayContaining([
+          'incomplete_sentence: Sentence has fewer than 8 words: "Markets fell sharply."',
+        ]),
+      );
+    });
+  });
 });

--- a/src/lib/why-it-matters-quality-gate.ts
+++ b/src/lib/why-it-matters-quality-gate.ts
@@ -44,6 +44,43 @@ const TERMINAL_PUNCTUATION_PATTERN = /[.!?]$/;
 const SIGNAL_SUFFIX_PATTERN = /\s*\(Signal:\s*[^)]+\)\s*$/i;
 const UNRESOLVED_VARIABLE_PATTERN =
   /(?:\{\{\s*[^{}]+\s*\}\}|\{[a-z][a-z0-9_\s-]*\}|\[[a-z][a-z0-9_\s-]*\]|\$[a-z][a-z0-9_]*)/gi;
+// v2 editorial framework §5.2 citation markers: [A], [A1]+, [P#], [F#], [V#].
+// Shape = single uppercase letter optionally followed by digits, bracketed.
+// These markers are REQUIRED content, not unfilled template tokens, so we
+// post-filter them out of UNRESOLVED_VARIABLE_PATTERN matches (issue #270).
+const CITATION_MARKER_PATTERN = /^\[[A-Z]\d*\]$/;
+// Sentinel char (SOH, U+0001) — guaranteed not to appear in editorial text.
+// We swap "."→sentinel in decimals and known abbreviations BEFORE splitting on
+// sentence-terminal punctuation, then swap back after each sentence is sliced
+// (issue #270 — the splitter was breaking on every period including 1.8 and
+// U.S.).
+const SENTENCE_GUARD_SENTINEL = "";
+// Whitelist of period-bearing abbreviations the sentence splitter must not
+// fragment. Sorted with longest first so multi-period abbreviations match
+// before their shorter prefixes (e.g. "U.S.A." before "U.S.").
+const SENTENCE_SPLITTER_ABBREVIATIONS = [
+  "U.S.A.",
+  "Ph.D.",
+  "U.S.",
+  "U.K.",
+  "E.U.",
+  "e.g.",
+  "i.e.",
+  "etc.",
+  "vs.",
+  "No.",
+  "Inc.",
+  "Ltd.",
+  "Corp.",
+  "Mrs.",
+  "Mr.",
+  "Ms.",
+  "Dr.",
+  "Jr.",
+  "Sr.",
+  "Mt.",
+  "St.",
+];
 const DANGLING_ENDING_PATTERNS = [
   {
     label: "rather than",
@@ -350,9 +387,30 @@ function getWordCount(value: string) {
     .filter((word) => /[A-Za-z0-9]/.test(word)).length;
 }
 
+// Replace periods that are part of decimals or known abbreviations with a
+// sentinel char so the sentence splitter does not fragment them. The sentinel
+// is restored back to "." after sentences are sliced.
+function protectSentenceSplitterEdgeCases(value: string) {
+  let protectedValue = value.replace(/(\d)\.(\d)/g, `$1${SENTENCE_GUARD_SENTINEL}$2`);
+  for (const abbreviation of SENTENCE_SPLITTER_ABBREVIATIONS) {
+    const pattern = new RegExp(escapeRegExp(abbreviation), "gi");
+    protectedValue = protectedValue.replace(pattern, (match) =>
+      match.replace(/\./g, SENTENCE_GUARD_SENTINEL),
+    );
+  }
+  return protectedValue;
+}
+
+function restoreSentenceSplitterEdgeCases(value: string) {
+  return value.split(SENTENCE_GUARD_SENTINEL).join(".");
+}
+
 function getSentences(value: string) {
-  const matches = value.match(/[^.!?]+[.!?]+|[^.!?]+$/g) ?? [];
-  return matches.map((sentence) => sentence.trim()).filter(Boolean);
+  const protectedValue = protectSentenceSplitterEdgeCases(value);
+  const matches = protectedValue.match(/[^.!?]+[.!?]+|[^.!?]+$/g) ?? [];
+  return matches
+    .map((sentence) => restoreSentenceSplitterEdgeCases(sentence).trim())
+    .filter(Boolean);
 }
 
 function hasSpecificNoun(value: string) {
@@ -432,7 +490,13 @@ function detectTemplatePlaceholderLanguage(
     }
   }
 
-  const unresolvedVariables = value.match(UNRESOLVED_VARIABLE_PATTERN) ?? [];
+  // Filter out v2 framework citation markers ([A], [A1]+, [P#], [F#], [V#]).
+  // The third branch of UNRESOLVED_VARIABLE_PATTERN (`\[[a-z]...\]` with /i
+  // flag) was catching them as unfilled placeholders — false positive
+  // tracked in issue #270.
+  const unresolvedVariables = (value.match(UNRESOLVED_VARIABLE_PATTERN) ?? []).filter(
+    (variable) => !CITATION_MARKER_PATTERN.test(variable),
+  );
   for (const variable of unresolvedVariables) {
     addFailure(
       failures,


### PR DESCRIPTION
Closes #270.

## What
Two surgical rule changes in `src/lib/why-it-matters-quality-gate.ts` so v2 LLM drafts stop false-failing the WITM gate.

1. **Citation markers**: `detectTemplatePlaceholderLanguage` now post-filters `UNRESOLVED_VARIABLE_PATTERN` matches against `CITATION_MARKER_PATTERN` = `/^\[[A-Z]\d*\]$/`. v2 framework §5.2 markers `[A]`, `[A1]`, `[P#]`, `[F#]`, `[V#]` are required content, not unfilled tokens.
2. **Sentence splitter**: `getSentences` wraps the splitter in `protect`/`restoreSentenceSplitterEdgeCases`. Periods inside decimals (`\d\.\d`) and a whitelist of abbreviations (`U.S.`, `U.K.`, `e.g.`, `i.e.`, `etc.`, `vs.`, `No.`, `Inc.`, `Ltd.`, `Corp.`, `Dr.`/`Mr.`/`Mrs.`/`Ms.`/`Jr.`/`Sr.`, `Ph.D.`, `Mt.`, `St.`, `U.S.A.`) are swapped for a `U+0001` sentinel before splitting on `.!?`, then restored.

## What is NOT changed
- `TEMPLATE_PLACEHOLDER_PHRASES` string-include path — untouched. Still catches forbidden vocab like `"individual decision-making"` (guardrail test E).
- All other rules (`abstract_variable_list`, `minimum_specificity`, `summary_only_wording`, `unsupported_structural_claim`, `evidence_accessibility_mismatch`) — untouched.
- The 8-word `incomplete_sentence` floor — kept. Genuine fragments still fail (guardrail test F).

## Tests (test-first)
6 new characterization tests in `src/lib/why-it-matters-quality-gate.test.ts` under `describe("v2 content (issue #270)")`:
- **A**: passes a Signal with `U.S.`, `1.8`, and `[A]`
- **B**: real 2026-05-24 supply-chain card text triggers neither `incomplete_sentence` nor `template_placeholder_language`
- **C**: `[A]`, `[A1]`, `[P2]`, `[F1]`, `[V1]` all bypass `template_placeholder_language`
- **D** (guardrail): `{company}` and `[topic]` still flagged
- **E** (guardrail): `"could move expectations"` and `"individual decision-making"` still flagged
- **F** (guardrail): genuine sub-8-word sentence still flagged

**Step 1**: 3 failed (A/B/C) + 24 passed (D/E/F + 21 prior). **Step 3 (after fix)**: 27/27 passed. **Full suite**: 803/803 passed across 102 files.

## Logical Step 4 acceptance (against today's prod rows)
Ran the fixed validator against the actual `ai_why_it_matters` text for `briefing_date='2026-05-24'`:

```
rank=1 (llm) Will Mounting Supply Chain Strains...           passed=true
rank=2 (llm) AIs Macroeconomic Challenges and Promises       passed=true
rank=3 (deterministic_template) Economic Letter Countdown    passed=false  failures=["unsupported_structural_claim"]
rank=4 (llm) The AI Investing Landscape...                   passed=true
rank=5 (llm) Advisory Council Observations: March 2026       passed=true
```

All 4 LLM rows now pass. Card 3 still fails — but ONLY on `unsupported_structural_claim`, which is the intentionally correct failure mode per the brief.

## What the editor must do post-deploy
Validation columns and `editorial_decision` are not auto-updated. The path that re-runs `validateWhyItMatters` AND resets `editorial_decision` off `rewrite_requested` is **`resetSignalPostToAiDraft`** (`src/lib/signals-editorial.ts:2434`). It's exposed in the prod admin UI as **"Reset to AI draft"** on each `CandidateRow`.

After this PR ships:
1. BM opens `/dashboard/signals/editorial-review`.
2. For each of the **4 LLM rows** (NOT Card 3 "Economic Letter Countdown"), expand the rewrite panel and click **Reset to AI draft**.
3. Each row's `why_it_matters_validation_status` flips to `passed`, `editorial_decision` flips to `pending_review`, and the assign-to-slot dropdown unlocks.

Brief explicitly said not to bypass `resetSignalPostToAiDraft` with a direct DB write, so this PR does not touch prod data.

## Test plan
- [ ] CI green
- [ ] Merge
- [ ] BM clicks "Reset to AI draft" on the 4 LLM rows for `2026-05-24` (NOT Card 3)
- [ ] Verify: `select id, why_it_matters_validation_status, editorial_decision from signal_posts where briefing_date='2026-05-24'` shows `passed`/`pending_review` for ranks 1, 2, 4, 5; rank 3 unchanged
- [ ] Verify in UI: dropdowns unlock for those 4 rows; "Publish slate" button condition reassesses

🤖 Generated with [Claude Code](https://claude.com/claude-code)