### PR TITLE
fix(foldback): reduce SignalCard expanded view to exactly three editorial layers (#276)

### DIFF
--- a/docs/engineering/bug-fixes/foldback-duplicate-witm-and-what-happened-2026-05-24.md
+++ b/docs/engineering/bug-fixes/foldback-duplicate-witm-and-what-happened-2026-05-24.md
@@ -1,0 +1,40 @@
+# Foldback Duplicate WITM + Leftover "What happened" Layer — Bug-Fix Record
+
+## Summary
+- **Problem addressed:** PR #275 (three-layer publish pipeline, closes #274) added the v2-labeled `The Signal` / `Before This` / `The Ripple` rendering to the expanded `SignalCard` foldback but did not remove two v1 leftovers in the same component: (a) a standalone top "Why this matters"-labeled WITM preview block that rendered the full WITM text outside the foldback (visually clamped but in DOM), and (b) a `WhatHappenedSection` that still rendered the source-headline body inside the foldback. The combination produced: WITM body in DOM twice when expanded; the foldback containing four sections instead of three; a v1 "Why this matters" label still surfaced; and a "What happened" label that the brief's editorial framework §2 cause-then-trajectory model said should not be there.
+- **Root cause:** Incomplete cleanup during PR #275. The new helpers (`LayerWithEmptyState`, `readLayerBody`) were added correctly but the v1 markup they were intended to replace was left in place.
+- **Affected object level:** Card (`src/components/signals/SignalCard.tsx` render only — no schema, no publish gate, no other data flow).
+- **Related issue:** #276. Direct follow-up to #274 / PR #275.
+
+## Fix
+Three surgical edits in `src/components/signals/SignalCard.tsx`.
+
+**1. Wrap the top WITM block in `!isExpanded`; drop the v1 label.** The collapsed/compact card-face teaser stays (so the card isn't blank), but it's now an unlabeled clamped preview and is removed from DOM entirely when the card is expanded. `data-testid` renamed `signal-why-this-matters` → `signal-card-teaser` to match its narrower role.
+
+**2. Delete the `WhatHappenedSection` invocation from the foldback** and delete the now-unused `WhatHappenedSection` helper + `whatHappenedBody` variable.
+
+**3. Update the foldback comment** to document the new contract: foldback renders exactly the three editorial layers; `WhatHappened` was deliberately removed because the source-headline material is already implied by the title + footer attribution.
+
+The three-layer rendering itself (the `LayerWithEmptyState` + `readLayerBody` helpers, `published_*`-only reads, no `ai_*` fallback) is unchanged from PR #275.
+
+## Tests
+Strict assertions added/updated across 4 test files:
+
+- `src/components/signals/visual-system-components.test.tsx`:
+  - Three-layer test now asserts each layer body appears **exactly once** (`toHaveLength(1)`), not just "at least once".
+  - Added explicit `queryByText("What happened" / "Why this matters" / "What led to this" / "What it connects to")` assertions to lock the v1 labels out.
+  - Replaced the prior "What happened in sans" typography test with "all three foldback layers in serif" — sans-vs-serif differentiation is moot now that no factual layer renders in the foldback.
+  - Collapsed-vs-expanded test now asserts teaser visibility flips correctly (`signal-card-teaser` visible when collapsed, absent when expanded).
+- `src/components/landing/homepage.test.tsx`: assertions now check for v2 labels (`The Signal` / `Before This` / `The Ripple`), assert `Why this matters` and `What happened` are NOT in DOM.
+- `src/app/signals/page.test.tsx`: test renamed and rewired to assert `signal-card-teaser` is line-clamped and no `Why this matters` label exists.
+- `src/components/briefing/BriefingDetailView.test.tsx`: "does not duplicate the lead paragraph" test repurposed to assert the `What happened` label is no longer rendered at all and the lead paragraph appears at most once.
+
+**Test results:** full suite **806/806** across 102 files. `npm run build` green.
+
+## Why production didn't catch this earlier
+PR #275 was merged with a test that used a tolerant `getAllByText(...).length).toBeGreaterThan(0)` assertion for the WITM body — it would pass whether the body appeared once or twice. The stricter `toHaveLength(1)` introduced in this PR would have caught the duplication before merge.
+
+## Not addressed by this fix
+- No changes to schema, publish gate, editor composer, or any data-flow file. Scope is `SignalCard.tsx` foldback render + test fixtures only.
+- No changes to the `editorialWhyItMatters` payload schema or to the citation-marker render path.
+- Codebase-wide v1→v2 identifier rename remains parked under #271.

--- a/src/app/signals/page.test.tsx
+++ b/src/app/signals/page.test.tsx
@@ -82,7 +82,7 @@ describe("public signals page", () => {
     expect(screen.queryByText("Private newsletter grounding snippet should never be public")).not.toBeInTheDocument();
   }, 10000);
 
-  it("renders public card-face labels and clamps the why-this-matters preview", async () => {
+  it("renders public card-face teaser preview clamped (#274 follow-up — no v1 'Why this matters' label)", async () => {
     getPublicSignalsPageState.mockResolvedValue({
       kind: "published",
       posts: [createPublishedPost(1)],
@@ -91,10 +91,12 @@ describe("public signals page", () => {
     const Page = (await import("@/app/signals/page")).default;
     render(await Page());
 
-    expect(screen.getByText("Why this matters")).toBeInTheDocument();
+    // v1 label removed; foldback now owns the labeled rendering.
+    expect(screen.queryByText("Why this matters")).not.toBeInTheDocument();
     expect(screen.queryByText("Top Event")).not.toBeInTheDocument();
     expect(screen.queryByText("TOP EVENT")).not.toBeInTheDocument();
-    expect(screen.getByTestId("signal-why-this-matters")).toHaveClass("line-clamp-2");
+    // Collapsed teaser is line-clamped to 2 lines on non-compact cards.
+    expect(screen.getByTestId("signal-card-teaser")).toHaveClass("line-clamp-2");
   }, 10000);
 
   it("renders Core and Context tier markers for the published slate", async () => {

--- a/src/components/briefing/BriefingDetailView.test.tsx
+++ b/src/components/briefing/BriefingDetailView.test.tsx
@@ -100,12 +100,21 @@ describe("BriefingDetailView", () => {
     expect(screen.queryByText(/confirmed-event rail/i)).not.toBeInTheDocument();
   });
 
-  it("does not duplicate the lead paragraph in the What happened section", () => {
+  // #274 follow-up: the "What happened" section was removed from the
+  // foldback entirely. The brief reasoning: the source-headline material
+  // it carried was already implied by the title + footer attribution,
+  // and crowded the editorial voice. The detail surface now shows only
+  // the three editorial layers (The Signal / Before This / The Ripple).
+  it("does not render the 'What happened' label and does not duplicate the lead paragraph", () => {
     const item = createItem();
 
     render(<BriefingDetailView data={createData()} viewer={null} />);
 
-    expect(screen.getAllByText(item.whatHappened)).toHaveLength(1);
-    expect(screen.getByText("What happened")).toBeInTheDocument();
+    expect(screen.queryByText("What happened")).not.toBeInTheDocument();
+    // The lead paragraph (item.whatHappened) is no longer rendered on
+    // detail cards. Either zero occurrences (current behavior) or one
+    // (if a future change re-introduces a different surface) is fine;
+    // two would still be a duplication regression.
+    expect(screen.queryAllByText(item.whatHappened).length).toBeLessThanOrEqual(1);
   });
 });

--- a/src/components/landing/homepage.test.tsx
+++ b/src/components/landing/homepage.test.tsx
@@ -137,11 +137,10 @@ describe("LandingHomepage", () => {
     expect(cards).toHaveLength(5);
     expect(within(cards[0]).getByText("Core signal · 01")).toBeInTheDocument();
     expect(within(cards[4]).getByText("Core signal · 05")).toBeInTheDocument();
-    // "Why this matters" appears twice when the card is expanded — once
-    // above the toggle as the collapsed-preview label, once below as
-    // the editorial depth-section label. Both are expected on the
-    // homepage now that cards land expanded by default.
-    expect(within(cards[0]).getAllByText("Why this matters").length).toBeGreaterThan(0);
+    // Post-#274-follow-up: the foldback owns the labeled rendering
+    // ("The Signal"); the v1 "Why this matters" label was removed.
+    expect(within(cards[0]).queryByText("Why this matters")).not.toBeInTheDocument();
+    expect(within(cards[0]).getByText("The Signal")).toBeInTheDocument();
     // Per-card inline depth expansion: top events expand in place rather
     // than linking out, and they now land already expanded on the
     // homepage so the depth is visible at first glance. The footer
@@ -169,9 +168,12 @@ describe("LandingHomepage", () => {
 
     const card = screen.getAllByTestId("signal-card")[0];
     expect(card).toHaveAttribute("data-signal-expanded", "true");
-    expect(within(card).getByText("What happened")).toBeInTheDocument();
-    // #274 foldback v2 labels: "Before This" replaces "What led to this".
+    // #274 follow-up: foldback shows the three editorial layers in v2
+    // labels. "What happened" was removed; never appears in DOM.
+    expect(within(card).queryByText("What happened")).not.toBeInTheDocument();
+    expect(within(card).getByText("The Signal")).toBeInTheDocument();
     expect(within(card).getByText("Before This")).toBeInTheDocument();
+    expect(within(card).getByText("The Ripple")).toBeInTheDocument();
 
     const toggle = within(card).getByTestId("signal-card-toggle");
     expect(toggle).toHaveAccessibleName(/collapse/i);
@@ -179,7 +181,9 @@ describe("LandingHomepage", () => {
     fireEvent.click(toggle);
 
     expect(card).toHaveAttribute("data-signal-expanded", "false");
-    expect(within(card).queryByText("What happened")).not.toBeInTheDocument();
+    // Collapsed: foldback labels absent; teaser is the only WITM rendering.
+    expect(within(card).queryByText("The Signal")).not.toBeInTheDocument();
+    expect(within(card).queryByText("Before This")).not.toBeInTheDocument();
     expect(toggle).toHaveAccessibleName(/expand/i);
 
     fireEvent.click(toggle);

--- a/src/components/signals/SignalCard.tsx
+++ b/src/components/signals/SignalCard.tsx
@@ -84,8 +84,13 @@ export function SignalCard({
   const whyItMatters = getWhyItMattersText(signal);
   const sourceAttribution = getSourceAttribution(signal);
   const relatedCoverage = getRelatedCoverage(signal);
-  const whatHappenedBody = (signal.whatHappened || signal.summary || "").trim();
-  // #274 Before This + The Ripple. Read ONLY published_* — never fall back
+  // #274 follow-up: the foldback shows EXACTLY three editorial layers
+  // (The Signal → Before This → The Ripple). The leftover "What happened"
+  // section and the standalone top WITM preview were removed; both made
+  // the same WITM text appear twice in DOM. The collapsed card face now
+  // surfaces only the title + footer + a teaser preview of The Signal,
+  // and the full Signal body appears once — inside the foldback.
+  // Before This + The Ripple. Read ONLY published_* — never fall back
   // to ai_*/edited_*/human_* and never re-mine the WITM payload's sections
   // array (that was the v1-era hack that surfaced empty state for cards
   // with real layer content). Empty/whitespace published_* shows the
@@ -136,18 +141,19 @@ export function SignalCard({
         {signal.title}
       </h2>
 
-      {whyItMatters ? (
+      {/* Collapsed/compact card-face teaser. Hidden when expanded so the
+          full Signal body only appears once — inside the foldback below.
+          No v1 "Why this matters" label here; the foldback owns the
+          labeled rendering. */}
+      {!isExpanded && whyItMatters ? (
         <section className="mt-3">
-          <p className="text-[var(--bu-size-micro)] font-medium uppercase leading-none tracking-[0.08em] text-[var(--bu-text-tertiary)]">
-            Why this matters
-          </p>
           <p
             className={cn(
-              "mt-1 font-heading text-[var(--bu-size-witm)] font-normal leading-[var(--bu-line-witm)] text-[var(--bu-text-primary)]",
-              !isExpanded && !compact && "line-clamp-2",
+              "font-heading text-[var(--bu-size-witm)] font-normal leading-[var(--bu-line-witm)] text-[var(--bu-text-primary)]",
+              !compact && "line-clamp-2",
               compact && "line-clamp-2 text-[var(--bu-size-meta)] leading-[1.5]",
             )}
-            data-testid="signal-why-this-matters"
+            data-testid="signal-card-teaser"
           >
             {whyItMatters}
           </p>
@@ -208,14 +214,15 @@ export function SignalCard({
 
       {isExpanded ? (
         <div className="mt-4 border-t border-[var(--bu-border-subtle)] pt-4">
-          {/* #274 Editorial framework §2 cause-then-trajectory order in the
-              foldback: factual "What happened" first (sans, factual reporting),
-              then the three editorial layers in serif:
+          {/* Foldback shows EXACTLY the three editorial layers in
+              cause-then-trajectory order (editorial framework §2):
                 The Signal → Before This → The Ripple.
-              v2 labels here only; codebase-wide v1→v2 rename of
+              "What happened" was removed in this follow-up — it duplicated
+              source-headline material already implied by the title and
+              footer attribution, and crowded the editorial voice. v2
+              labels here only; codebase-wide v1→v2 rename of
               validator/server-action/type identifiers is parked in #271. */}
           <div className="space-y-4">
-            <WhatHappenedSection body={whatHappenedBody} />
             <ExpandedSerifSection label="The Signal" body={whyItMatters} />
             <LayerWithEmptyState
               label="Before This"
@@ -266,26 +273,6 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
     <p className="text-[var(--bu-size-micro)] font-medium uppercase leading-none tracking-[0.08em] text-[var(--bu-text-tertiary)]">
       {children}
     </p>
-  );
-}
-
-/**
- * "What happened" body is the source-headline treatment — rendered in
- * sans, not serif, to signal factual reporting rather than editorial
- * judgment. See work prompt Change 1 typography rules.
- */
-function WhatHappenedSection({ body }: { body: string }) {
-  if (!body.trim()) {
-    return null;
-  }
-
-  return (
-    <section>
-      <SectionLabel>What happened</SectionLabel>
-      <p className="mt-1 font-sans text-[var(--bu-size-witm)] font-normal leading-[var(--bu-line-witm)] text-[var(--bu-text-primary)]">
-        {body}
-      </p>
-    </section>
   );
 }
 

--- a/src/components/signals/visual-system-components.test.tsx
+++ b/src/components/signals/visual-system-components.test.tsx
@@ -42,7 +42,11 @@ describe("Bootup News visual system components", () => {
     );
 
     expect(screen.getByText("Core signal · 01")).toBeInTheDocument();
-    expect(screen.getByText("Why this matters")).toBeInTheDocument();
+    // #274 follow-up: collapsed card face shows the unlabeled teaser
+    // preview (testid signal-card-teaser). The v1 "Why this matters"
+    // label was removed — the foldback owns the labeled rendering.
+    expect(screen.queryByText("Why this matters")).not.toBeInTheDocument();
+    expect(screen.getByTestId("signal-card-teaser")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Read more →" })).toHaveAttribute(
       "href",
       "/briefing/2026-05-13",
@@ -71,13 +75,24 @@ describe("Bootup News visual system components", () => {
 
     const { rerender } = render(<SignalCard signal={signal} rank={2} />);
 
-    expect(screen.queryByText("What happened")).not.toBeInTheDocument();
+    // Collapsed: no foldback labels, no supporting coverage. Teaser
+    // preview is the only WITM-derived rendering.
+    expect(screen.queryByText("The Signal")).not.toBeInTheDocument();
+    expect(screen.queryByText("Before This")).not.toBeInTheDocument();
+    expect(screen.queryByText("The Ripple")).not.toBeInTheDocument();
     expect(screen.queryByText("Supporting coverage")).not.toBeInTheDocument();
+    expect(screen.getByTestId("signal-card-teaser")).toBeInTheDocument();
 
     rerender(<SignalCard signal={signal} rank={2} expanded />);
 
-    expect(screen.getByText("What happened")).toBeInTheDocument();
+    // Expanded: foldback shows the three editorial layers + supporting
+    // coverage. The teaser is hidden so WITM appears only once in DOM.
+    expect(screen.getByText("The Signal")).toBeInTheDocument();
+    expect(screen.getByText("Before This")).toBeInTheDocument();
+    expect(screen.getByText("The Ripple")).toBeInTheDocument();
     expect(screen.getByText("Supporting coverage")).toBeInTheDocument();
+    expect(screen.queryByTestId("signal-card-teaser")).not.toBeInTheDocument();
+    expect(screen.queryByText("What happened")).not.toBeInTheDocument();
   });
 
   it("opens its own depth in place when defaultExpanded is provided", () => {
@@ -94,8 +109,10 @@ describe("Bootup News visual system components", () => {
 
     const card = screen.getByTestId("signal-card");
     expect(card).toHaveAttribute("data-signal-expanded", "false");
-    expect(screen.queryByText("What happened")).not.toBeInTheDocument();
+    // Collapsed: foldback labels absent; teaser visible.
+    expect(screen.queryByText("The Signal")).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Read more →" })).toBeNull();
+    expect(screen.getByTestId("signal-card-teaser")).toBeInTheDocument();
 
     const toggle = screen.getByTestId("signal-card-toggle");
     expect(toggle).toHaveAccessibleName(/expand/i);
@@ -103,7 +120,13 @@ describe("Bootup News visual system components", () => {
     fireEvent.click(toggle);
 
     expect(card).toHaveAttribute("data-signal-expanded", "true");
-    expect(screen.getByText("What happened")).toBeInTheDocument();
+    // Expanded: foldback shows "The Signal" + Before This + The Ripple.
+    // Teaser is hidden so WITM only appears once in DOM.
+    expect(screen.getByText("The Signal")).toBeInTheDocument();
+    expect(screen.getByText("Before This")).toBeInTheDocument();
+    expect(screen.getByText("The Ripple")).toBeInTheDocument();
+    expect(screen.queryByTestId("signal-card-teaser")).not.toBeInTheDocument();
+    expect(screen.queryByText("What happened")).not.toBeInTheDocument();
     expect(toggle).toHaveAccessibleName(/collapse/i);
   });
 
@@ -121,15 +144,19 @@ describe("Bootup News visual system components", () => {
 
     const card = screen.getByTestId("signal-card");
     expect(card).toHaveAttribute("data-signal-expanded", "true");
-    expect(screen.getByText("What happened")).toBeInTheDocument();
+    expect(screen.getByText("The Signal")).toBeInTheDocument();
     expect(screen.getByTestId("signal-card-toggle")).toHaveAccessibleName(/collapse/i);
   });
 
-  it("renders What happened in sans and the other depth sections in serif", () => {
+  // #274 follow-up: the foldback's editorial layers are all serif. The
+  // factual "What happened" layer was removed entirely; the sans-vs-
+  // serif typography differentiation is no longer relevant because the
+  // foldback now renders ONLY editorial-voice content.
+  it("renders all three foldback layers in serif (editorial voice)", () => {
     const signal = {
-      id: "signal-sans-vs-serif",
-      title: "Typography differentiation",
-      whatHappened: "Factual source-headline body for the What happened layer.",
+      id: "signal-serif",
+      title: "Typography uniformity in the foldback",
+      whatHappened: "Factual source-headline body — must NOT appear in foldback.",
       whyItMatters: "Editorial reasoning lives in serif voice.",
       sourceName: "Reuters",
       sourceUrl: "https://www.reuters.com/story",
@@ -137,22 +164,15 @@ describe("Bootup News visual system components", () => {
 
     render(<SignalCard signal={signal} rank={1} defaultExpanded />);
 
-    // What happened body — sans treatment for the factual layer.
-    const whatHappenedBody = screen.getByText(
-      /Factual source-headline body for the What happened layer/,
-    );
-    expect(whatHappenedBody).toHaveClass("font-sans");
-    expect(whatHappenedBody).not.toHaveClass("font-heading");
+    // The Signal body (from whyItMatters) — exactly one rendering, serif.
+    const signalBodies = screen.getAllByText("Editorial reasoning lives in serif voice.");
+    expect(signalBodies).toHaveLength(1);
+    expect(signalBodies[0]).toHaveClass("font-heading");
 
-    // Why this matters body appears in two places when expanded: the
-    // preview (line-clamped, above the footer) and the depth section
-    // (full, below the footer). Both must use the editorial serif
-    // family so the brand voice stays consistent across modes.
-    const whyItMattersBodies = screen.getAllByText("Editorial reasoning lives in serif voice.");
-    expect(whyItMattersBodies.length).toBeGreaterThan(0);
-    for (const body of whyItMattersBodies) {
-      expect(body).toHaveClass("font-heading");
-    }
+    // The "What happened" body must NOT be in DOM at all.
+    expect(
+      screen.queryByText(/Factual source-headline body/),
+    ).not.toBeInTheDocument();
   });
 
   // #274 renamed "What led to this" → "Before This" in the foldback and
@@ -199,18 +219,26 @@ describe("Bootup News visual system components", () => {
     expect(screen.getByText("The Signal")).toBeInTheDocument();
     expect(screen.getByText("Before This")).toBeInTheDocument();
     expect(screen.getByText("The Ripple")).toBeInTheDocument();
-    // The Signal body appears twice — once as the card-face preview
-    // (testid signal-why-this-matters) and once in the expanded foldback.
-    // Both pull from publishedWhyItMatters; presence at least once is the
-    // assertion that matters.
-    expect(screen.getAllByText("The Signal body — what this means right now.").length).toBeGreaterThan(0);
+    // #274 follow-up: when expanded, the teaser is hidden so each layer's
+    // body text appears EXACTLY ONCE in DOM. Duplicate WITM render was
+    // the explicit bug this PR fixed.
     expect(
-      screen.getByText("The Before This body — what conditions produced it."),
-    ).toBeInTheDocument();
-    expect(screen.getByText("The Ripple body — what this implies next.")).toBeInTheDocument();
+      screen.getAllByText("The Signal body — what this means right now."),
+    ).toHaveLength(1);
+    expect(
+      screen.getAllByText("The Before This body — what conditions produced it."),
+    ).toHaveLength(1);
+    expect(
+      screen.getAllByText("The Ripple body — what this implies next."),
+    ).toHaveLength(1);
 
-    // Render order: walk all section labels and assert the editorial-layer
-    // sequence is Signal → Before This → Ripple.
+    // Foldback contains EXACTLY the three editorial layers in order.
+    // No "What happened" label; no v1 labels.
+    expect(screen.queryByText("What happened")).not.toBeInTheDocument();
+    expect(screen.queryByText("Why this matters")).not.toBeInTheDocument();
+    expect(screen.queryByText("What led to this")).not.toBeInTheDocument();
+    expect(screen.queryByText("What it connects to")).not.toBeInTheDocument();
+
     const labels = screen
       .getAllByText(/^(The Signal|Before This|The Ripple)$/u)
       .map((node) => node.textContent);


### PR DESCRIPTION
Closes #276. Direct follow-up to #274 / PR #275 (three-layer publish pipeline).

## What
PR #275 added the v2-labeled `The Signal` / `Before This` / `The Ripple` rendering to the SignalCard foldback but left two v1 leftovers that broke the new contract:

1. **WITM rendered twice in DOM when expanded** — a standalone top "Why this matters"-labeled block (visually clamped but full text in DOM) plus the same `whyItMatters` text inside the foldback as "The Signal".
2. **A "What happened" section still rendered inside the foldback** — the `WhatHappenedSection` helper, carrying source-headline body, alongside the three intended editorial layers.

This PR cleans both up.

## Diff — three surgical edits to `src/components/signals/SignalCard.tsx`
1. **Wrap the top WITM block in `!isExpanded`** so it's removed from DOM when the card is expanded. Drop the v1 "Why this matters" label — the foldback owns the labeled rendering. Rename `data-testid="signal-why-this-matters"` → `"signal-card-teaser"` to reflect its narrower role (collapsed/compact teaser only).
2. **Delete the `WhatHappenedSection` invocation from the foldback** and delete the now-unused helper + `whatHappenedBody` variable.
3. **Update the foldback comment** to document the new contract: exactly three editorial layers in cause-then-trajectory order; "What happened" deliberately removed because the source-headline material is already implied by title + footer attribution.

The three-layer rendering itself (`LayerWithEmptyState`, `readLayerBody`, `published_*`-only reads, no `ai_*` fallback) is **unchanged** from PR #275.

## Tests — strict contract pinned
Updated across 4 files:
- `src/components/signals/visual-system-components.test.tsx` — three-layer test now asserts each layer body appears **exactly once** (`toHaveLength(1)`), not just ">=1" (the loose assertion in PR #275 is what hid the duplication). Added explicit `queryByText` assertions to lock the v1 labels (`Why this matters` / `What happened` / `What led to this` / `What it connects to`) out of DOM. Replaced "sans vs serif" typography test with "all three layers in serif" since there's no factual layer in the foldback anymore.
- `src/components/landing/homepage.test.tsx` — homepage card-face / collapse-re-expand tests now check for v2 labels and assert v1 labels are absent.
- `src/app/signals/page.test.tsx` — renamed + rewired to assert `signal-card-teaser` is line-clamped, no `Why this matters` label.
- `src/components/briefing/BriefingDetailView.test.tsx` — "does not duplicate the lead paragraph" repurposed to assert `What happened` label is no longer rendered.

**Full suite: 806/806 across 102 files. `npm run build` green.**

## What is NOT in this PR
- No schema, no publish gate, no editor composer, no data-flow files.
- No changes to the citation-marker render path or the `editorialWhyItMatters` payload schema.
- Codebase-wide v1→v2 identifier rename remains parked under #271.

## Test plan
- [ ] CI green
- [ ] BM verifies in prod after merge: expand any published card on the homepage, confirm the foldback shows EXACTLY `The Signal` → `Before This` → `The Ripple` and no "Why this matters" / "What happened" labels appear.

## Lineage
- **Closes:** #276.
- **Direct follow-up to:** #274 (the umbrella issue) / PR #275 (the three-layer pipeline implementation).
- **Related blocker (previously merged):** #270 / PR #273 — WITM validator false-positives, needed before the slate can be published at all.
- **Descends from PRs:**
  - **#229** "feature: brand identity visual system v1 + editorial composer two-pane" — born `SignalCard.tsx` in its current shape (with the "What happened" / "Why this matters" / "What led to this" / "What it connects to" v1 layout).
  - **#275** "feat(editorial): three-layer publish pipeline + v2 foldback render (#274)" — added the three v2-labeled layer helpers; this PR completes the cleanup by removing the v1 leftovers in the same component.
- **Related PRD:** PRD-66 — `prd-66-three-layer-publish-pipeline.md`. The render contract documented there ("foldback shows exactly the three editorial layers in cause-then-trajectory order") is what this PR enforces in code.
- **Surfaced by:** post-merge visual check on PR #275's preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)