### PR TITLE
fix(foldback): strip editorial citation markers from public render (#278)

### DIFF
--- a/docs/engineering/bug-fixes/citation-markers-leaking-to-public-render-2026-05-24.md
+++ b/docs/engineering/bug-fixes/citation-markers-leaking-to-public-render-2026-05-24.md
@@ -1,0 +1,56 @@
+# Citation Markers Leaking to Public Foldback Render — Bug-Fix Record
+
+## Summary
+- **Problem addressed:** Editorial v2 drafts include inline citation markers — `[A]`, `[A1]`, `[A12]`, `[P1]`, `[F2]`, `[V3]`, etc. — required by the framework §5.2 citation discipline and correctly recognized by the WITM validator after PR #273. But the public foldback rendered them as literal inline text (e.g. "…services slipped [A]. Community members reported [A1] that housing…"), which is the right stored content but the wrong reader experience for the MVP. No footnote parser exists.
+- **Decision (MVP):** Strip the markers at **render time only**. Stored `published_*` columns stay untouched. The full reader-verifiable-citations feature (footnotes, hover sources, source-link anchors) is deferred as a post-MVP follow-up tracked under #278.
+- **Affected object level:** Card render — `src/components/signals/SignalCard.tsx` only. No schema, no publish gate, no validator, no stored-data path.
+- **Related issue:** #278.
+
+## Fix
+Three surgical changes in `src/components/signals/SignalCard.tsx`.
+
+**1. New `stripCitationMarkers(text)` helper.** Pure function, exported so the unit test can pin its contract without rendering the component:
+
+```ts
+export function stripCitationMarkers(text: string): string {
+  if (!text) return text;
+  return text
+    .replace(/\[[A-Z]\d*\]/g, "")
+    .replace(/\s+([.,;:!?)])/g, "$1")  // " ." / " ," artifacts left by marker-before-punctuation
+    .replace(/[ \t]{2,}/g, " ")        // collapse double-spaces left by mid-sentence markers
+    .trim();
+}
+```
+
+The regex `/\[[A-Z]\d*\]/g` matches exactly the editorial framework's marker shape: a bracketed single uppercase letter optionally followed by digits. It does NOT match lowercase tokens like `[topic]` (genuine unfilled placeholders the validator catches before publish) or numeric references like `[1]` (not the editorial shape).
+
+**2. Apply the helper at three render sites** — the three editorial layer bodies. Stored `signal` props are NOT mutated; the helper wraps the value at the point it's bound to the local `whyItMatters` / `beforeThisBody` / `theRippleBody` variables that feed JSX:
+
+```ts
+const whyItMatters = stripCitationMarkers(getWhyItMattersText(signal));
+const beforeThisBody = stripCitationMarkers(
+  readLayerBody(signal.publishedWhatLedToIt, signal.publishedWhatLedToItStructured),
+);
+const theRippleBody = stripCitationMarkers(
+  readLayerBody(signal.publishedWhatItConnectsTo, signal.publishedWhatItConnectsToStructured),
+);
+```
+
+The collapsed-card teaser also reads from `whyItMatters`, so it inherits the strip automatically.
+
+**3. Inline comment** documenting the contract: render-only transform, markers stay in stored data, reader-verifiable citations deferred.
+
+## Tests
+- **Unit (`stripCitationMarkers`)**: 5 tests pin the contract — the brief's example string, all marker shapes (`[A]`/`[A1]`/`[A12]`/`[P#]`/`[F#]`/`[V#]`), whitespace collapse, edge cases (`[topic]` lowercase untouched, `[1]` numeric untouched, empty/pure-marker input).
+- **Component (`SignalCard` render)**: one new test renders a card with markers in all three layer bodies and asserts (a) `card.textContent` matches no `/\[[A-Z]\d*\]/`, (b) the clean prose between markers reads correctly for each layer.
+- **Full suite:** 812/812 passed across 102 files. `npm run build` green.
+
+## What is NOT in this fix
+- No footnote/source-link rendering. That's the deferred reader-verifiable-citations feature; this PR references #278 as the MVP placeholder.
+- No editor composer change. The editor continues to see markers in the textareas because they're load-bearing for the WITM validator and for the future footnote feature.
+- No mutation of stored data anywhere. `published_*` columns retain the markers verbatim.
+- No regex change in `why-it-matters-quality-gate.ts`. The validator's marker handling (PR #273) is unchanged.
+
+## Relation
+- Follows the #275 → #277 sequence that landed the three-layer foldback (`SignalCard.tsx`).
+- The reader-verifiable-citations follow-up is tracked under #278.

--- a/src/components/signals/SignalCard.tsx
+++ b/src/components/signals/SignalCard.tsx
@@ -81,7 +81,13 @@ export function SignalCard({
 
   const displayRank = rank ?? signal.finalSlateRank ?? signal.rank ?? 1;
   const displayTier = tier ?? resolveSignalTier(signal, displayRank);
-  const whyItMatters = getWhyItMattersText(signal);
+  // #278 MVP render hygiene: strip editorial citation markers ([A], [A1],
+  // [P2], [F1], [V3]…) from the displayed prose so readers see clean
+  // text. The markers stay in stored `published_*` columns and in the
+  // structured payload — this is a render-only transform. The full
+  // reader-verifiable-citations feature (footnotes/hover sources) is
+  // tracked separately as a post-MVP follow-up.
+  const whyItMatters = stripCitationMarkers(getWhyItMattersText(signal));
   const sourceAttribution = getSourceAttribution(signal);
   const relatedCoverage = getRelatedCoverage(signal);
   // #274 follow-up: the foldback shows EXACTLY three editorial layers
@@ -95,13 +101,11 @@ export function SignalCard({
   // array (that was the v1-era hack that surfaced empty state for cards
   // with real layer content). Empty/whitespace published_* shows the
   // layer's intentional empty state.
-  const beforeThisBody = readLayerBody(
-    signal.publishedWhatLedToIt,
-    signal.publishedWhatLedToItStructured,
+  const beforeThisBody = stripCitationMarkers(
+    readLayerBody(signal.publishedWhatLedToIt, signal.publishedWhatLedToItStructured),
   );
-  const theRippleBody = readLayerBody(
-    signal.publishedWhatItConnectsTo,
-    signal.publishedWhatItConnectsToStructured,
+  const theRippleBody = stripCitationMarkers(
+    readLayerBody(signal.publishedWhatItConnectsTo, signal.publishedWhatItConnectsToStructured),
   );
 
   const readMoreClassName = cn(
@@ -346,6 +350,34 @@ function readLayerBody(
     }
   }
   return (publishedText ?? "").trim();
+}
+
+/**
+ * MVP render-only strip of editorial citation markers from prose so the
+ * public card surface reads as clean text (issue #278). Removes any
+ * bracketed single uppercase letter optionally followed by digits — the
+ * canonical shape used across the editorial framework: `[A]`, `[A1]`,
+ * `[A12]`, `[P1]`, `[F2]`, `[V3]`, etc. After removal, collapse the
+ * whitespace artifacts the markers leave behind:
+ *   - `"slipped [A]. Community"` (a marker before a period leaves
+ *     a stray `" ."`) → `"slipped. Community"`.
+ *   - any resulting double space → single space.
+ *
+ * Exported so unit tests can pin the contract without rendering the
+ * whole component. NEVER mutates stored data — the markers stay in
+ * `published_*` columns and in the structured payload. The full
+ * reader-verifiable-citations feature (footnote rendering with source
+ * URLs) is a separate post-MVP follow-up.
+ */
+export function stripCitationMarkers(text: string): string {
+  if (!text) return text;
+  return text
+    .replace(/\[[A-Z]\d*\]/g, "")
+    // marker-before-punctuation artifacts: `" ."`, `" ,"`, `" ;"`, etc.
+    .replace(/\s+([.,;:!?)])/g, "$1")
+    // collapse double-spaces left by mid-sentence markers
+    .replace(/[ \t]{2,}/g, " ")
+    .trim();
 }
 
 function resolveSignalTier(signal: SignalCardSignal, rank: number): SignalTier {

--- a/src/components/signals/visual-system-components.test.tsx
+++ b/src/components/signals/visual-system-components.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { DateBadge } from "@/components/signals/DateBadge";
-import { SignalCard } from "@/components/signals/SignalCard";
+import { SignalCard, stripCitationMarkers } from "@/components/signals/SignalCard";
 import { TierBadge } from "@/components/signals/TierBadge";
 
 describe("Bootup News visual system components", () => {
@@ -302,5 +302,100 @@ describe("Bootup News visual system components", () => {
     expect(sourceLink).toHaveAttribute("href", "https://www.reuters.com/story");
     expect(sourceLink).toHaveAttribute("target", "_blank");
     expect(sourceLink).toHaveAccessibleName(/read source/i);
+  });
+
+  // #278 — MVP render hygiene: editorial citation markers ([A], [A1],
+  // [P2], [F1], [V3]…) are stripped from the displayed prose so readers
+  // see clean text. This is render-only; the markers stay in the stored
+  // published_* columns. The full reader-verifiable-citations feature
+  // (footnotes/hover sources) is a separate post-MVP follow-up.
+  describe("stripCitationMarkers (#278)", () => {
+    it("matches the brief's contract example", () => {
+      // From the brief: stripCitationMarkers("X slipped [A]. Y rose [A1] and [P2].")
+      // === "X slipped. Y rose and."
+      expect(
+        stripCitationMarkers("X slipped [A]. Y rose [A1] and [P2]."),
+      ).toBe("X slipped. Y rose and.");
+    });
+
+    it("removes every editorial-shape marker — [A], [A1], [A12], [P#], [F#], [V#]", () => {
+      const input =
+        "Rates moved [A]. Spreads tightened [A1] and widened [A12]. Policy [P1] and [P2], fiscal [F3], FX [V1].";
+      const output = stripCitationMarkers(input);
+      expect(output).not.toMatch(/\[[A-Z]\d*\]/);
+    });
+
+    it("collapses double spaces and ' .' artifacts left by mid-sentence markers", () => {
+      const input =
+        "Memory chips [A] and helium [A1] are climbing [P2].  Markets [F1] reacted [V3] .";
+      const output = stripCitationMarkers(input);
+      expect(output).not.toMatch(/ {2,}/);
+      expect(output).not.toMatch(/ \./);
+      expect(output).not.toMatch(/\[[A-Z]\d*\]/);
+    });
+
+    it("leaves lowercase-bracket tokens and non-citation brackets untouched", () => {
+      // The validator's UNRESOLVED_VARIABLE_PATTERN catches genuine
+      // placeholders like [topic] (lowercase, multi-letter) before
+      // publish. We don't strip those — they should never reach prod
+      // text. But if they do, leaving them in lets the bug surface
+      // visibly rather than getting silently scrubbed.
+      expect(stripCitationMarkers("Edge case [topic] survives.")).toBe(
+        "Edge case [topic] survives.",
+      );
+      // Bracket with digits-first (e.g. citation reference style) is not
+      // an editorial marker — leave untouched.
+      expect(stripCitationMarkers("Reference [1] cited.")).toBe("Reference [1] cited.");
+    });
+
+    it("handles empty input and pure-marker input safely", () => {
+      expect(stripCitationMarkers("")).toBe("");
+      expect(stripCitationMarkers("[A] [B] [C]")).toBe("");
+    });
+  });
+
+  // #278 — the SignalCard render must strip citation markers from all
+  // three editorial layer bodies. The stored prop values can contain
+  // [A] / [A1] / [P2] etc.; the rendered DOM must not.
+  it("strips citation markers from The Signal, Before This, and The Ripple in the rendered card (#278)", () => {
+    render(
+      <SignalCard
+        rank={1}
+        defaultExpanded
+        signal={{
+          id: "signal-citation-marker-strip",
+          title: "Card with citation markers in all three layers",
+          publishedWhyItMatters:
+            "Memory-chip prices climbed [A]. Helium supply tightened [A1].",
+          publishedWhatLedToIt:
+            "Strait closure triggered the supply shock [P1] and [P2].",
+          publishedWhatItConnectsTo:
+            "Fed will reassess rate path next quarter [F1] [V3].",
+          sourceName: "Reuters",
+          sourceUrl: "https://www.reuters.com/story",
+        }}
+      />,
+    );
+
+    // Labels are intact.
+    expect(screen.getByText("The Signal")).toBeInTheDocument();
+    expect(screen.getByText("Before This")).toBeInTheDocument();
+    expect(screen.getByText("The Ripple")).toBeInTheDocument();
+
+    // No editorial marker shape survives anywhere in the rendered DOM.
+    const card = screen.getByTestId("signal-card");
+    expect(card.textContent ?? "").not.toMatch(/\[[A-Z]\d*\]/);
+
+    // Each layer body still reads as clean prose — the prefix before the
+    // first marker is preserved.
+    expect(
+      screen.getByText(/Memory-chip prices climbed\. Helium supply tightened\./),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Strait closure triggered the supply shock and\./),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Fed will reassess rate path next quarter\./),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #278.

## What
Editorial v2 drafts include inline citation markers — `[A]`, `[A1]`, `[A12]`, `[P1]`, `[F2]`, `[V3]` — per framework §5.2 citation discipline. They were rendering as literal text on the public foldback ("…services slipped [A]. Community members reported [A1]…"). No footnote parser exists; the full reader-verifiable-citations feature (footnotes / hover sources / source-link anchors) is deferred as a post-MVP follow-up tracked under #278.

This PR strips the markers **at render time only**. Stored `published_*` columns are untouched, the WITM validator continues to recognize them (PR #273), and the editor's composer textareas still show them.

## SignalCard.tsx diff
Three surgical edits:

1. **New `stripCitationMarkers(text)` pure helper**, exported so unit tests can pin its contract without rendering the component:
   ```ts
   export function stripCitationMarkers(text: string): string {
     if (!text) return text;
     return text
       .replace(/\[[A-Z]\d*\]/g, "")
       .replace(/\s+([.,;:!?)])/g, "$1")  // ' .' / ' ,' artifacts before punctuation
       .replace(/[ \t]{2,}/g, " ")         // double-spaces left by mid-sentence markers
       .trim();
   }
   ```
   The regex matches exactly the editorial framework's marker shape: bracketed single uppercase letter optionally followed by digits. It does NOT match lowercase tokens like `[topic]` (genuine unfilled placeholders the validator catches before publish) or numeric references like `[1]`.

2. **Apply the helper at three render sites** — the three editorial layer bodies. Stored `signal` props are NOT mutated; the helper wraps the value at the point it's bound to the local variables that feed JSX:
   ```ts
   const whyItMatters = stripCitationMarkers(getWhyItMattersText(signal));
   const beforeThisBody = stripCitationMarkers(readLayerBody(...));
   const theRippleBody = stripCitationMarkers(readLayerBody(...));
   ```
   The collapsed-card teaser inherits the strip automatically because it reads from the same local `whyItMatters`.

3. Inline comment documenting the contract: render-only, markers stay in stored data, full citations deferred.

## Tests
- **Unit (`stripCitationMarkers`)**: 5 tests pin the contract — the brief's example string (`"X slipped [A]. Y rose [A1] and [P2]." → "X slipped. Y rose and."`), all marker shapes, whitespace artifacts, edge cases (`[topic]` lowercase + `[1]` numeric untouched), empty/pure-marker input.
- **Component (`SignalCard` render)**: one new test renders a card with markers in all three layer bodies and asserts (a) `card.textContent` matches no `/\[[A-Z]\d*\]/`, (b) clean prose between markers reads correctly for each layer.

**Full suite: 812/812 passed across 102 files. `npm run build` green.**

## What is NOT in this PR
- No footnote / source-link rendering. That's the deferred reader-verifiable-citations feature; this PR is the MVP placeholder.
- No editor composer change. The editor continues to see markers in the textareas — they're load-bearing for the WITM validator and for the future footnote feature.
- No mutation of stored data. `published_*` columns retain the markers verbatim.
- No regex change in `why-it-matters-quality-gate.ts`.
- Scope is `SignalCard.tsx` (+ its test fixtures) only.

## Test plan
- [ ] CI green
- [ ] BM verifies in prod: expand any published card with citation markers in the source text, confirm no `[A]` / `[A1]` / `[P2]` / etc. appears on screen. Confirm DB row still contains the markers (`select published_why_it_matters, published_what_led_to_it, published_what_it_connects_to from signal_posts where briefing_date='YYYY-MM-DD' and is_live=true`).

## Lineage
- **Closes:** #278.
- **Direct follow-up to:** PR #275 (three-layer publish pipeline) and PR #277 (foldback cleanup) — both established the three-layer render surface this PR adds a render-time transform to.
- **Related:** PR #273 / #270 — WITM validator rule that recognizes citation markers as legitimate content in `edited_*` / `published_*` text. That rule is unchanged here.
- **Descends from PRs:** #229 (born `SignalCard.tsx`), #275 (added `readLayerBody` + three-layer rendering), #277 (cleaned duplicate WITM + removed What Happened).
- **Deferred follow-up:** reader-verifiable citations — footnote rendering, hover sources, inline source-link anchors. The current PR is explicitly the MVP placeholder; the deferred work should reference #278 as the predecessor.
- **Surfaced by:** post-merge visual check on PR #275 / PR #277 preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)