### PR TITLE
fix(editorial): re-publish promotes typed depth content + hide Approve on live cards (#282)

### DIFF
--- a/docs/engineering/bug-fixes/republish-partial-state-2026-05-25.md
+++ b/docs/engineering/bug-fixes/republish-partial-state-2026-05-25.md
@@ -1,0 +1,46 @@
+# Re-Publish Live Card Partial State — Bug-Fix Record
+
+## Summary
+- **Problem addressed:** After clicking **Re-publish live card** on a live card (PR #281 / issue #280), production showed `editorial_status='approved'` (not `'published'`), `published_what_led_to_it` / `published_what_it_connects_to` `NULL`, `previous_published_snapshot` populated, `is_live=true`. Net effect: the card fell out of the public homepage query (which requires `editorial_status='published'`) and DISAPPEARED from the live site. Reproduced on more than one card. PR #281's 821/821 tests passed because they asserted the function's return / the snapshot, not the full row state.
+- **Root cause (two compounding bugs):**
+  1. **Re-publish silently dropped the editor's typed depth content.** `republishLiveSignalPost`'s `.update({...})` IS a single atomic write that includes `editorial_status: "published"` and all three `published_*` columns. But the values for `published_what_led_to_it` / `published_what_it_connects_to` came from `buildLayerPublishText(post.editedWhatLedToIt ?? post.publishedWhatLedToIt, …)` — a fallback chain that read DB only. The editor's just-typed textarea content never reached the function, and for live cards whose depth-layer `edited_*` and `published_*` were both null (the common state for any card first-published before PRD-66 / depth layers ever edited), this wrote `null` into both depth `published_*` columns. The action layer (`republishLiveSignalPostAction`) only forwarded `postId` to the lib.
+  2. **Approve button on a live card flips status `published`→`approved`.** `approveSignalPostWithContext` hardcodes `editorial_status: "approved"` + `editorial_decision: "approved"`, writes `edited_*` but never touches `published_*`. Its button was disabled only on `controlsDisabled` (storage/persisted), not on `isLive` / `editorialStatus === 'published'`. Likely prod sequence: editor re-publishes → doesn't see depth on public site → clicks Approve thinking that'll push them → status regresses, depth stays null, card vanishes.
+- **Affected object level:** Card (single-row `signal_posts` mutation path).
+- **Related issue:** #282. Direct regression on #280 / PR #281.
+
+## Fix
+
+**(A) `republishLiveSignalPost` accepts form-captured content** (`src/lib/signals-editorial.ts`). New optional inputs: `editedWhyItMatters`, `editedWhyItMattersStructured`, `editedWhatLedToIt`, `editedWhatLedToItStructured`, `editedWhatItConnectsTo`, `editedWhatItConnectsToStructured`. Resolution precedence per layer: **explicit input → DB `edited_*` → DB `published_*`**. The atomic single `.update({...})` is preserved — snapshot + all three `published_*` (text + payload) + `editorial_status='published'` + `is_live=true` + `published_at=now` all in one write. Form-captured content is ALSO persisted into `edited_*` in the same update so subsequent reads (Save Edits, refresh, future re-publish) see consistent state.
+
+**(B) `republishLiveSignalPostAction` reads the form fields** (`actions.ts`). Forwards `editedWhyItMatters` / `editedWhyItMattersStructured` (via the existing `readStructuredEditorialInput` helper) and `editedWhatLedToIt` / `editedWhatItConnectsTo` (via the existing `readLayerEditorialText` helper) to the lib.
+
+**(C) Hide the Approve button on currently-live-published cards** (`StructuredEditorialFields.tsx`). New `isCurrentlyLivePublished` flag gates the Approve button — Re-publish is the correct control for those rows. Save Edits and Reset to AI Draft remain (saveSignalDraft already preserves `editorial_status='published'`).
+
+## Tests
+
+**New characterization test** (`signals-editorial.test.ts`, in the `republishLiveSignalPost (#280)` describe block): a live+published card whose depth-layer `edited_*` AND `published_*` are BOTH null (the exact prod-bug precondition) gets re-published with form-supplied content. Asserts the COMPLETE row state:
+- `editorial_status === 'published'` (NOT `'approved'`)
+- `is_live === true`
+- `published_why_it_matters` === typed Signal content
+- `published_what_led_to_it` === typed Before This content
+- `published_what_it_connects_to` === typed Ripple content
+- `edited_*` also persisted from form
+- `previous_published_snapshot` captures the prior null values
+
+**Standing rule** added as an inline comment at the top of the `republishLiveSignalPost` describe block:
+
+> State-transition tests must assert the COMPLETE resulting row state (all promoted columns + status + is_live + id), never just the function return — this bug (and the #275 duplicate-render bug) both shipped because tests asserted the happy-path output, not the end state.
+
+Existing tests (validation refusal, never-published refusal, not_found, slate gate isolation) still pass. Full suite: **822/822 across 102 files** (was 821; +1 new). `npm run build` green.
+
+## Test-first sequencing
+Test was written + run against current code FIRST and FAILED at the first assertion (`published_why_it_matters` stayed at "Prior Signal" because the function read DB-`edited_*` instead of the typed input). After the fix: passes.
+
+## Operator follow-up (post-deploy)
+The 2026-05-24 live rows are already hand-stabilized; this PR does not touch them. After deploy, BM can use the corrected Re-publish flow on any card whose depth layers need an update — typing content into the textareas and clicking Re-publish will now write all three layers atomically and keep status=`published`.
+
+## Not addressed by this fix
+- No schema change.
+- No change to `publishApprovedSignals` (the slate publish gate, used for first-publish).
+- No change to `saveSignalDraft` — already preserves `editorial_status='published'` for live cards (verified). Bug 2 was specifically Approve, not Save.
+- No code mutation of any live row. Operator action required for any stale row content.

--- a/src/app/dashboard/signals/editorial-review/StructuredEditorialFields.tsx
+++ b/src/app/dashboard/signals/editorial-review/StructuredEditorialFields.tsx
@@ -98,6 +98,14 @@ export function SignalPostEditor({ post, storageReady, defaultExpanded = false }
     post.whyItMattersValidationStatus !== "requires_human_rewrite" &&
     !isBlockingDecision(post.editorialDecision);
   const requiresHumanRewrite = post.whyItMattersValidationStatus === "requires_human_rewrite";
+  // #282 — A card that is currently published+live MUST flow through
+  // Re-publish for any update. Approve flips editorial_status to
+  // 'approved' without touching published_*, which removes the card
+  // from the public homepage query (which requires status='published').
+  // Hide Approve on live cards so that footgun is gone; Re-publish is
+  // the correct control.
+  const isCurrentlyLivePublished =
+    post.isLive && post.editorialStatus === "published" && Boolean(post.publishedAt);
   const toggleLabel = isExpanded ? "Collapse" : "Expand";
   const panelId = `editorial-panel-${post.id}`;
 
@@ -205,15 +213,20 @@ export function SignalPostEditor({ post, storageReady, defaultExpanded = false }
               <Save className="h-4 w-4" />
               Save Edits
             </Button>
-            <Button
-              type="submit"
-              formAction={approveSignalPostAction}
-              disabled={controlsDisabled}
-              className="gap-2"
-            >
-              <CheckCircle2 className="h-4 w-4" />
-              Approve
-            </Button>
+            {/* #282 Approve hidden on currently-live-published cards
+                — see isCurrentlyLivePublished comment. Re-publish is
+                the safe path. */}
+            {isCurrentlyLivePublished ? null : (
+              <Button
+                type="submit"
+                formAction={approveSignalPostAction}
+                disabled={controlsDisabled}
+                className="gap-2"
+              >
+                <CheckCircle2 className="h-4 w-4" />
+                Approve
+              </Button>
+            )}
             <Button
               type="submit"
               formAction={resetSignalPostToAiDraftAction}
@@ -230,7 +243,7 @@ export function SignalPostEditor({ post, storageReady, defaultExpanded = false }
                 from edited_*. Validation gate (WITM passed) still applies.
                 Distinct from the slate-publish button (which only handles
                 never-published cards). */}
-            {post.isLive && post.editorialStatus === "published" && post.publishedAt ? (
+            {isCurrentlyLivePublished ? (
               <Button
                 type="submit"
                 formAction={republishLiveSignalPostAction}

--- a/src/app/dashboard/signals/editorial-review/actions.ts
+++ b/src/app/dashboard/signals/editorial-review/actions.ts
@@ -236,12 +236,29 @@ export async function publishSignalPostAction(formData: FormData) {
 /**
  * Re-publish an already-live signal post in place (#280). Snapshots the
  * prior `published_*` into `previous_published_snapshot` and overwrites
- * from `edited_*`. Refuses for never-published cards (use the slate
- * publish gate instead) and refuses on WITM validator failure.
+ * `published_*` from the editor's currently-typed form content (falling
+ * back to DB `edited_*` then DB `published_*` for layers the editor
+ * didn't touch). The form-captured content is also persisted into
+ * `edited_*` in the same atomic update so subsequent reads see
+ * consistent state.
+ *
+ * Refuses for never-published cards (use the slate publish gate instead)
+ * and refuses on WITM validator failure.
+ *
+ * #282 (regression fix): previously this action only passed `postId` to
+ * the lib, so the lib read DB `edited_*` (often null for depth layers)
+ * and wrote null into `published_what_led_to_it` /
+ * `published_what_it_connects_to`. The editor's typed textarea content
+ * was silently dropped. The lib's new optional `editedWhat*` parameters
+ * close that gap.
  */
 export async function republishLiveSignalPostAction(formData: FormData) {
   const result = await republishLiveSignalPost({
     postId: String(formData.get("postId") ?? ""),
+    editedWhyItMatters: String(formData.get("editedWhyItMatters") ?? ""),
+    editedWhyItMattersStructured: readStructuredEditorialInput(formData),
+    editedWhatLedToIt: readLayerEditorialText(formData, "editedWhatLedToIt"),
+    editedWhatItConnectsTo: readLayerEditorialText(formData, "editedWhatItConnectsTo"),
   });
 
   if (result.ok) {

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -3000,6 +3000,14 @@ describe("signals editorial workflow", () => {
     });
   });
 
+  // STANDING RULE (issue #282 — re-publish partial-state bug):
+  // State-transition tests must assert the COMPLETE resulting row state
+  // (all promoted columns + status + is_live + id), never just the
+  // function return — this bug (and the #275 duplicate-render bug) both
+  // shipped because tests asserted the happy-path output, not the end
+  // state. Every test in this block reads the final mock row and pins
+  // every column the brief's acceptance criteria mention.
+
   // #280 — re-publish a card that is already live + published. Snapshots
   // the prior published_* into previous_published_snapshot, overwrites in
   // place from edited_*, keeps is_live=true and same id. Does NOT replace
@@ -3168,6 +3176,104 @@ describe("signals editorial workflow", () => {
       expect(rows.every((row) => row.is_live === true)).toBe(true);
       // First-time publish does not snapshot — the column stays null.
       expect(rows.every((row) => row.previous_published_snapshot === null)).toBe(true);
+    });
+
+    // STANDING RULE applies to this test — assert the COMPLETE row state.
+    // This is the regression test for issue #282 (the prod bug where
+    // depth layers stayed NULL and status flipped to "approved" after
+    // re-publish, causing the card to vanish from the public homepage).
+    //
+    // Repro: a live+published card whose depth-layer `edited_*` AND
+    // `published_*` columns are BOTH null (the common state for any
+    // card that was first-published before depth-layer promotion was
+    // supported, or whose depth layers were never edited+saved). The
+    // editor types depth-layer content into the textareas and clicks
+    // Re-publish. The action passes the typed text to the lib via the
+    // new optional `editedWhat*` parameters. Expected: all three
+    // `published_*` columns reflect the typed content, status stays
+    // 'published', is_live=true, snapshot captures the null prior.
+    it("issue #282: re-publishes ALL three layers from form-supplied content even when DB edited_*/published_* are both null", async () => {
+      const priorPublishedAt = "2026-05-23T12:00:00.000Z";
+      const rows = [
+        createRow({
+          id: "live-card-282",
+          briefing_date: "2026-05-24",
+          editorial_status: "published",
+          editorial_decision: "approved",
+          is_live: true,
+          published_at: priorPublishedAt,
+          why_it_matters_validation_status: "passed",
+          // The Signal IS published (slate gate writes it on first publish).
+          published_why_it_matters: createValidWhyItMatters("Prior Signal"),
+          edited_why_it_matters: createValidWhyItMatters("Prior Signal"),
+          // BUT depth layers are NULL in DB — never edited, never promoted.
+          // This is the exact prod-bug precondition.
+          edited_what_led_to_it: null,
+          published_what_led_to_it: null,
+          edited_what_it_connects_to: null,
+          published_what_it_connects_to: null,
+          source_url: "https://example.com/source",
+        }),
+      ];
+      createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+      safeGetUser.mockResolvedValue({
+        user: { id: "admin-1", email: "admin@example.com" },
+        supabase: {},
+        sessionCookiePresent: true,
+      });
+
+      const { republishLiveSignalPost } = await loadEditorialModule();
+      const result = await republishLiveSignalPost({
+        postId: "live-card-282",
+        // Editor's typed textarea content — must reach published_* even
+        // though DB-edited_* and DB-published_* are null for these layers.
+        editedWhyItMatters: createValidWhyItMatters("Updated Signal"),
+        editedWhatLedToIt: "New Before This text typed in the cockpit.",
+        editedWhatItConnectsTo: "New Ripple text typed in the cockpit.",
+      });
+
+      // Read the COMPLETE resulting row state, not just the function return.
+      const row = rows[0];
+
+      // The function must succeed.
+      expect(result.ok).toBe(true);
+      expect(result.code).toBe("republished");
+
+      // Status MUST stay 'published' — NOT 'approved' (the prod regression).
+      expect(row.editorial_status).toBe("published");
+      expect(row.is_live).toBe(true);
+      expect(row.id).toBe("live-card-282");
+
+      // ALL THREE published_* layers must reflect the typed content.
+      expect(row.published_why_it_matters).toBe(createValidWhyItMatters("Updated Signal"));
+      // These two are the layers that went NULL in prod — the regression
+      // test pins them tight.
+      expect(row.published_what_led_to_it).toBe(
+        "New Before This text typed in the cockpit.",
+      );
+      expect(row.published_what_it_connects_to).toBe(
+        "New Ripple text typed in the cockpit.",
+      );
+
+      // edited_* should ALSO carry the new content so any later Save
+      // Edits / refresh / Approve sees consistent state.
+      expect(row.edited_what_led_to_it).toBe(
+        "New Before This text typed in the cockpit.",
+      );
+      expect(row.edited_what_it_connects_to).toBe(
+        "New Ripple text typed in the cockpit.",
+      );
+
+      // Snapshot captured the prior published values (null for the depth
+      // layers in this scenario).
+      expect(row.previous_published_snapshot).toMatchObject({
+        why_it_matters: createValidWhyItMatters("Prior Signal"),
+        what_led_to_it: null,
+        what_it_connects_to: null,
+      });
+
+      // published_at bumped.
+      expect(row.published_at).not.toBe(priorPublishedAt);
     });
   });
 });

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -3812,6 +3812,24 @@ export async function publishSignalPost(input: {
  */
 export async function republishLiveSignalPost(input: {
   postId: string;
+  // #282 — Optional editor-typed content from the cockpit form. When
+  // provided, these values are used in preference to the DB's `edited_*`
+  // for the corresponding layer, AND are persisted into `edited_*` in
+  // the same atomic update so the row's edit-state stays consistent.
+  // When undefined, the function falls back to DB `edited_*` then DB
+  // `published_*` (the prior behavior).
+  //
+  // Why this matters: without form-capture, an editor who typed depth-
+  // layer content into the textareas and clicked Re-publish would write
+  // null into `published_what_led_to_it` / `published_what_it_connects_to`
+  // because DB `edited_*` was null for those layers (the prod incident
+  // root cause).
+  editedWhyItMatters?: string;
+  editedWhyItMattersStructured?: EditorialWhyItMattersContent | null;
+  editedWhatLedToIt?: string;
+  editedWhatLedToItStructured?: EditorialWhyItMattersContent | null;
+  editedWhatItConnectsTo?: string;
+  editedWhatItConnectsToStructured?: EditorialWhyItMattersContent | null;
   route?: string;
 }): Promise<EditorialMutationResult> {
   const context = await getAdminEditorialContext(input.route ?? SIGNALS_EDITORIAL_ROUTE);
@@ -3868,16 +3886,25 @@ export async function republishLiveSignalPost(input: {
     };
   }
 
-  // Build the new published text from edited_* first (the editor's
-  // latest review), falling back to the existing published value when
-  // edited_* is null. Mirrors the slate publish path.
+  // #282 — Resolve each layer's "to-be-published" text using a strict
+  // precedence: explicit form input wins, then DB `edited_*`, then DB
+  // `published_*` (so an unedited layer keeps whatever was already
+  // published). Form-captured content also flows into `edited_*` in the
+  // same atomic update so the row's edit-state stays in sync.
+  //
+  // The Signal: structured payload + text are resolved together so the
+  // payload-derived text (matching the slate publish + WITM editor) wins
+  // when a structured payload exists.
+  const witmTextSource =
+    input.editedWhyItMatters !== undefined
+      ? input.editedWhyItMatters
+      : (post.editedWhyItMatters || post.publishedWhyItMatters || "");
   const structuredContent =
-    post.editedWhyItMattersStructured ?? post.publishedWhyItMattersStructured;
+    input.editedWhyItMattersStructured !== undefined
+      ? input.editedWhyItMattersStructured
+      : (post.editedWhyItMattersStructured ?? post.publishedWhyItMattersStructured);
   const witmText = normalizeEditorialText(
-    buildEditorialWhyItMattersText(
-      structuredContent,
-      post.editedWhyItMatters || post.publishedWhyItMatters || "",
-    ),
+    buildEditorialWhyItMattersText(structuredContent, witmTextSource),
   );
   if (!witmText) {
     return {
@@ -3895,21 +3922,28 @@ export async function republishLiveSignalPost(input: {
     };
   }
 
-  // Before This + The Ripple use the editor's edited_* if set, else fall
-  // back to the existing published_* so a re-publish that only touches
-  // The Signal doesn't accidentally null out the other two layers.
-  const wltiStructured =
-    post.editedWhatLedToItStructured ?? post.publishedWhatLedToItStructured;
-  const wltiText = buildLayerPublishText(
-    post.editedWhatLedToIt ?? post.publishedWhatLedToIt,
-    wltiStructured,
-  );
-  const witcStructured =
-    post.editedWhatItConnectsToStructured ?? post.publishedWhatItConnectsToStructured;
-  const witcText = buildLayerPublishText(
-    post.editedWhatItConnectsTo ?? post.publishedWhatItConnectsTo,
-    witcStructured,
-  );
+  // Before This + The Ripple — same precedence. Falling back to existing
+  // `published_*` keeps a Signal-only re-publish from accidentally
+  // nulling the other two layers.
+  const wltiResolvedText =
+    input.editedWhatLedToIt !== undefined
+      ? input.editedWhatLedToIt
+      : (post.editedWhatLedToIt ?? post.publishedWhatLedToIt);
+  const wltiResolvedStructured =
+    input.editedWhatLedToItStructured !== undefined
+      ? input.editedWhatLedToItStructured
+      : (post.editedWhatLedToItStructured ?? post.publishedWhatLedToItStructured);
+  const wltiText = buildLayerPublishText(wltiResolvedText, wltiResolvedStructured);
+
+  const witcResolvedText =
+    input.editedWhatItConnectsTo !== undefined
+      ? input.editedWhatItConnectsTo
+      : (post.editedWhatItConnectsTo ?? post.publishedWhatItConnectsTo);
+  const witcResolvedStructured =
+    input.editedWhatItConnectsToStructured !== undefined
+      ? input.editedWhatItConnectsToStructured
+      : (post.editedWhatItConnectsToStructured ?? post.publishedWhatItConnectsToStructured);
+  const witcText = buildLayerPublishText(witcResolvedText, witcResolvedStructured);
 
   const snapshottedAt = new Date().toISOString();
   // Snapshot the CURRENT published_* + WITM payload BEFORE overwriting.
@@ -3925,16 +3959,43 @@ export async function republishLiveSignalPost(input: {
     snapshotted_at: snapshottedAt,
   };
 
+  // #282 — Persist form-captured content into `edited_*` alongside the
+  // `published_*` promotion so any subsequent Save Edits / refresh / etc.
+  // reads consistent state. Only writes the column when input was
+  // explicitly provided (undefined ⇒ leave `edited_*` untouched).
+  const editedWritebacks: Record<string, unknown> = {};
+  if (input.editedWhyItMatters !== undefined) {
+    editedWritebacks.edited_why_it_matters = witmText || null;
+  }
+  if (input.editedWhyItMattersStructured !== undefined) {
+    editedWritebacks.edited_why_it_matters_payload = structuredContent;
+  }
+  if (input.editedWhatLedToIt !== undefined) {
+    editedWritebacks.edited_what_led_to_it = wltiText;
+  }
+  if (input.editedWhatLedToItStructured !== undefined) {
+    editedWritebacks.edited_what_led_to_it_payload = wltiResolvedStructured;
+  }
+  if (input.editedWhatItConnectsTo !== undefined) {
+    editedWritebacks.edited_what_it_connects_to = witcText;
+  }
+  if (input.editedWhatItConnectsToStructured !== undefined) {
+    editedWritebacks.edited_what_it_connects_to_payload = witcResolvedStructured;
+  }
+
   const updateResult = await context.client
     .from("signal_posts")
     .update({
       previous_published_snapshot: previousPublishedSnapshot,
+      // Edited writebacks (form-captured content → edited_*).
+      ...editedWritebacks,
+      // Published promotion (all three layers).
       published_why_it_matters: witmText,
       published_why_it_matters_payload: structuredContent,
       published_what_led_to_it: wltiText,
-      published_what_led_to_it_payload: wltiStructured,
+      published_what_led_to_it_payload: wltiResolvedStructured,
       published_what_it_connects_to: witcText,
-      published_what_it_connects_to_payload: witcStructured,
+      published_what_it_connects_to_payload: witcResolvedStructured,
       // Stay live, stay published. Bump published_at so observability
       // can tell the re-publish moment apart from the original publish.
       is_live: true,


### PR DESCRIPTION
Closes #282. Direct regression on #280 / PR #281.

## Step 0 — Source findings

**Quote** of `republishLiveSignalPost`'s `.update({...})` in PR #281:

```ts
.update({
  previous_published_snapshot: previousPublishedSnapshot,
  published_why_it_matters: witmText,
  published_why_it_matters_payload: structuredContent,
  published_what_led_to_it: wltiText,
  published_what_led_to_it_payload: wltiStructured,
  published_what_it_connects_to: witcText,
  published_what_it_connects_to_payload: witcStructured,
  is_live: true,
  editorial_status: "published",
  editorial_decision: "approved",
  published_at: snapshottedAt,
  ...buildWhyItMattersValidationFields(validation, snapshottedAt),
  updated_at: snapshottedAt,
})
.eq("id", input.postId);
```

1. **Writes all three depth layers** in the same update — NOT just The Signal.
2. **Sets `editorial_status: "published"`** atomically with the depth-layer writes.
3. **Single atomic `.update({...})`** — no intermediate write that could leave snapshot-set / depth-null / status-approved.

**The brief's hypothesis "multiple writes with early exit" is contradicted by the code.** The signature (snapshot YES + depth NULL + status=approved) cannot come from `republishLiveSignalPost` alone. It requires a second write after re-publish.

The depth-null part comes from the values: `wltiText` = `buildLayerPublishText(post.editedWhatLedToIt ?? post.publishedWhatLedToIt, …)` — a DB-only fallback chain. For any card whose depth `edited_*` and `published_*` are both null in DB (the common state for cards first-published before depth layers were ever edited), this writes `null` into the depth `published_*` columns. The editor's just-typed textarea content never reaches the function because `republishLiveSignalPostAction` only forwarded `postId`.

The status=approved part comes from `approveSignalPostWithContext` (`signals-editorial.ts:~2390`), which the "Approve" button submits to. It hardcodes `editorial_status: "approved"` + `editorial_decision: "approved"` and writes `edited_*` but never touches `published_*`. Its button is gated only by `controlsDisabled` (storage/persisted), so it's clickable on a live published card.

**Most likely prod sequence:** BM re-publishes (snapshot, depth=null due to DB-fallback bug, status=published) → doesn't see depth on public site → clicks Approve thinking it'll push them → status regresses to 'approved', depth stays null, card vanishes from homepage.

## Step 1 — Characterization test (FAILS against current code)

New test in the existing `republishLiveSignalPost (#280)` describe block reproduces the exact prod precondition: live+published card with depth-layer `edited_*` AND `published_*` BOTH null. Asserts the COMPLETE resulting row state. **Failed at the first assertion** against pre-fix code:

```
AssertionError: expected 'Prior Signal's growth is now structu…' to be 'Updated Signal's growth is now struc…'
> expect(row.published_why_it_matters).toBe(createValidWhyItMatters("Updated Signal"));
```

The function read DB-`edited_*` instead of the typed input. Depth-layer assertions would have failed next.

## Step 2 — Fix (diff)

Two compounding bugs, fixed in two places + a UI guard.

**(A) `republishLiveSignalPost` accepts form-captured content** (`src/lib/signals-editorial.ts`).
New optional inputs: `editedWhyItMatters` + `editedWhyItMattersStructured` + `editedWhatLedToIt` + `editedWhatLedToItStructured` + `editedWhatItConnectsTo` + `editedWhatItConnectsToStructured`. Resolution precedence per layer: **explicit input → DB `edited_*` → DB `published_*`**. The atomic single `.update({...})` is preserved — snapshot + all three `published_*` (text + payload) + `editorial_status='published'` + `is_live=true` + `published_at=now` + edited_* writebacks all go in one shot.

**(B) `republishLiveSignalPostAction` reads form fields** (`actions.ts`).
Forwards `editedWhyItMatters` / `structuredWhyItMatters` (via existing `readStructuredEditorialInput`) and `editedWhatLedToIt` / `editedWhatItConnectsTo` (via existing `readLayerEditorialText`) to the lib.

**(C) Hide Approve on currently-live-published cards** (`StructuredEditorialFields.tsx`).
New `isCurrentlyLivePublished` flag gates the Approve button. Re-publish is the correct control for those rows. Save Edits and Reset to AI Draft remain — `saveSignalDraft` already preserves `editorial_status='published'`.

## Step 3 — Verify

- **Characterization test from Step 1 now PASSES** (all three layers + status + snapshot + in-place).
- **Inverse guards verified by existing tests** in the same describe block: never-published cards refused (`code: "publish_blocked"`, message matches `/already live and published/i`); WITM validation failure refused (`code: "publish_blocked"`, `previous_published_snapshot` stays null, `published_*` unchanged).
- **Full vitest suite: 822/822 passed across 102 files** (was 821; +1 new test).
- **`npm run build`** green.
- **Did NOT touch the live 2026-05-24 rows** — they were already hand-stabilized; re-publishing through the fixed path is a separate post-deploy verification step.

## Step 4 — Standing rule pinned

Added as an inline comment at the top of the `republishLiveSignalPost` describe block:

> State-transition tests must assert the COMPLETE resulting row state (all promoted columns + status + is_live + id), never just the function return — this bug (and the #275 duplicate-render bug) both shipped because tests asserted the happy-path output, not the end state.

## What is NOT in this PR
- No schema change.
- No change to `publishApprovedSignals` (the slate publish gate).
- No change to `saveSignalDraft` (already preserves status=`published` for live cards — verified).
- No code mutation of any live row. Operator action through the corrected flow remains the path to fix any stale row content.

## Test plan
- [ ] CI green
- [ ] BM post-deploy: open a live published card whose depth layers need an update, type into the new textareas, click **Re-publish live card**. Verify `select editorial_status, published_what_led_to_it, published_what_it_connects_to, previous_published_snapshot from signal_posts where id='…'` shows `status='published'`, depth columns reflect the typed content, snapshot captures the prior values. Verify the card stays on the public homepage.
- [ ] Visual: confirm the foldback renders the updated depth content.

## Lineage
- **Closes:** #282.
- **Direct regression on:** #280 / PR #281 (the original re-publish feature). The atomic-update shape was correct; the fix is about WHERE the depth content reads from (now: form input) and a UI guard against the wrong-button footgun.
- **Related PRs:**
  - **#275** (three-layer publish pipeline) — established the `edited_* → published_*` promotion shape that this PR extends to also accept form inputs.
  - **#277** (foldback three-layer cleanup) — the render surface that highlighted depth-layer absence in prod (cards rendered the depth empty-state strings).
  - **#279** (citation marker strip) — public render also passes re-published text through this strip.
  - **#273** (WITM validator false-positives) — still the gate `republishLiveSignalPost` calls; unchanged in this PR.
- **PRDs referenced:** PRD-66 (three-layer pipeline), PRD-67 (re-publish live card — this PR's regression is on PRD-67's implementation).
- **Surfaced by:** 2026-05-24/25 prod observation — re-published cards landed with `status='approved'` and depth `published_*` NULL, vanishing from the public homepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)