### PR TITLE
perf(sentry): defer Session Replay out of the homepage render-blocking window

### DIFF
--- a/docs/engineering/bug-fixes/homepage-render-blocking-sentry-replay-2026-06-04.md
+++ b/docs/engineering/bug-fixes/homepage-render-blocking-sentry-replay-2026-06-04.md
@@ -1,0 +1,34 @@
+# Homepage Render-Blocking Sentry Replay — Bug-Fix Record
+
+- **Related PRD:** None (cross-cutting client-performance fix; not owned by a single feature PRD)
+- **Date:** 2026-06-04
+- **Affected object level:** Public homepage (`/`) client render path; all public routes share the client instrumentation hook.
+
+## Summary
+
+- **Problem addressed:** Field Core Web Vitals on `/` regressed to **FCP 3.92s / LCP 5.91s** (Vercel Speed Insights, RES 60) despite a healthy **TTFB of 0.16s** — i.e. the server responds fast and the cost is render-blocking client JS, not the backend. The lab perf gate (`scripts/release/verify-performance.mjs`) reported LCP ~1.4s and stayed green because it runs an unthrottled desktop-class headless browser, so it never saw the device-class regression.
+- **Root cause (this fix's slice):** `src/instrumentation-client.ts` initialized Sentry **synchronously** at client-instrumentation load with the heavy `replayIntegration` in the `Sentry.init({ integrations: [...] })` array. Session Replay's instantiation and recording start are real synchronous main-thread work, and they ran **inside the render-blocking window before First Contentful Paint** on every page load. On mid-tier devices this measurably delayed FCP/LCP. (The May 24 foldback-v2 hydration weight is a separate, larger contributor addressed in a follow-up PR; this record covers only the Sentry-replay slice.)
+
+## Fix
+
+Apply PR #233's existing analytics-defer pattern (the 3000ms PostHog deferral) to Sentry:
+
+- **Sentry core stays synchronous.** `Sentry.init` still runs at instrumentation load with `dsn`, `beforeSend`/`beforeBreadcrumb` sanitizers, trace sampling, and replay sample rates unchanged — error/exception/trace capture is active from t=0 and is not affected.
+- **Replay is attached after first paint.** A new `scheduleDeferredSentryReplay(attach, opts)` helper in `src/lib/sentry-config.ts` runs the replay attachment on the first `requestIdleCallback` (3000ms `setTimeout` fallback, matching PostHog). `instrumentation-client.ts` now calls `Sentry.addIntegration(Sentry.replayIntegration({...}))` inside that deferred callback instead of listing it in `Sentry.init`.
+- The helper is injectable (`schedule`, `onError`) and unit-tested in `src/lib/sentry-config.test.ts`: the attach callback does not run synchronously, runs once scheduled, and any failure is swallowed so replay can never break error capture or the app.
+
+### Honest scope note
+
+Replay **bytes** remain in the shared client chunk (`main-*.js`, ~587 KB, unchanged). The synchronous `onRouterTransitionStart` export forces a static `import * as Sentry from "@sentry/nextjs"`, and a dynamic import of the same module resolves to that same chunk — so replay cannot be code-split out without breaking that export. The realized win is removing replay's synchronous **execution** from the pre-paint window, which is the cost the field regression attributed to it. Quantitative FCP/LCP confirmation comes from the throttled perf gate (separate follow-up PR) and post-deploy field RES recovery.
+
+## Verification
+
+- `scheduleDeferredSentryReplay` unit tests (3) pass.
+- Full vitest suite green; lint clean; production build green.
+- Build inspection: `main-*.js` size unchanged before/after (586,841 → 587,172 bytes), confirming the change is execution-deferral, not a bundle delta.
+- Error capture intact by construction: `Sentry.init` is byte-for-byte equivalent minus the `integrations` array; replay sample-rate config is preserved.
+
+## Non-Goals
+
+- Does NOT collapse homepage signal cards. Cards remain SSR-rendered and visually expanded by default (locked product decision). This PR does not touch `SignalCard.tsx`.
+- Does NOT address the foldback-v2 hydration weight or the unthrottled perf gate — those are separate PRs in the same remediation series.

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -10,11 +10,18 @@ import {
   readSentryTracesSampleRate,
   sanitizeBreadcrumb,
   sanitizeSentryEvent,
+  scheduleDeferredSentryReplay,
 } from "@/lib/sentry-config";
 
 const dsn = readSentryDsn("client");
 
 if (dsn) {
+  // Sentry CORE initializes synchronously so error/exception/trace capture is
+  // active from the very first moment of page load. The heavy Session Replay
+  // integration is intentionally NOT listed here — it previously ran inside the
+  // render-blocking window before First Contentful Paint. Replay is now attached
+  // after first paint via scheduleDeferredSentryReplay(). See
+  // src/lib/sentry-replay.ts. [perf: defer-sentry]
   Sentry.init({
     dsn,
     environment: readSentryEnvironment(),
@@ -23,13 +30,6 @@ if (dsn) {
     tracesSampleRate: readSentryTracesSampleRate(),
     enableLogs: true,
     maxBreadcrumbs: 50,
-    integrations: [
-      Sentry.replayIntegration({
-        maskAllText: true,
-        maskAllInputs: true,
-        blockAllMedia: true,
-      }),
-    ],
     replaysSessionSampleRate: readSentryReplaysSessionSampleRate(),
     replaysOnErrorSampleRate: readSentryReplaysOnErrorSampleRate(),
     beforeSend(event) {
@@ -38,6 +38,18 @@ if (dsn) {
     beforeBreadcrumb(breadcrumb) {
       return sanitizeBreadcrumb(breadcrumb);
     },
+  });
+
+  // Attach Session Replay after first paint instead of synchronously, keeping
+  // its instantiation + recording start out of the FCP/LCP window.
+  scheduleDeferredSentryReplay(() => {
+    Sentry.addIntegration(
+      Sentry.replayIntegration({
+        maskAllText: true,
+        maskAllInputs: true,
+        blockAllMedia: true,
+      }),
+    );
   });
 }
 

--- a/src/lib/sentry-config.test.ts
+++ b/src/lib/sentry-config.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 function clearSentryEnv() {
   delete process.env.SENTRY_DSN;
@@ -100,5 +100,55 @@ describe("isFilteredRssNoiseEvent (PRD-65 Phase 4.5)", () => {
     expect(isFilteredRssNoiseEvent(undefined)).toBe(false);
     expect(isFilteredRssNoiseEvent({})).toBe(false);
     expect(isFilteredRssNoiseEvent({ exception: { values: [{}] } })).toBe(false);
+  });
+});
+
+describe("scheduleDeferredSentryReplay", () => {
+  it("does NOT run the attach callback synchronously — only after the schedule fires", async () => {
+    const { scheduleDeferredSentryReplay } = await import("@/lib/sentry-config");
+    const attach = vi.fn();
+    let scheduled: (() => void) | null = null;
+    const schedule = (cb: () => void) => {
+      scheduled = cb;
+      return () => {};
+    };
+
+    scheduleDeferredSentryReplay(attach, { schedule });
+
+    // The whole point: replay setup must not touch the main thread before paint.
+    expect(attach).not.toHaveBeenCalled();
+    expect(scheduled).toBeTypeOf("function");
+  });
+
+  it("runs the attach callback once the scheduled callback fires", async () => {
+    const { scheduleDeferredSentryReplay } = await import("@/lib/sentry-config");
+    const attach = vi.fn();
+    let scheduled: (() => void) | null = null;
+    const schedule = (cb: () => void) => {
+      scheduled = cb;
+      return () => {};
+    };
+
+    scheduleDeferredSentryReplay(attach, { schedule });
+    scheduled!();
+
+    expect(attach).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows attach failures so replay never breaks error capture or the app", async () => {
+    const { scheduleDeferredSentryReplay } = await import("@/lib/sentry-config");
+    const attach = vi.fn(() => {
+      throw new Error("replay attach failed");
+    });
+    const onError = vi.fn();
+    let scheduled: (() => void) | null = null;
+    const schedule = (cb: () => void) => {
+      scheduled = cb;
+      return () => {};
+    };
+
+    scheduleDeferredSentryReplay(attach, { schedule, onError });
+    expect(() => scheduled!()).not.toThrow();
+    expect(onError).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/sentry-config.ts
+++ b/src/lib/sentry-config.ts
@@ -83,6 +83,68 @@ export function readSentryReplaysOnErrorSampleRate() {
   return readSampleRate("SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE", DEFAULT_REPLAYS_ON_ERROR_SAMPLE_RATE);
 }
 
+export const SENTRY_REPLAY_DEFER_MS = 3000;
+
+type ScheduleFn = (callback: () => void) => () => void;
+
+/**
+ * Defer Sentry Session Replay attachment out of the render-blocking window.
+ *
+ * Replay is the heaviest Sentry integration: instantiating `replayIntegration()`
+ * and starting its recording machinery is real synchronous main-thread work.
+ * Previously it was passed to `Sentry.init({ integrations: [replayIntegration()] })`
+ * in `instrumentation-client.ts`, which runs at client-instrumentation load —
+ * inside the render-blocking window before First Contentful Paint. On mid-tier
+ * devices that synchronous setup measurably delayed FCP/LCP.
+ *
+ * This runs `attach` AFTER first paint (first idle callback, or a 3000ms
+ * fallback mirroring the existing PostHog defer), so replay setup never runs
+ * before the page is interactive. Sentry core still initializes synchronously,
+ * so error/exception/trace capture is unaffected — only the replay recording
+ * attachment is delayed by a few seconds.
+ *
+ * `schedule` is injectable for unit testing; `onError` keeps replay best-effort.
+ * Returns a cancel function (used by tests; harmless in production).
+ */
+export function scheduleDeferredSentryReplay(
+  attach: () => void,
+  options: { schedule?: ScheduleFn; onError?: (error: unknown) => void } = {},
+): () => void {
+  const schedule = options.schedule ?? defaultReplaySchedule;
+  const onError = options.onError ?? (() => {});
+
+  return schedule(() => {
+    try {
+      attach();
+    } catch (error) {
+      onError(error);
+    }
+  });
+}
+
+const defaultReplaySchedule: ScheduleFn = (callback) => {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  const idle = (
+    window as unknown as {
+      requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+      cancelIdleCallback?: (handle: number) => void;
+    }
+  ).requestIdleCallback;
+
+  if (typeof idle === "function") {
+    const handle = idle(callback, { timeout: SENTRY_REPLAY_DEFER_MS + 2000 });
+    return () => {
+      (window as unknown as { cancelIdleCallback?: (h: number) => void }).cancelIdleCallback?.(handle);
+    };
+  }
+
+  const timer = window.setTimeout(callback, SENTRY_REPLAY_DEFER_MS);
+  return () => window.clearTimeout(timer);
+};
+
 export function sanitizeUrl(value: string) {
   const trimmed = value.trim();
 


### PR DESCRIPTION
## PR 1 of 3 — homepage render-blocking regression remediation

Field Core Web Vitals on `/` regressed to **FCP 3.92s / LCP 5.91s** (Speed Insights, RES 60) while **TTFB is 0.16s** — the server is fast; the cost is render-blocking client JS. This is the first of three separate fixes.

### What this PR does

`src/instrumentation-client.ts` initialized Sentry **synchronously** with the heavy `replayIntegration` in the `Sentry.init({ integrations: [...] })` array, so Session Replay's instantiation + recording start ran **before First Contentful Paint** on every page.

This applies PR #233's analytics-defer pattern to Sentry:

- **Sentry core stays synchronous** — `Sentry.init` keeps `dsn`, `beforeSend`/`beforeBreadcrumb` sanitizers, trace sampling, and replay sample rates unchanged. **Error/exception/trace capture is active from t=0 and unaffected.**
- **Replay attaches after first paint** — new `scheduleDeferredSentryReplay()` in `src/lib/sentry-config.ts` runs the attach on the first `requestIdleCallback` (3000ms fallback, the same delay PostHog uses). `instrumentation-client.ts` calls `Sentry.addIntegration(Sentry.replayIntegration({...}))` inside that deferred callback.

### Before / after

| | Before | After |
|---|---|---|
| Replay instantiation + recording start | **synchronous, pre-FCP**, in `Sentry.init` | **deferred to first idle / 3000ms after paint** |
| Sentry core error capture | synchronous | synchronous (unchanged) |
| `main-*.js` size | 586,841 B | 587,172 B (≈unchanged) |

**Honest scope note:** replay **bytes** stay in the shared `main-*.js` chunk. The synchronous `onRouterTransitionStart` export forces a static `import * as Sentry from "@sentry/nextjs"`, and a dynamic import of the same module resolves to that same chunk — replay can't be code-split out without breaking that export. The realized win is removing replay's synchronous **execution** from the pre-paint window (the cost the field regression attributed to it). Quantitative LCP confirmation comes from PR 3's throttled gate + post-deploy field RES.

### Constraint compliance

- **Cards remain SSR-expanded.** This PR does not touch `SignalCard.tsx` or any render output. No collapse, no flash, no CLS change.
- No new module/system surface — the helper lives in the existing `sentry-config.ts`.

### Validation

- `scheduleDeferredSentryReplay` unit tests (3): attach not run synchronously; runs once scheduled; failures swallowed so replay never breaks error capture.
- Full vitest suite green; lint clean; production build green.
- `release-governance-gate` passes locally (bug-fix lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)