### PR TITLE
fix(observability): Sentry-capture pipeline-log + source-health-log no-ops (#291)

### DIFF
--- a/docs/engineering/bug-fixes/log-writers-sentry-on-drift-2026-06-03.md
+++ b/docs/engineering/bug-fixes/log-writers-sentry-on-drift-2026-06-03.md
@@ -1,0 +1,39 @@
+# Log Writers Dark Without Sentry Signal — Bug-Fix Record
+
+## Summary
+- **Problem addressed:** `src/lib/observability/pipeline-log.ts` and `src/lib/observability/source-health-log.ts` emit only `logServerEvent("warn", ...)` when env vars drift off the Vercel Production scope, returning `{ written: false, reason }` and continuing. A `warn`-level log is not pageable; observability degrading to silence is invisible until the next manual review. Notion Pipeline Log + Source Health Log were both empty across the 2026-05-22 → 2026-06-03 audit window with no Sentry signal.
+- **Root cause:** Missing pageable signal on writer no-op. Writers are correct code; their failure contract was too quiet for an observability surface.
+- **Affected object level:** Observability infrastructure.
+- **Related issue:** #291. Track 2 P2.
+
+## Fix
+Both writers now also call `Sentry.captureMessage(...)` (or `captureException` on a thrown error) at `warning` level on EVERY no-op path:
+- env missing (DB ID or token)
+- Notion HTTP non-2xx
+- Notion response missing `id`
+- thrown error
+
+Each call carries a stable `fingerprint: [<writer-tag>, <reason>]` so Sentry groups all 38 per-source no-ops in a single day into ONE issue, not 38. Tags include `observability_surface` (`"pipeline_log"` / `"source_health_log"`) and `writer_noop_reason` for fast filtering.
+
+Successful writes do NOT capture (no false alarms).
+
+## Tests
+- `src/lib/observability/pipeline-log.test.ts` (NEW): 5 tests — env-missing, token-missing, HTTP non-2xx, fetch throws, success path captures nothing.
+- `src/lib/observability/source-health-log.test.ts` (NEW): 3 tests — env-missing, fingerprint-dedup across 3 sources, success path captures nothing.
+
+Full suite: 850/850 passed across 105 files (+8 from previous baseline). `npm run build` green.
+
+## Why production didn't catch this earlier
+The writers themselves were correct — they returned the right `{ written: false }` result and a `warn` log. But a `warn` log is the wrong tier for an observability surface going dark. By the time we noticed, multiple weeks of operational history were missing.
+
+## Operator follow-up (post-deploy)
+- Verify next cron run produces:
+  - One Pipeline Log row in Notion (after BM confirms `NOTION_PIPELINE_LOG_DB_ID` + `NOTION_TOKEN` are set on Vercel Production scope).
+  - 38 Source Health Log rows (or PATCHes), one per RSS source (after BM confirms `NOTION_SOURCE_HEALTH_LOG_DB_ID` is set).
+- If env drifts again in the future, a Sentry `warning` issue grouped by reason fires within minutes of the next cron tick.
+
+## Not addressed by this fix
+- Setting / verifying the env vars on Vercel Production — BM action.
+- The P1 cron success boolean fix (separate PR #290).
+- P3 per-call timeout on Gmail fetch (separate PR).
+- Renaming `NOTION_SOURCE_HEALTH_LOG_DB_ID` if BM prefers a different convention; the code reads what it reads.

--- a/src/lib/observability/pipeline-log.test.ts
+++ b/src/lib/observability/pipeline-log.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sentryCaptureMessage = vi.fn();
+const sentryCaptureException = vi.fn();
+
+vi.mock("@sentry/nextjs", () => ({
+  captureMessage: sentryCaptureMessage,
+  captureException: sentryCaptureException,
+}));
+
+vi.mock("@/lib/observability", () => ({
+  // Avoid Sentry init imports inside `@/lib/observability/index`.
+  logServerEvent: vi.fn(),
+  errorContext: (error: unknown) => ({
+    errorMessage: error instanceof Error ? error.message : String(error),
+  }),
+}));
+
+describe("writePipelineLogEntry — observability hygiene (#272 P2)", () => {
+  const originalFetch = globalThis.fetch;
+  const originalDbId = process.env.NOTION_PIPELINE_LOG_DB_ID;
+  const originalToken = process.env.NOTION_TOKEN;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    delete process.env.NOTION_PIPELINE_LOG_DB_ID;
+    delete process.env.NOTION_TOKEN;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalDbId === undefined) delete process.env.NOTION_PIPELINE_LOG_DB_ID;
+    else process.env.NOTION_PIPELINE_LOG_DB_ID = originalDbId;
+    if (originalToken === undefined) delete process.env.NOTION_TOKEN;
+    else process.env.NOTION_TOKEN = originalToken;
+  });
+
+  const entry = {
+    runType: "ingestion" as const,
+    status: "ok" as const,
+    rowCount: 7,
+    message: "Ingestion completed: RSS=ok",
+    briefingDate: "2026-06-03",
+  };
+
+  it("captures a Sentry message when NOTION_PIPELINE_LOG_DB_ID is missing", async () => {
+    const { writePipelineLogEntry } = await import("@/lib/observability/pipeline-log");
+
+    const result = await writePipelineLogEntry(entry);
+
+    expect(result).toEqual({
+      written: false,
+      reason: "NOTION_PIPELINE_LOG_DB_ID not configured",
+    });
+    expect(sentryCaptureMessage).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureMessage).toHaveBeenCalledWith(
+      "Pipeline log writer no-op",
+      expect.objectContaining({
+        level: "warning",
+        fingerprint: ["pipeline-log-writer-noop", "NOTION_PIPELINE_LOG_DB_ID not configured"],
+        tags: expect.objectContaining({
+          observability_surface: "pipeline_log",
+          writer_noop_reason: "NOTION_PIPELINE_LOG_DB_ID not configured",
+        }),
+      }),
+    );
+  });
+
+  it("captures a Sentry message when NOTION_TOKEN is missing", async () => {
+    process.env.NOTION_PIPELINE_LOG_DB_ID = "db-id";
+
+    const { writePipelineLogEntry } = await import("@/lib/observability/pipeline-log");
+    const result = await writePipelineLogEntry(entry);
+
+    expect(result).toEqual({
+      written: false,
+      reason: "NOTION_TOKEN not configured",
+    });
+    expect(sentryCaptureMessage).toHaveBeenCalledWith(
+      "Pipeline log writer no-op",
+      expect.objectContaining({
+        fingerprint: ["pipeline-log-writer-noop", "NOTION_TOKEN not configured"],
+      }),
+    );
+  });
+
+  it("captures a Sentry message when Notion returns a non-2xx response", async () => {
+    process.env.NOTION_PIPELINE_LOG_DB_ID = "db-id";
+    process.env.NOTION_TOKEN = "tok";
+    globalThis.fetch = vi.fn(async () =>
+      new Response("{ \"object\": \"error\" }", { status: 403 }),
+    ) as typeof fetch;
+
+    const { writePipelineLogEntry } = await import("@/lib/observability/pipeline-log");
+    const result = await writePipelineLogEntry(entry);
+
+    expect(result.written).toBe(false);
+    if (!result.written) expect(result.reason).toBe("HTTP 403");
+    expect(sentryCaptureMessage).toHaveBeenCalledWith(
+      "Pipeline log writer no-op",
+      expect.objectContaining({
+        fingerprint: ["pipeline-log-writer-noop", "HTTP 403"],
+      }),
+    );
+  });
+
+  it("captures a Sentry exception when fetch throws", async () => {
+    process.env.NOTION_PIPELINE_LOG_DB_ID = "db-id";
+    process.env.NOTION_TOKEN = "tok";
+    const networkError = new Error("network unreachable");
+    globalThis.fetch = vi.fn(async () => {
+      throw networkError;
+    }) as typeof fetch;
+
+    const { writePipelineLogEntry } = await import("@/lib/observability/pipeline-log");
+    const result = await writePipelineLogEntry(entry);
+
+    expect(result.written).toBe(false);
+    if (!result.written) expect(result.reason).toBe("network unreachable");
+    expect(sentryCaptureException).toHaveBeenCalledWith(
+      networkError,
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          observability_surface: "pipeline_log",
+          writer_noop_reason: "threw",
+        }),
+      }),
+    );
+  });
+
+  it("does NOT capture Sentry when the write succeeds (no false alarms)", async () => {
+    process.env.NOTION_PIPELINE_LOG_DB_ID = "db-id";
+    process.env.NOTION_TOKEN = "tok";
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ id: "page-1" }), { status: 200 }),
+    ) as typeof fetch;
+
+    const { writePipelineLogEntry } = await import("@/lib/observability/pipeline-log");
+    const result = await writePipelineLogEntry(entry);
+
+    expect(result).toEqual({ written: true, pageId: "page-1" });
+    expect(sentryCaptureMessage).not.toHaveBeenCalled();
+    expect(sentryCaptureException).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/observability/pipeline-log.ts
+++ b/src/lib/observability/pipeline-log.ts
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/nextjs";
+
 import { errorContext, logServerEvent } from "@/lib/observability";
 
 /**
@@ -49,27 +51,62 @@ function richText(content: string) {
   return [{ text: { content } }];
 }
 
+/**
+ * Capture a Sentry message for a writer no-op. Track 2 P2: the legacy
+ * `warn`-only path went dark on prod when log env vars drifted off the
+ * Production scope on Vercel — there was no pageable signal that
+ * observability had stopped working. A Sentry message at `warning`
+ * level surfaces silent observability loss without paging.
+ *
+ * Deduped by fingerprint per reason so a missing env var produces one
+ * Sentry issue, not one per cron run. The `extra` payload carries the
+ * specific reason + run metadata for the issue body.
+ */
+function captureWriterNoop(reason: string, extra: Record<string, unknown>) {
+  Sentry.captureMessage("Pipeline log writer no-op", {
+    level: "warning",
+    fingerprint: ["pipeline-log-writer-noop", reason],
+    tags: {
+      observability_surface: "pipeline_log",
+      writer_noop_reason: reason,
+    },
+    extra,
+  });
+}
+
 export async function writePipelineLogEntry(
   entry: PipelineLogEntry,
 ): Promise<PipelineLogWriteResult> {
   const dbId = process.env.NOTION_PIPELINE_LOG_DB_ID?.trim();
   if (!dbId) {
+    const reason = "NOTION_PIPELINE_LOG_DB_ID not configured";
     logServerEvent("warn", "Pipeline log skipped: NOTION_PIPELINE_LOG_DB_ID not configured", {
       runType: entry.runType,
       status: entry.status,
       briefingDate: entry.briefingDate,
     });
-    return { written: false, reason: "NOTION_PIPELINE_LOG_DB_ID not configured" };
+    captureWriterNoop(reason, {
+      runType: entry.runType,
+      status: entry.status,
+      briefingDate: entry.briefingDate,
+    });
+    return { written: false, reason };
   }
 
   const token = process.env.NOTION_TOKEN?.trim();
   if (!token) {
+    const reason = "NOTION_TOKEN not configured";
     logServerEvent("warn", "Pipeline log skipped: NOTION_TOKEN not configured", {
       runType: entry.runType,
       status: entry.status,
       briefingDate: entry.briefingDate,
     });
-    return { written: false, reason: "NOTION_TOKEN not configured" };
+    captureWriterNoop(reason, {
+      runType: entry.runType,
+      status: entry.status,
+      briefingDate: entry.briefingDate,
+    });
+    return { written: false, reason };
   }
 
   const sourceHealth =
@@ -104,6 +141,7 @@ export async function writePipelineLogEntry(
 
     if (!response.ok) {
       const text = await response.text().catch(() => "(no body)");
+      const reason = `HTTP ${response.status}`;
       logServerEvent("warn", "Pipeline log write failed", {
         runType: entry.runType,
         status: entry.status,
@@ -111,23 +149,46 @@ export async function writePipelineLogEntry(
         httpStatus: response.status,
         body: truncate(text, 400),
       });
-      return { written: false, reason: `HTTP ${response.status}` };
+      captureWriterNoop(reason, {
+        runType: entry.runType,
+        status: entry.status,
+        briefingDate: entry.briefingDate,
+        httpStatus: response.status,
+        body: truncate(text, 400),
+      });
+      return { written: false, reason };
     }
 
     const data = (await response.json().catch(() => ({}))) as { id?: string };
-    return data.id
-      ? { written: true, pageId: data.id }
-      : { written: false, reason: "Notion response missing id" };
+    if (data.id) {
+      return { written: true, pageId: data.id };
+    }
+    const reason = "Notion response missing id";
+    captureWriterNoop(reason, {
+      runType: entry.runType,
+      status: entry.status,
+      briefingDate: entry.briefingDate,
+    });
+    return { written: false, reason };
   } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
     logServerEvent("warn", "Pipeline log write threw", {
       runType: entry.runType,
       status: entry.status,
       briefingDate: entry.briefingDate,
       ...errorContext(error),
     });
-    return {
-      written: false,
-      reason: error instanceof Error ? error.message : String(error),
-    };
+    Sentry.captureException(error, {
+      tags: {
+        observability_surface: "pipeline_log",
+        writer_noop_reason: "threw",
+      },
+      extra: {
+        runType: entry.runType,
+        status: entry.status,
+        briefingDate: entry.briefingDate,
+      },
+    });
+    return { written: false, reason };
   }
 }

--- a/src/lib/observability/source-health-log.test.ts
+++ b/src/lib/observability/source-health-log.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sentryCaptureMessage = vi.fn();
+const sentryCaptureException = vi.fn();
+
+vi.mock("@sentry/nextjs", () => ({
+  captureMessage: sentryCaptureMessage,
+  captureException: sentryCaptureException,
+}));
+
+vi.mock("@/lib/observability", () => ({
+  logServerEvent: vi.fn(),
+  errorContext: (error: unknown) => ({
+    errorMessage: error instanceof Error ? error.message : String(error),
+  }),
+}));
+
+describe("writeSourceHealthEntry — observability hygiene (#272 P2)", () => {
+  const originalFetch = globalThis.fetch;
+  const originalDbId = process.env.NOTION_SOURCE_HEALTH_LOG_DB_ID;
+  const originalToken = process.env.NOTION_TOKEN;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    delete process.env.NOTION_SOURCE_HEALTH_LOG_DB_ID;
+    delete process.env.NOTION_TOKEN;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalDbId === undefined) delete process.env.NOTION_SOURCE_HEALTH_LOG_DB_ID;
+    else process.env.NOTION_SOURCE_HEALTH_LOG_DB_ID = originalDbId;
+    if (originalToken === undefined) delete process.env.NOTION_TOKEN;
+    else process.env.NOTION_TOKEN = originalToken;
+  });
+
+  const entry = {
+    source: "Reuters Politics",
+    date: "2026-06-03",
+    outcome: "success" as const,
+    lastSuccessfulFetchAt: "2026-06-03T12:00:00.000Z",
+  };
+
+  it("captures a Sentry message when env is not configured (deduped by reason)", async () => {
+    const { writeSourceHealthEntry } = await import("@/lib/observability/source-health-log");
+
+    const result = await writeSourceHealthEntry(entry);
+
+    expect(result).toEqual({
+      written: false,
+      reason: "NOTION_SOURCE_HEALTH_LOG_DB_ID not configured",
+    });
+    expect(sentryCaptureMessage).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureMessage).toHaveBeenCalledWith(
+      "Source health log writer no-op",
+      expect.objectContaining({
+        level: "warning",
+        fingerprint: [
+          "source-health-log-writer-noop",
+          "NOTION_SOURCE_HEALTH_LOG_DB_ID not configured",
+        ],
+        tags: expect.objectContaining({
+          observability_surface: "source_health_log",
+        }),
+      }),
+    );
+  });
+
+  it("captures Sentry once per reason across multiple sources (fingerprint dedup)", async () => {
+    const { writeSourceHealthEntry } = await import("@/lib/observability/source-health-log");
+
+    await writeSourceHealthEntry({ ...entry, source: "Reuters Politics" });
+    await writeSourceHealthEntry({ ...entry, source: "Axios Tech" });
+    await writeSourceHealthEntry({ ...entry, source: "Semafor" });
+
+    // The fingerprint dedup happens server-side at Sentry — but the *call*
+    // happens once per writer invocation. We assert all three captures
+    // carry the same fingerprint so Sentry can group them, not three
+    // distinct issues.
+    expect(sentryCaptureMessage).toHaveBeenCalledTimes(3);
+    const fingerprints = sentryCaptureMessage.mock.calls.map((c) => c[1]?.fingerprint);
+    expect(new Set(fingerprints.map((f) => JSON.stringify(f))).size).toBe(1);
+  });
+
+  it("does NOT capture Sentry when the write succeeds", async () => {
+    process.env.NOTION_SOURCE_HEALTH_LOG_DB_ID = "db-id";
+    process.env.NOTION_TOKEN = "tok";
+    // First fetch = findExistingRow query (return empty). Second = create POST.
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ results: [] }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: "page-1" }), { status: 200 }),
+      ) as typeof fetch;
+
+    const { writeSourceHealthEntry } = await import("@/lib/observability/source-health-log");
+    const result = await writeSourceHealthEntry(entry);
+
+    expect(result).toEqual({ written: true, pageId: "page-1", action: "inserted" });
+    expect(sentryCaptureMessage).not.toHaveBeenCalled();
+    expect(sentryCaptureException).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/observability/source-health-log.ts
+++ b/src/lib/observability/source-health-log.ts
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/nextjs";
+
 import { errorContext, logServerEvent } from "@/lib/observability";
 
 /**
@@ -171,6 +173,23 @@ function buildProperties(
   return properties;
 }
 
+/**
+ * Track 2 P2 — Sentry signal when the source-health writer no-ops.
+ * Deduped per reason so a missing env var produces one Sentry issue
+ * across the entire run, not one per source fetched (38 sources/day).
+ */
+function captureSourceHealthNoop(reason: string, extra: Record<string, unknown>) {
+  Sentry.captureMessage("Source health log writer no-op", {
+    level: "warning",
+    fingerprint: ["source-health-log-writer-noop", reason],
+    tags: {
+      observability_surface: "source_health_log",
+      writer_noop_reason: reason,
+    },
+    extra,
+  });
+}
+
 export async function writeSourceHealthEntry(
   entry: SourceHealthEntry,
 ): Promise<SourceHealthWriteResult> {
@@ -178,6 +197,11 @@ export async function writeSourceHealthEntry(
   if (!env.ok) {
     logServerEvent("warn", "Source health log skipped: env not configured", {
       reason: env.reason,
+      source: entry.source,
+      date: entry.date,
+      outcome: entry.outcome,
+    });
+    captureSourceHealthNoop(env.reason, {
       source: entry.source,
       date: entry.date,
       outcome: entry.outcome,
@@ -202,6 +226,7 @@ export async function writeSourceHealthEntry(
       });
       if (!response.ok) {
         const text = await response.text().catch(() => "(no body)");
+        const reason = `HTTP ${response.status}`;
         logServerEvent("warn", "Source health log update failed", {
           source: entry.source,
           date: entry.date,
@@ -209,7 +234,14 @@ export async function writeSourceHealthEntry(
           httpStatus: response.status,
           body: truncate(text, 400),
         });
-        return { written: false, reason: `HTTP ${response.status}` };
+        captureSourceHealthNoop(reason, {
+          source: entry.source,
+          date: entry.date,
+          pageId: existing.pageId,
+          httpStatus: response.status,
+          body: truncate(text, 400),
+        });
+        return { written: false, reason };
       }
       return { written: true, pageId: existing.pageId, action: "updated" };
     }
@@ -228,24 +260,48 @@ export async function writeSourceHealthEntry(
     });
     if (!response.ok) {
       const text = await response.text().catch(() => "(no body)");
+      const reason = `HTTP ${response.status}`;
       logServerEvent("warn", "Source health log create failed", {
         source: entry.source,
         date: entry.date,
         httpStatus: response.status,
         body: truncate(text, 400),
       });
-      return { written: false, reason: `HTTP ${response.status}` };
+      captureSourceHealthNoop(reason, {
+        source: entry.source,
+        date: entry.date,
+        httpStatus: response.status,
+        body: truncate(text, 400),
+      });
+      return { written: false, reason };
     }
     const data = (await response.json().catch(() => ({}))) as { id?: string };
-    return data.id
-      ? { written: true, pageId: data.id, action: "inserted" }
-      : { written: false, reason: "Notion response missing id" };
+    if (data.id) {
+      return { written: true, pageId: data.id, action: "inserted" };
+    }
+    const reason = "Notion response missing id";
+    captureSourceHealthNoop(reason, {
+      source: entry.source,
+      date: entry.date,
+    });
+    return { written: false, reason };
   } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
     logServerEvent("warn", "Source health log write threw", {
       source: entry.source,
       date: entry.date,
       ...errorContext(error),
     });
-    return { written: false, reason: error instanceof Error ? error.message : String(error) };
+    Sentry.captureException(error, {
+      tags: {
+        observability_surface: "source_health_log",
+        writer_noop_reason: "threw",
+      },
+      extra: {
+        source: entry.source,
+        date: entry.date,
+      },
+    });
+    return { written: false, reason };
   }
 }


### PR DESCRIPTION
**Track 2 Priority 2 — branch-only, do NOT merge without BM sign-off.**

Closes #291.

## What
Notion Pipeline Log + Source Health Log have been empty across the 2026-05-22 → 2026-06-03 audit window with NO Sentry signal. The writers correctly returned `{ written: false, reason }` and emitted a `warn`-level log — but `warn` is not pageable, and an observability surface going dark is invisible until the next manual review.

This PR adds Sentry capture on EVERY writer no-op path.

## Diff
**Both writers** (`pipeline-log.ts`, `source-health-log.ts`) now call `Sentry.captureMessage(...)` (or `captureException` on a thrown error) at `warning` level on EVERY no-op path:
- env missing (DB ID or token)
- Notion HTTP non-2xx
- Notion response missing `id`
- thrown error

Each call carries a stable `fingerprint: [<writer-tag>, <reason>]` so Sentry groups all per-source no-ops in a single day into ONE issue. Tags include `observability_surface` (`"pipeline_log"` / `"source_health_log"`) and `writer_noop_reason` for fast filtering.

**Successful writes do NOT capture.** No false alarms.

## Tests (+8)
- `pipeline-log.test.ts` (NEW): 5 tests — env-missing, token-missing, HTTP non-2xx, fetch throws, success path captures nothing.
- `source-health-log.test.ts` (NEW): 3 tests — env-missing, fingerprint-dedup across 3 sources, success path captures nothing.

**Full suite: 850/850 passed across 105 files** (+8 from P1's 842). `npm run build` green.

## Verification (post-deploy, what I'd run)
- Before BM env-applies: next cron tick produces ONE Sentry `warning` issue per writer + reason (1 for Pipeline Log `NOTION_PIPELINE_LOG_DB_ID not configured`, 1 for Source Health Log fingerprint covering 38 sources).
- After BM env-applies: zero new Sentry issues at next cron tick; one Pipeline Log row appears in Notion + N Source Health rows.

## What is NOT in this PR
- Setting / verifying the env vars on Vercel Production — BM action. Names to verify (from `process.env` reads in code):
  - `NOTION_PIPELINE_LOG_DB_ID`
  - `NOTION_SOURCE_HEALTH_LOG_DB_ID` (note `_LOG_` — the earlier env-name mismatch was missing this segment)
  - `NOTION_TOKEN`
- P1 cron success boolean (PR #290).
- P3 per-call timeout on Gmail fetch (separate).
- P4 cross-date Notion dedup (separate).
- P5 kill orphan endpoints (separate).
- P6 source-diversity gate on `/api/cron/health` (separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)