### PR TITLE
fix(newsletter): 10s per-call timeout on Gmail fetch (#293)

### DIFF
--- a/docs/engineering/bug-fixes/newsletter-gmail-per-call-timeout-2026-06-03.md
+++ b/docs/engineering/bug-fixes/newsletter-gmail-per-call-timeout-2026-06-03.md
@@ -1,0 +1,32 @@
+# Gmail Fetch Has No Per-Call Timeout — Bug-Fix Record
+
+## Summary
+- **Problem addressed:** `cron_runs` duration drifted 25s → 55s through late May / early June; June 1 hit the 55.4s internal timeout. Newsletter source died on 2026-05-18 (likely Gmail OAuth refresh token expiry). The Gmail client had no per-call timeout — every HTTP call (OAuth refresh + API) was at the mercy of the outer 55s wall, and retries × multiple calls compounded.
+- **Root cause:** `src/lib/newsletter-ingestion/gmail.ts` called `fetchImpl(...)` without an `AbortSignal` in two places: `getGmailAccessToken` (OAuth refresh) and `gmailFetchJson` (all API calls).
+- **Affected object level:** Cron pipeline runtime envelope.
+- **Related issue:** #293. Track 2 P3.
+
+## Fix
+New `fetchWithTimeout(fetchImpl, url, init, failureLabel, timeoutMs = 10_000)` helper wraps every Gmail HTTP call with `AbortController` / `AbortSignal`. On timeout:
+- Aborts the request.
+- Captures `Sentry.captureMessage("Gmail call timed out", { level: "warning", fingerprint: ["gmail-call-timeout", failureLabel] })` so a dead credential produces ONE Sentry issue per cron run (grouped by fingerprint), not one per retry × per call.
+- Throws a retryable `GmailApiError` so `gmailFetchJson`'s retry policy handles a timeout uniformly with HTTP-retryable failures.
+
+Why 10s per call: typical Gmail p99 < 2s; anything > 10s means broken credential / network. Fail fast, let the run record `warn` (per P1's three-state status), avoid ratcheting toward the 60s Vercel function ceiling.
+
+## Tests
+- `src/lib/newsletter-ingestion/gmail.test.ts`: new "times out a hung Gmail call after the per-call ceiling and captures Sentry" — mocks `fetchImpl` to never resolve until `AbortSignal` fires, advances fake timers past 10s, asserts `GmailApiError` with `"timed out after 10000ms"` + `retryable: true` + Sentry capture with the expected fingerprint.
+
+Existing 5 tests in the file still pass. Full suite: 843/843 across 103 files (+1 new). `npm run build` green.
+
+## Why production didn't catch this earlier
+The Gmail client had retry logic but no upper bound on a single call — the retry budget assumed each call would either return quickly or fail with an HTTP status. A hung connection violates that assumption. The outer 55s timeout only caught the catastrophic case; the slow drift had no signal.
+
+## Operator follow-up (post-deploy)
+- Even with the Gmail OAuth still expired: `cron_runs` duration should immediately drop back to ~25–35s (the RSS + editorial-staging work). Sentry should show ONE `gmail-call-timeout` issue per run grouped by fingerprint until BM re-auths.
+- After BM re-auths the Gmail credential: durations stay ~25–35s, newsletter rows resume in `newsletter_emails`, no further Sentry timeouts.
+
+## Not addressed by this fix
+- Re-auth the actual Gmail OAuth credential (BM action).
+- P1 cron success boolean (separate PR #290).
+- P2 Sentry-capture log writers (separate PR #292).

--- a/src/lib/newsletter-ingestion/gmail.test.ts
+++ b/src/lib/newsletter-ingestion/gmail.test.ts
@@ -8,6 +8,13 @@ import {
   verifyGmailNewsletterLabelVisible,
 } from "@/lib/newsletter-ingestion/gmail";
 
+const { sentryCaptureMessage } = vi.hoisted(() => ({
+  sentryCaptureMessage: vi.fn(),
+}));
+vi.mock("@sentry/nextjs", () => ({
+  captureMessage: sentryCaptureMessage,
+}));
+
 describe("Gmail newsletter API client", () => {
   it("builds the benchmark label search query with a since date", () => {
     expect(
@@ -158,5 +165,73 @@ describe("Gmail newsletter API client", () => {
       expect(result.message).not.toContain("refresh-token");
       expect(result.message).not.toContain("client-secret");
     }
+  });
+
+  // Track 2 P3 — per-call timeout. A hung Gmail call must NOT block the
+  // cron toward the 60s Vercel function ceiling. The timeout fires at
+  // 10s (per-call), aborts the request, captures Sentry, and raises a
+  // retryable GmailApiError so the caller's retry policy handles it
+  // uniformly.
+  it("times out a hung Gmail call after the per-call ceiling and captures Sentry (#272 P3)", async () => {
+    sentryCaptureMessage.mockReset();
+    // Mock fetch that never resolves until aborted via the AbortSignal.
+    // We listen to init.signal for the abort and reject with an AbortError
+    // — exactly what runtimes do when AbortController.abort() fires.
+    const fetchImpl = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (signal?.aborted) {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+          return;
+        }
+        signal?.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    });
+
+    // Speed up the test — use fake timers to advance past the 10s ceiling.
+    vi.useFakeTimers();
+
+    const tokenPromise = (async () => {
+      try {
+        // getAccessToken() is the first call — wrap a refresh-token fetch.
+        const { getGmailAccessToken } = await import("@/lib/newsletter-ingestion/gmail");
+        return await getGmailAccessToken(
+          {
+            clientId: "client-id",
+            clientSecret: "client-secret",
+            refreshToken: "refresh-token",
+          },
+          fetchImpl as typeof fetch,
+        );
+      } catch (error) {
+        return error;
+      }
+    })();
+
+    // Advance past the 10s per-call ceiling.
+    await vi.advanceTimersByTimeAsync(10_100);
+    const outcome = await tokenPromise;
+    vi.useRealTimers();
+
+    expect(outcome).toBeInstanceOf(GmailApiError);
+    expect((outcome as GmailApiError).message).toMatch(/timed out after 10000ms/i);
+    // Timed-out OAuth refresh is retryable so any caller's retry policy
+    // can re-attempt with backoff (the OAuth helper itself doesn't
+    // retry; the gmailFetchJson wrapper does for API calls).
+    expect((outcome as GmailApiError).retryable).toBe(true);
+
+    expect(sentryCaptureMessage).toHaveBeenCalledWith(
+      "Gmail call timed out",
+      expect.objectContaining({
+        level: "warning",
+        fingerprint: ["gmail-call-timeout", "Gmail OAuth refresh"],
+      }),
+    );
   });
 });

--- a/src/lib/newsletter-ingestion/gmail.ts
+++ b/src/lib/newsletter-ingestion/gmail.ts
@@ -1,4 +1,24 @@
+import * as Sentry from "@sentry/nextjs";
+
 import { DEFAULT_NEWSLETTER_LABEL } from "@/lib/newsletter-ingestion/config";
+
+/**
+ * Per-call timeout for any single Gmail HTTP request — OAuth refresh,
+ * messages.list, messages.get, labels.list. Each network call gets its
+ * own AbortSignal; a hung request times out at 10 seconds (rather than
+ * blocking until the function's outer 55s budget fires).
+ *
+ * Why 10s: typical Gmail API p99 is <2s. Anything above 10s on a single
+ * call means the credential / network is broken; the right move is to
+ * fail fast and let the run record a degraded status, not ratchet
+ * duration toward the 60s Vercel function ceiling and hit the internal
+ * 55s timeout.
+ *
+ * Track 2 P3. Issue #292-follow. Companion to P1's success-boolean fix:
+ * P1 stops mislabeling a dead-newsletter run as `fail`; P3 stops a dead
+ * newsletter from ratcheting duration to a real timeout.
+ */
+const GMAIL_PER_CALL_TIMEOUT_MS = 10_000;
 
 export type GmailFetch = typeof fetch;
 
@@ -107,6 +127,50 @@ async function wait(ms: number) {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Wrap a single fetch invocation in an AbortSignal-based timeout.
+ * When the timeout fires, the abort surfaces as a `DOMException`
+ * (or a plain `Error` in some runtimes) with name `"AbortError"`.
+ * We normalize that into a `GmailApiError` so the caller's catch/retry
+ * paths handle it uniformly, AND capture a Sentry message so a slow
+ * upstream is observable without waiting for the outer cron timeout.
+ */
+async function fetchWithTimeout(
+  fetchImpl: GmailFetch,
+  url: URL | string,
+  init: RequestInit,
+  failureLabel: string,
+  timeoutMs: number = GMAIL_PER_CALL_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchImpl(url, { ...init, signal: controller.signal });
+  } catch (error) {
+    const aborted =
+      (error instanceof DOMException && error.name === "AbortError") ||
+      (error instanceof Error && error.name === "AbortError");
+    if (aborted) {
+      Sentry.captureMessage("Gmail call timed out", {
+        level: "warning",
+        fingerprint: ["gmail-call-timeout", failureLabel],
+        tags: {
+          observability_surface: "newsletter_ingestion",
+          gmail_failure_label: failureLabel,
+        },
+        extra: { timeoutMs, url: String(url) },
+      });
+      throw new GmailApiError(
+        `${failureLabel} timed out after ${timeoutMs}ms.`,
+        { status: null, retryable: true },
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 async function parseJsonResponse<T>(response: Response, failureLabel: string): Promise<T> {
   if (response.ok) {
     return await response.json() as T;
@@ -122,18 +186,23 @@ export async function getGmailAccessToken(
   credentials: GmailCredentials,
   fetchImpl: GmailFetch = fetch,
 ) {
-  const response = await fetchImpl("https://oauth2.googleapis.com/token", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
+  const response = await fetchWithTimeout(
+    fetchImpl,
+    "https://oauth2.googleapis.com/token",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        client_id: credentials.clientId,
+        client_secret: credentials.clientSecret,
+        refresh_token: credentials.refreshToken,
+        grant_type: "refresh_token",
+      }),
     },
-    body: new URLSearchParams({
-      client_id: credentials.clientId,
-      client_secret: credentials.clientSecret,
-      refresh_token: credentials.refreshToken,
-      grant_type: "refresh_token",
-    }),
-  });
+    "Gmail OAuth refresh",
+  );
   const body = await parseJsonResponse<GmailTokenResponse>(response, "Gmail OAuth refresh");
   const accessToken = body.access_token?.trim();
 
@@ -160,11 +229,33 @@ async function gmailFetchJson<T>(
   let attempt = 0;
 
   while (true) {
-    const response = await input.fetchImpl(input.url, {
-      headers: {
-        Authorization: `Bearer ${input.accessToken}`,
-      },
-    });
+    let response: Response;
+    try {
+      response = await fetchWithTimeout(
+        input.fetchImpl,
+        input.url,
+        {
+          headers: {
+            Authorization: `Bearer ${input.accessToken}`,
+          },
+        },
+        input.failureLabel,
+      );
+    } catch (error) {
+      // fetchWithTimeout already converts AbortError -> retryable
+      // GmailApiError. Apply the same retry policy as for HTTP failures
+      // so a transient timeout is retried with backoff.
+      if (
+        error instanceof GmailApiError &&
+        error.retryable &&
+        attempt < maxRetries
+      ) {
+        attempt += 1;
+        await wait(100 * attempt);
+        continue;
+      }
+      throw error;
+    }
 
     try {
       return await parseJsonResponse<T>(response, input.failureLabel);


### PR DESCRIPTION
**Track 2 Priority 3 — branch-only, do NOT merge without BM sign-off.**

Closes #293.

## Diff
- New `fetchWithTimeout(fetchImpl, url, init, failureLabel, timeoutMs = 10_000)` helper in `src/lib/newsletter-ingestion/gmail.ts`.
- Applied to OAuth refresh (`getGmailAccessToken`) and all API calls (`gmailFetchJson`).
- On timeout: `Sentry.captureMessage("Gmail call timed out", { fingerprint: ["gmail-call-timeout", failureLabel] })` at warning level + retryable `GmailApiError`.
- `gmailFetchJson` retries a timeout the same way it retries HTTP-retryable failures (existing 2 attempts × 100ms backoff).

Why 10s: Gmail p99 < 2s. > 10s means broken credential / network. Fail fast.

## Tests (+1)
`gmail.test.ts`: hung-fetch + fake timers verifies timeout fires, retryable `GmailApiError` raised with correct message, Sentry capture with correct fingerprint. Existing 5 tests still pass. Full suite **843/843 across 103 files**. `npm run build` green.

## Verification (post-deploy)
- Even with Gmail OAuth still expired: `cron_runs` duration drops back to ~25–35s. Sentry shows ONE `gmail-call-timeout` issue per run grouped by fingerprint.
- After BM re-auths: durations stay ~25–35s, newsletter rows resume.

## Not in this PR
- Re-auth Gmail OAuth (BM action).
- P1 cron success boolean (PR #290).
- P2 Sentry log-writer signals (PR #292).
- P4/P5/P6 (separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)