### PR TITLE
fix(notion): cross-date dedup keeps evergreens from recurring (#295)

### DIFF
--- a/docs/engineering/bug-fixes/notion-cross-date-dedup-2026-06-03.md
+++ b/docs/engineering/bug-fixes/notion-cross-date-dedup-2026-06-03.md
@@ -1,0 +1,34 @@
+# Notion Editorial Queue Cross-Date Dedup — Bug-Fix Record
+
+## Summary
+- **Problem addressed:** Two Fed-research evergreens (NY Fed "AIs Macroeconomic Challenges and Promises" May 25 → Jun 2; SF Fed "Economic Letter Countdown" May 30 → Jun 2) recurred in the Notion Editorial Queue across multiple briefing dates. Editor had to manually skip / archive the same item every day.
+- **Root cause:** `findExistingRow` (`src/lib/editorial-staging/notion-writer.ts`) keys ONLY on (Headline, Briefing Date). A new briefing date had no memory of yesterday's staging decision.
+- **Affected object level:** Notion Editorial Queue write semantics.
+- **Related issue:** #295. Track 2 P4.
+
+## Fix
+Cross-date lookback query in `writeEditorialQueueRow` that runs ONLY when the same-day query returns no match:
+- Window: 14 days (`CROSS_DATE_DEDUP_LOOKBACK_DAYS`). Documented in code why this width.
+- Filter: Headline-exact-equals + Briefing Date `on_or_after` (today − 14d) + `on_or_before` (today − 1d). Excludes today by construction so we don't re-match the same-day row.
+- If match at status `raw`: re-staging proceeds (matches existing "raw can be updated" semantics).
+- If match at any non-`raw` status: new action `skipped_duplicate_across_dates`; result carries `existingStatus` and `existingBriefingDate` for logging.
+
+New summary field `notionRowsSkippedDuplicateAcrossDates` in the staging runner aggregates per run.
+
+## Tests
+- `notion-writer.test.ts`: 2 new tests — "skips when same headline already exists at non-raw status on a recent briefing date" + "does NOT skip when the cross-date match is still at status=raw". 3 existing tests updated to add the cross-date query response in the mock chain.
+
+Full suite: 844/844 across 103 files. `npm run build` green.
+
+## Why production didn't catch this earlier
+The dedup key reflected the original "one row per signal per briefing day" design. Evergreen sources weren't anticipated; once Fed-research evergreens started appearing in the RSS pool, the same-day key let them through every time.
+
+## Operator follow-up (post-deploy)
+- After deploy: `notionRowsSkippedDuplicateAcrossDates` should fire >0 on most days while there are evergreens active.
+- Editorial Queue stops accumulating cross-date duplicates of the Fed-research pieces.
+- Existing duplicates already in the Notion queue from before deploy are NOT cleaned up — operator action (archive / delete) only if BM cares.
+
+## Not addressed by this fix
+- Existing cross-date duplicates in Notion (BM choice — keep for archive completeness or clean manually).
+- Newsletter ingestion still dead until BM re-auths Gmail (P3 makes the timeout visible; P1 stops mislabeling the run).
+- Soft `MED-HIGH` priority per Track 2 brief — lower than P1/P2/P3.

--- a/src/lib/editorial-staging/notion-writer.test.ts
+++ b/src/lib/editorial-staging/notion-writer.test.ts
@@ -72,13 +72,20 @@ describe("writeEditorialQueueRow — idempotent insert | update | skip", () => {
     delete process.env.NOTION_TOKEN;
   });
 
-  it("inserts when no matching row exists", async () => {
+  it("inserts when no matching row exists (no same-day, no cross-date)", async () => {
     fetchMock.mockReset();
     fetchMock
+      // 1. Same-day Headline+Briefing Date query — empty.
       .mockImplementationOnce(async (url: string, init?: RequestInit) => {
         calls.push({ url, init });
         return emptyQueryResponse();
       })
+      // 2. Cross-date lookback query (#P4) — empty.
+      .mockImplementationOnce(async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return emptyQueryResponse();
+      })
+      // 3. Create.
       .mockImplementationOnce(async (url: string, init?: RequestInit) => {
         calls.push({ url, init });
         return createSuccessResponse("new-page-1");
@@ -91,10 +98,11 @@ describe("writeEditorialQueueRow — idempotent insert | update | skip", () => {
     });
 
     expect(result).toEqual({ action: "inserted", pageId: "new-page-1" });
-    expect(calls).toHaveLength(2);
+    expect(calls).toHaveLength(3);
     expect(calls[0].url).toBe(`https://api.notion.com/v1/databases/${NOTION_DB_ID}/query`);
-    expect(calls[1].url).toBe("https://api.notion.com/v1/pages");
-    expect(calls[1].init?.method).toBe("POST");
+    expect(calls[1].url).toBe(`https://api.notion.com/v1/databases/${NOTION_DB_ID}/query`);
+    expect(calls[2].url).toBe("https://api.notion.com/v1/pages");
+    expect(calls[2].init?.method).toBe("POST");
   });
 
   it("updates in place when a matching row exists at Status=raw", async () => {
@@ -165,10 +173,16 @@ describe("writeEditorialQueueRow — idempotent insert | update | skip", () => {
     expect(result.existingStatus).toBe("(unset)");
   });
 
-  it("filters the Notion query by both Headline AND Briefing Date", async () => {
+  it("filters the same-day Notion query by both Headline AND Briefing Date", async () => {
     fetchMock.mockReset();
     fetchMock
       .mockImplementationOnce(async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return emptyQueryResponse();
+      })
+      .mockImplementationOnce(async (url: string, init?: RequestInit) => {
+        // Cross-date query (#P4) — empty so we still exercise the
+        // same-day filter assertions below.
         calls.push({ url, init });
         return emptyQueryResponse();
       })
@@ -195,13 +209,102 @@ describe("writeEditorialQueueRow — idempotent insert | update | skip", () => {
     });
   });
 
+  // Track 2 P4 — cross-date dedup. Same headline staged at non-`raw`
+  // status on a prior briefing date within the 14-day window → skip,
+  // do not create a fresh row.
+  it("skips when the same headline already exists at non-raw status on a recent briefing date (#P4)", async () => {
+    fetchMock.mockReset();
+    fetchMock
+      // 1. Same-day query — no match.
+      .mockImplementationOnce(async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return emptyQueryResponse();
+      })
+      // 2. Cross-date query — match at Approved, briefing date 4 days ago.
+      .mockImplementationOnce(async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return jsonResponse(200, {
+          results: [
+            {
+              id: "evergreen-page-1",
+              properties: {
+                Status: { select: { name: "Approved" } },
+                "Briefing Date": { date: { start: "2026-05-13" } },
+              },
+            },
+          ],
+        });
+      });
+
+    const result = await writeEditorialQueueRow({
+      candidate: baseCandidate,
+      briefingDate: BRIEFING_DATE,
+      notionDbId: NOTION_DB_ID,
+    });
+
+    expect(result).toEqual({
+      action: "skipped_duplicate_across_dates",
+      pageId: "evergreen-page-1",
+      existingStatus: "Approved",
+      existingBriefingDate: "2026-05-13",
+    });
+    // No third call (no create) — only the two queries.
+    expect(calls).toHaveLength(2);
+    expect(calls[0].url).toBe(`https://api.notion.com/v1/databases/${NOTION_DB_ID}/query`);
+    expect(calls[1].url).toBe(`https://api.notion.com/v1/databases/${NOTION_DB_ID}/query`);
+    // Cross-date filter excludes the current briefing date by upper-bounding
+    // on `on_or_before` < BRIEFING_DATE.
+    const crossDateBody = JSON.parse((calls[1].init?.body as string) ?? "{}");
+    expect(crossDateBody.filter.and).toHaveLength(3);
+    expect(crossDateBody.filter.and[0]).toEqual({
+      property: "Headline",
+      title: { equals: baseCandidate.headline },
+    });
+    expect(crossDateBody.filter.and[2].property).toBe("Briefing Date");
+    expect(crossDateBody.filter.and[2].date.on_or_before).toBe("2026-05-16");
+  });
+
+  it("does NOT skip when the cross-date match is still at status=raw (re-staging allowed)", async () => {
+    fetchMock.mockReset();
+    fetchMock
+      // 1. Same-day — no match.
+      .mockImplementationOnce(async () => emptyQueryResponse())
+      // 2. Cross-date — match at raw (not yet processed). Should NOT skip.
+      .mockImplementationOnce(async () =>
+        jsonResponse(200, {
+          results: [
+            {
+              id: "stale-raw-1",
+              properties: {
+                Status: { select: { name: "raw" } },
+                "Briefing Date": { date: { start: "2026-05-15" } },
+              },
+            },
+          ],
+        }),
+      )
+      // 3. Create — proceed with insert because cross-date match is raw.
+      .mockImplementationOnce(async () => createSuccessResponse("new-page-3"));
+
+    const result = await writeEditorialQueueRow({
+      candidate: baseCandidate,
+      briefingDate: BRIEFING_DATE,
+      notionDbId: NOTION_DB_ID,
+    });
+
+    expect(result.action).toBe("inserted");
+    expect(result.pageId).toBe("new-page-3");
+  });
+
   it("is idempotent: running twice with the same input produces one insert then one update", async () => {
     fetchMock.mockReset();
     fetchMock
-      // run 1: query (empty) -> create
+      // run 1: same-day (empty) -> cross-date (empty) -> create
+      .mockImplementationOnce(async () => emptyQueryResponse())
       .mockImplementationOnce(async () => emptyQueryResponse())
       .mockImplementationOnce(async () => createSuccessResponse("page-XYZ"))
-      // run 2: query (returns the row we just created at raw) -> update
+      // run 2: same-day query returns the row we just created at raw -> update
+      // (no cross-date query because same-day match short-circuits)
       .mockImplementationOnce(async () =>
         queryResponseWithMatch("page-XYZ", "raw"),
       )
@@ -221,9 +324,10 @@ describe("writeEditorialQueueRow — idempotent insert | update | skip", () => {
     expect(first.action).toBe("inserted");
     expect(second.action).toBe("updated");
     expect(second.pageId).toBe("page-XYZ");
-    // Two runs total = 4 API calls (2 queries + 1 create + 1 update). Zero
-    // duplicate-row writes.
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    // Run 1 = 3 calls (same-day query + cross-date query + create).
+    // Run 2 = 2 calls (same-day query + update; cross-date skipped
+    // because same-day match short-circuits). Total = 5.
+    expect(fetchMock).toHaveBeenCalledTimes(5);
   });
 
   it("throws a descriptive error when NOTION_TOKEN is unset", async () => {

--- a/src/lib/editorial-staging/notion-writer.ts
+++ b/src/lib/editorial-staging/notion-writer.ts
@@ -14,22 +14,48 @@ export type EditorialCandidateForNotion = {
 export type EditorialQueueWriteAction =
   | "inserted"
   | "updated"
-  | "skipped_human_edited";
+  | "skipped_human_edited"
+  /**
+   * Track 2 P4 — the same headline was already staged at a non-`raw`
+   * status within the last `CROSS_DATE_DEDUP_LOOKBACK_DAYS` (typically
+   * 14). The editor / archive system already has it. We do NOT create a
+   * new row on a different briefing date; preserves each day's archive
+   * but stops evergreen recurrence (e.g. the two recurring Fed-research
+   * pieces that drifted across multiple briefing dates without ever
+   * being re-edited by BM).
+   */
+  | "skipped_duplicate_across_dates";
 
 export type EditorialQueueWriteResult = {
   action: EditorialQueueWriteAction;
   /** The Notion page ID for the row (set for inserted/updated; also set for skipped). */
   pageId: string;
   /**
-   * Existing Status value seen when the action is `skipped_human_edited`. Omitted
-   * for inserts; for updates, this is always "raw" (otherwise we would skip).
+   * Existing Status value seen when the action is `skipped_human_edited`
+   * or `skipped_duplicate_across_dates`. Omitted for inserts; for
+   * updates, this is always "raw" (otherwise we would skip).
    */
   existingStatus?: string;
+  /**
+   * Set for `skipped_duplicate_across_dates`: the briefing date of the
+   * pre-existing row that triggered the skip. Useful in logs to confirm
+   * the cross-date match was real.
+   */
+  existingBriefingDate?: string;
 };
 
 const NOTION_API_VERSION = "2022-06-28";
 const NOTION_PAGES_URL = "https://api.notion.com/v1/pages";
 const NOTION_TITLE_MAX = 2000;
+/**
+ * Cross-date dedup lookback window. Long enough to catch evergreens
+ * a single source typically re-serves (1-2 weeks); short enough that a
+ * later re-staging on a genuinely new briefing date is not blocked
+ * indefinitely. Adjust with care — narrower lets evergreens recur;
+ * wider risks suppressing a legitimate re-publish of a story whose
+ * substance changed.
+ */
+const CROSS_DATE_DEDUP_LOOKBACK_DAYS = 14;
 
 function richText(content: string) {
   return [{ text: { content: content.slice(0, NOTION_TITLE_MAX) } }];
@@ -200,12 +226,98 @@ async function updateRow(
 }
 
 /**
- * Idempotent write to the Notion Editorial Queue, keyed on Headline +
- * Briefing Date:
- *  - inserts when no matching row exists,
- *  - updates in place when a matching row exists with Status="raw",
- *  - skips entirely when a matching row exists with any other Status
- *    (the row has been touched by the human editor).
+ * Track 2 P4 — find an EXISTING row with the same Headline staged on a
+ * DIFFERENT briefing date within the last `lookbackDays`. Returns the
+ * first match (in case there are several recurrences). Used by the
+ * cross-date dedup guard to refuse re-staging evergreens that BM has
+ * already advanced past `raw`.
+ *
+ * Implementation note: Notion's database query doesn't support a "NOT
+ * EQUAL" filter on date directly — we filter to the date range
+ * `[today - lookbackDays, today - 1]` (which excludes today by
+ * construction). The same-day `findExistingRow` continues to handle the
+ * same-briefing-date case.
+ */
+type CrossDateMatch = {
+  pageId: string;
+  status: string | null;
+  briefingDate: string | null;
+};
+
+async function findCrossDateMatch(
+  notionDbId: string,
+  headline: string,
+  briefingDate: string,
+  token: string,
+  lookbackDays: number,
+): Promise<CrossDateMatch | null> {
+  const todayMs = Date.parse(`${briefingDate}T00:00:00Z`);
+  if (Number.isNaN(todayMs)) return null;
+  const startMs = todayMs - lookbackDays * 24 * 60 * 60 * 1000;
+  const startISO = new Date(startMs).toISOString().slice(0, 10);
+  // End is the day BEFORE the current briefingDate so we don't
+  // double-match the same-day row (which findExistingRow handles).
+  const endMs = todayMs - 24 * 60 * 60 * 1000;
+  const endISO = new Date(endMs).toISOString().slice(0, 10);
+
+  const headlineForQuery = headline.slice(0, NOTION_TITLE_MAX);
+  const response = await fetch(
+    `https://api.notion.com/v1/databases/${notionDbId}/query`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "Notion-Version": NOTION_API_VERSION,
+      },
+      body: JSON.stringify({
+        filter: {
+          and: [
+            { property: "Headline", title: { equals: headlineForQuery } },
+            { property: "Briefing Date", date: { on_or_after: startISO } },
+            { property: "Briefing Date", date: { on_or_before: endISO } },
+          ],
+        },
+        page_size: 5,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "(no body)");
+    throw new Error(`Notion cross-date query failed (${response.status}): ${text}`);
+  }
+
+  const data = (await response.json()) as {
+    results?: Array<{
+      id?: string;
+      properties?: {
+        Status?: { select?: { name?: string } | null };
+        "Briefing Date"?: { date?: { start?: string } | null };
+      };
+    }>;
+  };
+
+  const first = data.results?.[0];
+  if (!first?.id) return null;
+  const statusName = first.properties?.Status?.select?.name ?? null;
+  const existingBriefingDate = first.properties?.["Briefing Date"]?.date?.start ?? null;
+  return { pageId: first.id, status: statusName, briefingDate: existingBriefingDate };
+}
+
+/**
+ * Idempotent write to the Notion Editorial Queue:
+ *  - Same briefing date: inserts when no matching row exists, updates
+ *    in place when a matching row exists with Status="raw", skips
+ *    entirely when a matching row exists with any other Status (human
+ *    editor touched it).
+ *  - Cross-date (#P4): if the same Headline already exists within the
+ *    last `CROSS_DATE_DEDUP_LOOKBACK_DAYS` on a DIFFERENT briefing
+ *    date at any non-`raw` status (i.e. the editor has already moved
+ *    it through the queue), skip with `skipped_duplicate_across_dates`
+ *    rather than create a fresh row. A row still at `raw` on a prior
+ *    date is treated as not-yet-processed and re-staging is allowed
+ *    (matches existing "raw can be updated" semantics).
  */
 export async function writeEditorialQueueRow(input: {
   candidate: EditorialCandidateForNotion;
@@ -236,6 +348,23 @@ export async function writeEditorialQueueRow(input: {
     }
     await updateRow(existing.pageId, candidate, briefingDate, token);
     return { action: "updated", pageId: existing.pageId };
+  }
+
+  // No same-day match. Check the cross-date window before inserting.
+  const crossDate = await findCrossDateMatch(
+    notionDbId,
+    candidate.headline,
+    briefingDate,
+    token,
+    CROSS_DATE_DEDUP_LOOKBACK_DAYS,
+  );
+  if (crossDate && crossDate.status && crossDate.status !== "raw") {
+    return {
+      action: "skipped_duplicate_across_dates",
+      pageId: crossDate.pageId,
+      existingStatus: crossDate.status,
+      existingBriefingDate: crossDate.briefingDate ?? undefined,
+    };
   }
 
   const pageId = await createRow(notionDbId, candidate, briefingDate, token);

--- a/src/lib/editorial-staging/runner.ts
+++ b/src/lib/editorial-staging/runner.ts
@@ -30,6 +30,8 @@ export type EditorialStagingRunSummary = {
   notionRowsInserted: number;
   notionRowsUpdated: number;
   notionRowsSkippedHumanEdited: number;
+  /** Track 2 P4 — staged headline already exists at non-`raw` status on a different briefing date within the lookback window. */
+  notionRowsSkippedDuplicateAcrossDates: number;
   notionErrors: string[];
 };
 
@@ -205,6 +207,7 @@ function buildFailureResult(
       notionRowsInserted: 0,
       notionRowsUpdated: 0,
       notionRowsSkippedHumanEdited: 0,
+      notionRowsSkippedDuplicateAcrossDates: 0,
       notionErrors: [],
     },
   };
@@ -276,6 +279,7 @@ export async function runEditorialStaging(options: {
   let notionRowsInserted = 0;
   let notionRowsUpdated = 0;
   let notionRowsSkippedHumanEdited = 0;
+  let notionRowsSkippedDuplicateAcrossDates = 0;
   const notionErrors: string[] = [];
 
   for (const candidate of selected) {
@@ -283,6 +287,8 @@ export async function runEditorialStaging(options: {
       const result = await writeEditorialQueueRow({ candidate, briefingDate, notionDbId });
       if (result.action === "inserted") notionRowsInserted += 1;
       else if (result.action === "updated") notionRowsUpdated += 1;
+      else if (result.action === "skipped_duplicate_across_dates")
+        notionRowsSkippedDuplicateAcrossDates += 1;
       else notionRowsSkippedHumanEdited += 1;
 
       logServerEvent("info", "editorial_queue_row write", {
@@ -347,6 +353,7 @@ export async function runEditorialStaging(options: {
     notionRowsInserted,
     notionRowsUpdated,
     notionRowsSkippedHumanEdited,
+    notionRowsSkippedDuplicateAcrossDates,
   });
 
   return {
@@ -363,6 +370,7 @@ export async function runEditorialStaging(options: {
       notionRowsInserted,
       notionRowsUpdated,
       notionRowsSkippedHumanEdited,
+      notionRowsSkippedDuplicateAcrossDates,
       notionErrors,
     },
   };


### PR DESCRIPTION
**Track 2 Priority 4 — branch-only, do NOT merge without BM sign-off.**

Closes #295.

## Diff
`src/lib/editorial-staging/notion-writer.ts`:
- New `findCrossDateMatch` queries Notion for the same Headline within the last 14 days, excluding today by construction (`on_or_after today−14d` + `on_or_before today−1d`).
- `writeEditorialQueueRow`: runs cross-date query ONLY when same-day returns null. If match at non-`raw` status → `skipped_duplicate_across_dates`. If match at `raw` → insert allowed (existing 'raw can be updated' semantics).
- New action `skipped_duplicate_across_dates` in `EditorialQueueWriteAction` union.
- Result carries `existingStatus` + `existingBriefingDate` for log inspection.

`src/lib/editorial-staging/runner.ts`:
- New summary field `notionRowsSkippedDuplicateAcrossDates` aggregated per run.

## Tests (+2; existing 3 updated)
- New: "skips when same headline exists at non-raw status on a recent briefing date" — verifies skip, `existingStatus`, `existingBriefingDate`, and the cross-date query upper-bound (`on_or_before = BRIEFING_DATE − 1`).
- New: "does NOT skip when the cross-date match is still at status=raw (re-staging allowed)" — verifies the raw-allowed semantics.
- Existing 3 updated to add the cross-date query in mock chains.

Full suite: **844/844 across 103 files**. `npm run build` green.

## Verification (post-deploy)
- Once deployed, `notionRowsSkippedDuplicateAcrossDates > 0` shows up in Pipeline Log on days an evergreen would have re-staged.
- Editorial Queue stops accumulating duplicate Fed-research rows across days.
- Existing duplicate rows already in Notion are NOT cleaned up — BM's call whether to archive.

## Not in this PR
- Existing duplicate rows in Notion (operator choice).
- P1/P2/P3 cron observability (PRs #290 / #292 / #294).
- P5 kill orphan endpoints (separate).
- P6 source-diversity gate (separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)