### PR TITLE
refactor(pipeline): unify cron + dry-run harness onto one shared body (Track 2 PR-1)

### DIFF
--- a/docs/product/prd/prd-65-pipeline-reliability-external-cron-migration.md
+++ b/docs/product/prd/prd-65-pipeline-reliability-external-cron-migration.md
@@ -261,6 +261,25 @@ The specific trap this closes: newsletter with a missing Gmail credential now re
 
 **No schema changes, no migrations, no P4/P7 logic changes, no stage moved off the critical path** (that is the decouple-legs PR). Read-only fetches against prod Supabase/Notion are intentional (real P4 dedup data); zero writes occur.
 
+### Phase 7.6 — Pipeline-body unification: harness runs the real prod sequence (Track 2, 2026-06-07)
+
+**Problem this closes (found in the Phase 7.5 pre-merge review):** the dry-run harness had its own COPY of the stage sequence and ran the RSS leg through `runControlledPipeline(dry_run)` instead of the production `runDailyNewsCron`. A green `npm run pipeline:dry` therefore did not exercise the function prod actually calls for RSS — `runDailyNewsCron`'s seed-fallback gate, degraded-flag logic, and signal_posts snapshot path were all unvalidated by the harness. The fork could silently drift from prod.
+
+**Fix — one shared body.** New `src/lib/pipeline/editorial-ingestion-pipeline.ts` exports `runEditorialIngestionPipeline({ dryRun, now, runStage })`: the single newsletter → RSS → staging sequence (prod order; newsletter first for rank-slot reservation). It is called by BOTH:
+
+- the production cron `/api/cron/fetch-editorial-inputs` (`dryRun: false`, inside the existing run-lock + 55s internal-timeout + Pipeline-Log/Source-Health wrapper), and
+- the harness `runFullPipelineDryRun` (`dryRun: true`).
+
+Each consumer injects a `runStage` wrapper for its own concerns (the route: per-stage timeout attribution + degrade-don't-throw; the harness: `StageTimer` timing + outcome capture). After this, **the only difference between a dry run and the real 12:00 UTC run is that dry mode persists nothing.**
+
+**`runDailyNewsCron` gained a `dryRun` param** that threads `persistPipelineCandidates: !dryRun` into `generateDailyBriefing`, skips the `persistSignalPostsForBriefing` snapshot write, and skips the RSS cron-monitor check-in. `dryRun` defaults `false`, so the prod call is byte-for-byte unchanged (the 23 route tests stay green). The RSS dry leg is genuinely zero-write — verified: `ingestRawItems` performs no Supabase writes, and the only writers (`persistNormalizedArticleCandidates` / cluster / ranking) sit inside `if (shouldPersistArticleCandidates)`.
+
+**Harness behavior change — run-all-like-prod.** The harness now RUNS every stage exactly as prod would; the capability matrix is a **pre-check** that names missing dependencies. A missing credential surfaces as that stage's real `error`/`degrade` (with the matrix reason attached), not a tidy `skipped`. This is strictly more faithful: the dry run's control flow is identical to the cron's. (The earlier skip-on-missing behavior from Phase 7.5 is replaced.)
+
+**Evidence:** 925 unit tests green (incl. 23 route tests unchanged + rewritten harness tests asserting run-all + dryRun threading + the shared body). `npm run pipeline:dry` against a no-creds sandbox now exercises the real `runDailyNewsCron` and correctly reports its seed-fallback gate as an RSS error — proof the real prod RSS path is now in the loop. Lint + build clean.
+
+**Still does NOT certify the Vercel 60s fit** (`certifies60sFit: false`). That requires a deployed test — the next step is a guarded, read-only `?dryRun=1` trigger on the cron route so the unified body can be run on a preview deployment under the real serverless budget on demand (no 24h wait).
+
 ## Closeout Checklist
 
 - Scope completed: all phases (0–5) plus the cron-job.org sync tooling landing.

--- a/src/app/api/cron/fetch-editorial-inputs/route.ts
+++ b/src/app/api/cron/fetch-editorial-inputs/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse, after } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 
-import { runDailyNewsCron, type DailyNewsCronRunResult } from "@/lib/cron/fetch-news";
-import { runNewsletterIngestion, type NewsletterIngestionRunResult } from "@/lib/newsletter-ingestion/runner";
-import { runEditorialStaging, type EditorialStagingRunResult } from "@/lib/editorial-staging/runner";
+import {
+  runEditorialIngestionPipeline,
+  type EditorialPipelineResults,
+  type EditorialPipelineStageRunner,
+} from "@/lib/pipeline/editorial-ingestion-pipeline";
 import { runNeedsReviewSweep } from "@/lib/editorial-sweep/needs-review-sweep";
 import { errorContext, logServerEvent } from "@/lib/observability";
 import { writePipelineLogEntry } from "@/lib/observability/pipeline-log";
@@ -227,15 +229,6 @@ export const runtime = "nodejs";
 
 type EditorialInputTaskName = "rss" | "newsletter" | "editorial_staging";
 
-type EditorialInputTaskResult = {
-  success: boolean;
-  timestamp: string | null;
-  summary:
-    | DailyNewsCronRunResult["summary"]
-    | NewsletterIngestionRunResult["summary"]
-    | EditorialStagingRunResult["summary"]
-    | null;
-};
 
 // Hard internal wall for the after() pipeline. Sits below the function-level
 // maxDuration (60s in vercel.json) so we always trip this guard first and
@@ -259,35 +252,6 @@ function isAuthorized(request: Request) {
   }
 
   return false;
-}
-
-async function runTask<T extends DailyNewsCronRunResult | NewsletterIngestionRunResult | EditorialStagingRunResult>(
-  name: EditorialInputTaskName,
-  task: () => Promise<T>,
-): Promise<EditorialInputTaskResult> {
-  try {
-    const result = await task();
-
-    return {
-      success: result.success,
-      timestamp: result.timestamp,
-      summary: result.summary,
-    };
-  } catch (error) {
-    logServerEvent("error", "Combined editorial input cron task failed before completion", {
-      route: "/api/cron/fetch-editorial-inputs",
-      task: name,
-      ...errorContext(error),
-    });
-
-    return {
-      success: false,
-      timestamp: new Date().toISOString(),
-      summary: {
-        message: `${name} task failed before completion.`,
-      } as EditorialInputTaskResult["summary"],
-    };
-  }
 }
 
 class IngestionTimeoutInternalError extends Error {
@@ -319,24 +283,39 @@ function runWithInternalTimeout<T>(
   });
 }
 
-async function runIngestionPipeline(stageRef: { current: EditorialInputTaskName }) {
-  // Newsletter must run before RSS so that reserveNewsletterCandidateRanksForRssSnapshot
-  // can push newsletter rows to high rank slots and leave low ranks free for the RSS snapshot.
-  // If RSS runs first it fills all 20 rank slots, leaving no room for newsletter promotion.
-  stageRef.current = "newsletter";
-  const newsletter = await runTask("newsletter", () =>
-    runNewsletterIngestion({
-      writeCandidates: true,
-    }),
-  );
+async function runIngestionPipeline(stageRef: {
+  current: EditorialInputTaskName;
+}): Promise<EditorialPipelineResults> {
+  // The stage SEQUENCE + dry threading live in the shared
+  // runEditorialIngestionPipeline (Track 2 unification) so this prod cron and
+  // the dry-run harness execute byte-for-byte the same legs in the same order
+  // (newsletter before RSS for rank-slot reservation). The route injects its own
+  // stage wrapper: per-stage timeout attribution via stageRef, plus the
+  // degrade-don't-throw catch that keeps one leg's failure from aborting the
+  // rest (newsletter dying must not stop RSS/staging).
+  const runStage: EditorialPipelineStageRunner = async <T>(
+    name: EditorialInputTaskName,
+    run: () => Promise<T>,
+  ): Promise<T> => {
+    stageRef.current = name;
+    try {
+      return await run();
+    } catch (error) {
+      logServerEvent("error", "Combined editorial input cron task failed before completion", {
+        route: "/api/cron/fetch-editorial-inputs",
+        task: name,
+        ...errorContext(error),
+      });
+      return {
+        success: false,
+        timestamp: new Date().toISOString(),
+        summary: { message: `${name} task failed before completion.` },
+      } as unknown as T;
+    }
+  };
 
-  stageRef.current = "rss";
-  const rss = await runTask("rss", () => runDailyNewsCron());
-
-  stageRef.current = "editorial_staging";
-  const editorialStaging = await runTask("editorial_staging", () => runEditorialStaging());
-
-  return { newsletter, rss, editorialStaging };
+  // dryRun: false — this IS the real 12:00 UTC cron. Persists everything.
+  return runEditorialIngestionPipeline({ dryRun: false, runStage });
 }
 
 async function executePipelineWork(briefingDate: string) {
@@ -366,9 +345,7 @@ async function executePipelineWork(briefingDate: string) {
     });
   }
 
-  let pipelineResult:
-    | { newsletter: EditorialInputTaskResult; rss: EditorialInputTaskResult; editorialStaging: EditorialInputTaskResult }
-    | null = null;
+  let pipelineResult: EditorialPipelineResults | null = null;
 
   try {
     pipelineResult = await runWithInternalTimeout(

--- a/src/lib/cron/fetch-news.ts
+++ b/src/lib/cron/fetch-news.ts
@@ -65,10 +65,23 @@ function buildFailureResult(timestamp: string, message: string): DailyNewsCronRu
   };
 }
 
-export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
+export async function runDailyNewsCron(
+  options: { dryRun?: boolean } = {},
+): Promise<DailyNewsCronRunResult> {
+  // Track 2 pipeline unification: in dry mode the RSS leg runs the SAME
+  // generateDailyBriefing core but persists NOTHING — no article candidates
+  // (persistPipelineCandidates: false), no signal_posts snapshot — and does not
+  // ping the production RSS cron monitor. dryRun defaults false so the prod cron
+  // path (route.ts) is byte-for-byte unchanged.
+  const dryRun = options.dryRun ?? false;
   const timestamp = new Date().toISOString();
   const startedAtMs = Date.now();
-  const checkInId = captureRssCronCheckIn("in_progress");
+  const checkInId = dryRun ? undefined : captureRssCronCheckIn("in_progress");
+  // Cron-monitor check-ins are skipped entirely in dry mode — a dry run must not
+  // ping the production RSS monitor and corrupt its schedule tracking.
+  const recordCheckIn = (...args: Parameters<typeof captureRssCronCheckIn>): void => {
+    if (!dryRun) captureRssCronCheckIn(...args);
+  };
 
   logServerEvent("info", "Daily news cron started", {
     // Track 2 P5: /api/cron/fetch-news endpoint removed (orphan, never
@@ -90,7 +103,11 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
     // /api/cron/fetch-editorial-inputs. Log tag follows the live caller.
     route: "/api/cron/fetch-editorial-inputs",
       },
-      () => generateDailyBriefing(demoTopics, sources, { suppliedByManifest: sourcePlan.suppliedByManifest }),
+      () =>
+        generateDailyBriefing(demoTopics, sources, {
+          suppliedByManifest: sourcePlan.suppliedByManifest,
+          persistPipelineCandidates: !dryRun,
+        }),
     );
     const briefingDate = briefing.briefingDate.slice(0, 10);
     const stagedItemCount = briefing.items.length;
@@ -141,7 +158,7 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
           feedFailureCount: pipelineRun.feed_failures.length,
         },
       });
-      captureRssCronCheckIn("error", checkInId, durationSeconds(startedAtMs));
+      recordCheckIn("error", checkInId, durationSeconds(startedAtMs));
 
       return result;
     }
@@ -184,7 +201,7 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
           feedFailureCount: pipelineRun.feed_failures.length,
         },
       });
-      captureRssCronCheckIn("error", checkInId, durationSeconds(startedAtMs));
+      recordCheckIn("error", checkInId, durationSeconds(startedAtMs));
 
       return result;
     }
@@ -203,10 +220,12 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
       });
     }
 
-    const snapshot = await persistSignalPostsForBriefing({
-      briefingDate,
-      items: briefing.items,
-    });
+    const snapshot = dryRun
+      ? { ok: true, insertedCount: 0, message: "Dry-run: signal_posts snapshot persistence skipped (zero writes)." }
+      : await persistSignalPostsForBriefing({
+          briefingDate,
+          items: briefing.items,
+        });
     const result = {
       success: snapshot.ok,
       timestamp,
@@ -243,7 +262,7 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
       });
     }
 
-    captureRssCronCheckIn(snapshot.ok ? "ok" : "error", checkInId, durationSeconds(startedAtMs));
+    recordCheckIn(snapshot.ok ? "ok" : "error", checkInId, durationSeconds(startedAtMs));
 
     return result;
   } catch (error) {
@@ -269,7 +288,7 @@ export async function runDailyNewsCron(): Promise<DailyNewsCronRunResult> {
     route: "/api/cron/fetch-editorial-inputs",
       },
     });
-    captureRssCronCheckIn("error", checkInId, durationSeconds(startedAtMs));
+    recordCheckIn("error", checkInId, durationSeconds(startedAtMs));
 
     return result;
   }

--- a/src/lib/pipeline/editorial-ingestion-pipeline.ts
+++ b/src/lib/pipeline/editorial-ingestion-pipeline.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared editorial ingestion pipeline body (Track 2 — pipeline unification).
+ *
+ * ONE sequence — newsletter → RSS → staging — called by BOTH:
+ *   - the production cron route /api/cron/fetch-editorial-inputs (dryRun: false)
+ *   - the local dry-run harness `npm run pipeline:dry` (dryRun: true)
+ *
+ * This eliminates the earlier FORK where the harness re-implemented the stage
+ * sequence and ran RSS through runControlledPipeline instead of the real prod
+ * runDailyNewsCron. After this, the ONLY difference between a dry run and the
+ * real 12:00 UTC cron is that dry mode persists nothing:
+ *   - newsletter takes its in-memory dryRunExtract path (full Gmail fetch +
+ *     parse, zero writes) instead of writing candidates,
+ *   - runDailyNewsCron skips article-candidate + signal_posts persistence and
+ *     the RSS cron-monitor check-in,
+ *   - runEditorialStaging skips the Notion queue write + completion email
+ *     (P4 read-only dedup + P7 filter + selection still run).
+ *
+ * Stage ORDER is load-bearing and identical to prod: newsletter MUST run before
+ * RSS so reserveNewsletterCandidateRanksForRssSnapshot can claim high rank slots
+ * before the RSS snapshot fills them.
+ */
+
+import { runDailyNewsCron, type DailyNewsCronRunResult } from "@/lib/cron/fetch-news";
+import { runEditorialStaging, type EditorialStagingRunResult } from "@/lib/editorial-staging/runner";
+import { runNewsletterIngestion, type NewsletterIngestionRunResult } from "@/lib/newsletter-ingestion/runner";
+
+export type EditorialPipelineStageName = "newsletter" | "rss" | "editorial_staging";
+
+/**
+ * Wraps a single stage's execution. Consumers inject their own concerns:
+ *   - the prod route records per-stage timeout attribution + degrade-don't-throw,
+ *   - the harness times each stage (StageTimer) + records its outcome.
+ *
+ * A stage runner MUST resolve (catch-and-continue) so one leg failing never
+ * aborts the others — matching prod's "degrade, don't fail" behavior. The
+ * default runner just runs the stage with no wrapping.
+ */
+export type EditorialPipelineStageRunner = <T>(
+  name: EditorialPipelineStageName,
+  run: () => Promise<T>,
+) => Promise<T>;
+
+export type EditorialPipelineResults = {
+  newsletter: NewsletterIngestionRunResult;
+  rss: DailyNewsCronRunResult;
+  editorialStaging: EditorialStagingRunResult;
+};
+
+const defaultRunStage: EditorialPipelineStageRunner = (_name, run) => run();
+
+export async function runEditorialIngestionPipeline(options: {
+  dryRun: boolean;
+  now?: Date;
+  runStage?: EditorialPipelineStageRunner;
+}): Promise<EditorialPipelineResults> {
+  const { dryRun, now } = options;
+  const runStage = options.runStage ?? defaultRunStage;
+
+  // Newsletter first (rank-slot reservation), then RSS, then staging — prod order.
+  const newsletter = await runStage("newsletter", () =>
+    dryRun
+      ? runNewsletterIngestion({ dryRun: true, now })
+      : runNewsletterIngestion({ writeCandidates: true, now }),
+  );
+
+  const rss = await runStage("rss", () => runDailyNewsCron({ dryRun }));
+
+  const editorialStaging = await runStage("editorial_staging", () =>
+    runEditorialStaging({ dryRun, now }),
+  );
+
+  return { newsletter, rss, editorialStaging };
+}

--- a/src/lib/pipeline/full-dry-run.test.ts
+++ b/src/lib/pipeline/full-dry-run.test.ts
@@ -2,14 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PreflightDeps } from "@/lib/pipeline/preflight";
 
-// Mock the four production stage functions so the orchestrator's gating + dryRun
-// propagation can be asserted without touching real Supabase / Notion / feeds.
+// Mock the LEAF stage functions only, so the REAL shared pipeline body
+// (runEditorialIngestionPipeline) + the REAL harness mapping run end-to-end.
 const mocks = vi.hoisted(() => ({
   runNeedsReviewSweep: vi.fn(),
   runNewsletterIngestion: vi.fn(),
-  runControlledPipeline: vi.fn(),
+  runDailyNewsCron: vi.fn(),
   runEditorialStaging: vi.fn(),
-  resolveControlledPipelineConfig: vi.fn(() => ({ mode: "dry_run" })),
 }));
 
 vi.mock("@/lib/editorial-sweep/needs-review-sweep", () => ({
@@ -18,14 +17,11 @@ vi.mock("@/lib/editorial-sweep/needs-review-sweep", () => ({
 vi.mock("@/lib/newsletter-ingestion/runner", () => ({
   runNewsletterIngestion: mocks.runNewsletterIngestion,
 }));
-vi.mock("@/lib/pipeline/controlled-runner", () => ({
-  runControlledPipeline: mocks.runControlledPipeline,
+vi.mock("@/lib/cron/fetch-news", () => ({
+  runDailyNewsCron: mocks.runDailyNewsCron,
 }));
 vi.mock("@/lib/editorial-staging/runner", () => ({
   runEditorialStaging: mocks.runEditorialStaging,
-}));
-vi.mock("@/lib/pipeline/controlled-execution", () => ({
-  resolveControlledPipelineConfig: mocks.resolveControlledPipelineConfig,
 }));
 
 import { runFullPipelineDryRun } from "@/lib/pipeline/full-dry-run";
@@ -59,22 +55,23 @@ const FULL_ENV = {
   NOTION_EDITORIAL_QUEUE_DB_ID: "db",
 } as unknown as NodeJS.ProcessEnv;
 
-const NOW = new Date("2026-06-06T12:00:00.000Z");
+const NOW = new Date("2026-06-07T12:00:00.000Z");
 
-function primeReadyMocks() {
+function primeHealthyMocks() {
   mocks.runNeedsReviewSweep.mockResolvedValue({ disposedCount: 2, flaggedCount: 1, mutated: false });
   mocks.runNewsletterIngestion.mockResolvedValue({
     success: true,
+    timestamp: "t",
     summary: { message: "ok", fetchedMessageCount: 3 },
   });
-  mocks.runControlledPipeline.mockResolvedValue({
-    candidateCount: 7,
-    clusterCount: 5,
-    candidate_pool_insufficient: false,
-    candidate_pool_insufficient_reason: null,
+  mocks.runDailyNewsCron.mockResolvedValue({
+    success: true,
+    timestamp: "t",
+    summary: { rawItemCount: 40, clusterCount: 7, degraded: false, message: "ok" },
   });
   mocks.runEditorialStaging.mockResolvedValue({
     success: true,
+    timestamp: "t",
     summary: {
       candidateCount: 7,
       coreCount: 5,
@@ -86,41 +83,13 @@ function primeReadyMocks() {
   });
 }
 
-describe("runFullPipelineDryRun", () => {
+describe("runFullPipelineDryRun (run-all-like-prod)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.resolveControlledPipelineConfig.mockReturnValue({ mode: "dry_run" });
+    primeHealthyMocks();
   });
 
-  it("skips every stage and calls NO stage fn when no deps are available", async () => {
-    const report = await runFullPipelineDryRun({
-      env: {} as NodeJS.ProcessEnv,
-      now: NOW,
-      preflight: { supabaseClient: null, fetchImpl: fakeFetch({ egress: false, notion: false }) },
-    });
-
-    expect(report.stages.sweep.outcome).toBe("skipped");
-    expect(report.stages.newsletter.outcome).toBe("skipped");
-    expect(report.stages.rss.outcome).toBe("skipped");
-    expect(report.stages.staging.outcome).toBe("skipped");
-
-    // Anti-false-success: a skipped stage records N/A timing, never a fast 0.
-    expect(report.stageMs.sweep).toBe("N/A");
-    expect(report.stageMs.newsletter).toBe("N/A");
-    expect(report.stageMs.rss).toBe("N/A");
-    expect(report.stageMs.staging).toBe("N/A");
-
-    // No production stage fn may execute when its dependency is absent.
-    expect(mocks.runNeedsReviewSweep).not.toHaveBeenCalled();
-    expect(mocks.runNewsletterIngestion).not.toHaveBeenCalled();
-    expect(mocks.runControlledPipeline).not.toHaveBeenCalled();
-    expect(mocks.runEditorialStaging).not.toHaveBeenCalled();
-
-    expect(report.certifies60sFit).toBe(false);
-  });
-
-  it("runs every stage in DRY mode when all deps are ready", async () => {
-    primeReadyMocks();
+  it("runs the SAME shared pipeline body in dry mode, all stages ran + timed", async () => {
     const report = await runFullPipelineDryRun({
       env: FULL_ENV,
       now: NOW,
@@ -132,34 +101,62 @@ describe("runFullPipelineDryRun", () => {
     expect(report.stages.rss.outcome).toBe("ran");
     expect(report.stages.staging.outcome).toBe("ran");
 
-    // dryRun must be propagated to the production functions — no fork.
+    // dryRun threaded into the REAL prod functions — no fork. RSS uses the real
+    // runDailyNewsCron (not runControlledPipeline anymore).
     expect(mocks.runNewsletterIngestion).toHaveBeenCalledWith(expect.objectContaining({ dryRun: true }));
+    expect(mocks.runDailyNewsCron).toHaveBeenCalledWith({ dryRun: true });
     expect(mocks.runEditorialStaging).toHaveBeenCalledWith(expect.objectContaining({ dryRun: true }));
-    // sweep is forced dry via NEEDS_REVIEW_SWEEP_DRY_RUN in the env it receives.
+    // sweep forced dry via env.
     expect(mocks.runNeedsReviewSweep).toHaveBeenCalledWith(
       expect.objectContaining({ env: expect.objectContaining({ NEEDS_REVIEW_SWEEP_DRY_RUN: "true" }) }),
     );
 
-    // PART 2 timing present for every ran stage + a wall-clock total.
+    // Every stage timed (none N/A — they all ran), plus a wall-clock total.
+    expect(report.stageMs.sweep).not.toBe("N/A");
     expect(report.stageMs.newsletter).not.toBe("N/A");
+    expect(report.stageMs.rss).not.toBe("N/A");
     expect(report.stageMs.staging).not.toBe("N/A");
     expect(report.stageMs.total).toEqual(expect.any(Number));
 
-    // PART 3 feature-validation visibility surfaced.
+    // Feature-validation visibility.
     expect(report.stages.staging.evergreenFiltered).toBe(1);
     expect(report.stages.staging.crossDateWouldSkip).toBe(1);
     expect(report.stages.newsletter.itemsProcessed).toBe(3);
+    expect(report.stages.rss.candidateCount).toBe(40);
 
     expect(report.certifies60sFit).toBe(false);
   });
 
-  it("degrades (not throws) when all feeds fail → candidate_pool_insufficient", async () => {
-    primeReadyMocks();
-    mocks.runControlledPipeline.mockResolvedValue({
-      candidateCount: 0,
-      clusterCount: 0,
-      candidate_pool_insufficient: true,
-      candidate_pool_insufficient_reason: "all_feeds_failed",
+  it("RUNS a stage even when its dependency is missing (prod fidelity), surfacing a real error + matrix reason", async () => {
+    // Newsletter has no Gmail creds in env, and its real run fails. The harness
+    // must still CALL it (prod runs every leg) and report error, not skip.
+    const envNoGmail = { NOTION_TOKEN: "tok", NOTION_EDITORIAL_QUEUE_DB_ID: "db" } as unknown as NodeJS.ProcessEnv;
+    mocks.runNewsletterIngestion.mockResolvedValue({
+      success: false,
+      timestamp: "t",
+      summary: { message: "Gmail auth failed" },
+    });
+
+    const report = await runFullPipelineDryRun({
+      env: envNoGmail,
+      now: NOW,
+      preflight: { supabaseClient: fakeSupabase(true), fetchImpl: fakeFetch({ egress: true, notion: true }) },
+    });
+
+    expect(mocks.runNewsletterIngestion).toHaveBeenCalledTimes(1); // RAN despite missing creds
+    expect(report.stages.newsletter.outcome).toBe("error");
+    expect(report.stages.newsletter.note).toMatch(/GMAIL/); // matrix pre-check names the missing var
+    // The other legs still ran — one leg's failure does not abort the rest.
+    expect(report.stages.rss.outcome).toBe("ran");
+    expect(report.stages.staging.outcome).toBe("ran");
+    expect(report.stageMs.newsletter).not.toBe("N/A"); // it ran (and failed), so it is timed
+  });
+
+  it("maps RSS degraded (all-feeds-thin) without throwing", async () => {
+    mocks.runDailyNewsCron.mockResolvedValue({
+      success: true,
+      timestamp: "t",
+      summary: { rawItemCount: 3, clusterCount: 3, degraded: true, message: "degraded: under target" },
     });
 
     const report = await runFullPipelineDryRun({
@@ -169,8 +166,28 @@ describe("runFullPipelineDryRun", () => {
     });
 
     expect(report.stages.rss.outcome).toBe("degraded");
-    expect(report.stages.rss.insufficientReason).toBe("all_feeds_failed");
-    // Degraded RSS is still timed (it ran) — not N/A.
     expect(report.stageMs.rss).not.toBe("N/A");
+  });
+
+  it("never throws and still produces a report when ALL deps are missing", async () => {
+    mocks.runNeedsReviewSweep.mockResolvedValue({ disposedCount: 0, flaggedCount: 0, mutated: false, error: "no supabase" });
+    mocks.runNewsletterIngestion.mockResolvedValue({ success: false, timestamp: "t", summary: { message: "no creds" } });
+    mocks.runDailyNewsCron.mockResolvedValue({ success: false, timestamp: "t", summary: { message: "no egress" } });
+    mocks.runEditorialStaging.mockResolvedValue({ success: false, timestamp: "t", summary: { message: "no notion" } });
+
+    const report = await runFullPipelineDryRun({
+      env: {} as NodeJS.ProcessEnv,
+      now: NOW,
+      preflight: { supabaseClient: null, fetchImpl: fakeFetch({ egress: false, notion: false }) },
+    });
+
+    // All four were attempted (run-all), none aborted the others.
+    expect(mocks.runNeedsReviewSweep).toHaveBeenCalled();
+    expect(mocks.runNewsletterIngestion).toHaveBeenCalled();
+    expect(mocks.runDailyNewsCron).toHaveBeenCalled();
+    expect(mocks.runEditorialStaging).toHaveBeenCalled();
+    expect(report.stages.sweep.outcome).toBe("error");
+    expect(report.stages.rss.outcome).toBe("error");
+    expect(report.certifies60sFit).toBe(false);
   });
 });

--- a/src/lib/pipeline/full-dry-run.ts
+++ b/src/lib/pipeline/full-dry-run.ts
@@ -1,26 +1,27 @@
 /**
  * Full-pipeline dry-run harness (Track 2 — end the 24-hour feedback loop).
  *
- * Runs the ENTIRE pipeline — preflight → sweep → newsletter → RSS → staging —
- * by calling the SAME production functions in dry mode, writing NOTHING to prod,
- * and emitting one report: a capability matrix (PART 0), per-stage timing
- * (PART 2), and feature-validation visibility (PART 3). Validates LOGIC +
- * RELATIVE stage timing in <1 min instead of waiting ~24h for the cron tick.
+ * Runs the ENTIRE pipeline — sweep → newsletter → RSS → staging — by calling the
+ * EXACT SAME shared body the production cron runs (runEditorialIngestionPipeline),
+ * just with dryRun: true. Writes NOTHING to prod, and emits one report: a
+ * capability matrix pre-check (PART 0), per-stage timing (PART 2), and
+ * feature-validation visibility (PART 3).
+ *
+ * RUN-ALL-LIKE-PROD: every stage executes, exactly as the 12:00 UTC cron would.
+ * The capability matrix is a PRE-CHECK that names which dependencies are present;
+ * a missing one surfaces as that stage's real error/degrade (not a tidy skip),
+ * so the dry run's control flow is identical to prod's.
  *
  * SCOPE BOUNDARY: a local node process has NO 60s ceiling. A green run here does
- * NOT certify the Vercel timeout is fixed — `report.certifies60sFit` is always
- * false. "Does it fit in 60s on Vercel" requires a deployed test.
- *
- * Every stage is forced dry: the sweep gets NEEDS_REVIEW_SWEEP_DRY_RUN=true,
- * newsletter/staging get { dryRun: true }, RSS runs PIPELINE_RUN_MODE=dry_run.
- * No signal_posts writes, no Notion writes, no email, no sweep mutation.
+ * NOT certify the Vercel timeout is fixed — `certifies60sFit` is always false.
+ * "Does it fit in 60s on Vercel" requires a deployed test (the PR-2 trigger).
  */
 
 import { runNeedsReviewSweep } from "@/lib/editorial-sweep/needs-review-sweep";
-import { runEditorialStaging } from "@/lib/editorial-staging/runner";
-import { runNewsletterIngestion } from "@/lib/newsletter-ingestion/runner";
-import { resolveControlledPipelineConfig } from "@/lib/pipeline/controlled-execution";
-import { runControlledPipeline } from "@/lib/pipeline/controlled-runner";
+import {
+  runEditorialIngestionPipeline,
+  type EditorialPipelineStageName,
+} from "@/lib/pipeline/editorial-ingestion-pipeline";
 import {
   formatCapabilityMatrix,
   runPreflight,
@@ -30,9 +31,9 @@ import {
 } from "@/lib/pipeline/preflight";
 import { StageTimer, type StageMs } from "@/lib/pipeline/stage-timing";
 
-export type StageOutcome = "ran" | "skipped" | "degraded" | "error";
+export type StageOutcome = "ran" | "degraded" | "error";
 
-type StageBase = { outcome: StageOutcome; skipReason?: string; error?: string };
+type StageBase = { outcome: StageOutcome; note?: string; error?: string };
 
 export type FullDryRunReport = {
   startedAt: string;
@@ -47,7 +48,8 @@ export type FullDryRunReport = {
     rss: StageBase & {
       candidateCount?: number;
       clusterCount?: number;
-      insufficientReason?: string | null;
+      degraded?: boolean;
+      message?: string;
     };
     staging: StageBase & {
       wouldStage?: number;
@@ -56,14 +58,14 @@ export type FullDryRunReport = {
       evergreenFiltered?: number;
       crossDateWouldSkip?: number;
       detail?: unknown;
-      p4DedupNote?: string;
+      message?: string;
     };
   };
 };
 
 const SCOPE_NOTE =
-  "Local dry-run: validates pipeline LOGIC + RELATIVE stage timing with zero prod writes. " +
-  "Does NOT certify the Vercel 60s fit — that requires a deployed (preview/prod) test.";
+  "Local dry-run: runs the SAME pipeline body as the 12:00 UTC cron (dryRun) with zero prod writes. " +
+  "Validates LOGIC + RELATIVE stage timing. Does NOT certify the Vercel 60s fit — that needs a deployed test.";
 
 export type FullDryRunOptions = {
   env?: NodeJS.ProcessEnv;
@@ -71,6 +73,12 @@ export type FullDryRunOptions = {
   /** Forwarded to the preflight (injectable probes for tests). */
   preflight?: Omit<PreflightDeps, "env">;
 };
+
+/** The matrix pre-check note for a stage (named missing dep), used to explain a failure. */
+function predictedNote(matrix: CapabilityMatrix, stage: StageName): string | undefined {
+  const cap = matrix.stages.find((s) => s.stage === stage);
+  return cap?.willRun === "ready" ? undefined : cap?.skipReason;
+}
 
 export async function runFullPipelineDryRun(options: FullDryRunOptions = {}): Promise<FullDryRunReport> {
   const baseEnv = options.env ?? process.env;
@@ -80,11 +88,10 @@ export async function runFullPipelineDryRun(options: FullDryRunOptions = {}): Pr
 
   const timer = new StageTimer();
   const matrix = await runPreflight({ env, ...(options.preflight ?? {}) });
-  const cap = (s: StageName) => matrix.stages.find((x) => x.stage === s);
 
-  // ---- sweep ----
+  // ---- sweep ---- (runs first, like prod's executePipelineWork; best-effort)
   let sweep: FullDryRunReport["stages"]["sweep"];
-  if (cap("sweep")?.willRun === "ready") {
+  try {
     const summary = await timer.time("sweep", () => runNeedsReviewSweep({ env, now }));
     sweep = {
       outcome: summary.error ? "error" : "ran",
@@ -92,72 +99,82 @@ export async function runFullPipelineDryRun(options: FullDryRunOptions = {}): Pr
       flagged: summary.flaggedCount,
       mutated: summary.mutated,
       error: summary.error,
+      note: summary.error ? predictedNote(matrix, "sweep") : undefined,
     };
-  } else {
-    timer.markSkipped("sweep");
-    sweep = { outcome: "skipped", skipReason: cap("sweep")?.skipReason };
+  } catch (error) {
+    sweep = {
+      outcome: "error",
+      error: error instanceof Error ? error.message : String(error),
+      note: predictedNote(matrix, "sweep"),
+    };
   }
 
-  // ---- newsletter ----
-  let newsletter: FullDryRunReport["stages"]["newsletter"];
-  if (cap("newsletter")?.willRun === "ready") {
-    const result = await timer.time("newsletter", () => runNewsletterIngestion({ dryRun: true, now }));
-    const items = (result.summary as { fetchedMessageCount?: number }).fetchedMessageCount ?? 0;
-    newsletter = {
-      outcome: !result.success ? "error" : items === 0 ? "degraded" : "ran",
-      itemsProcessed: items,
-      // `truncated` is produced by the time-box from the timeout bundle; surface
-      // it if present, otherwise undefined (not yet built).
-      truncated: (result.summary as { newsletterTruncated?: boolean }).newsletterTruncated,
-      message: result.summary.message,
-    };
-  } else {
-    timer.markSkipped("newsletter");
-    newsletter = { outcome: "skipped", skipReason: cap("newsletter")?.skipReason };
-  }
+  // ---- newsletter → RSS → staging ---- via the SHARED prod pipeline body, dry.
+  // The harness's stage runner times each leg and catches an unexpected throw so
+  // one leg's failure never aborts the rest (degrade-like-prod).
+  const threw: Partial<Record<EditorialPipelineStageName, string>> = {};
+  const runStage = async <T>(name: EditorialPipelineStageName, run: () => Promise<T>): Promise<T> =>
+    timer.time(name, async () => {
+      try {
+        return await run();
+      } catch (error) {
+        threw[name] = error instanceof Error ? error.message : String(error);
+        return {
+          success: false,
+          timestamp: now.toISOString(),
+          summary: { message: `${name} threw: ${threw[name]}` },
+        } as unknown as T;
+      }
+    });
 
-  // ---- RSS ----
-  let rss: FullDryRunReport["stages"]["rss"];
-  if (cap("rss")?.willRun === "ready") {
-    const rssReport = await timer.time("rss", () =>
-      runControlledPipeline(resolveControlledPipelineConfig({ ...env, PIPELINE_RUN_MODE: "dry_run" })),
-    );
-    rss = {
-      outcome: rssReport.candidate_pool_insufficient ? "degraded" : "ran",
-      candidateCount: rssReport.candidateCount,
-      clusterCount: rssReport.clusterCount,
-      insufficientReason: rssReport.candidate_pool_insufficient
-        ? rssReport.candidate_pool_insufficient_reason
-        : null,
-    };
-  } else {
-    // Skipped (e.g. no egress) — NOT a "0 candidates" degraded run. The
-    // capability matrix names the reason; the timer records N/A.
-    timer.markSkipped("rss");
-    rss = { outcome: "skipped", skipReason: cap("rss")?.skipReason };
-  }
+  const { newsletter: nl, rss: rssResult, editorialStaging: st } = await runEditorialIngestionPipeline({
+    dryRun: true,
+    now,
+    runStage,
+  });
 
-  // ---- staging ----
-  let staging: FullDryRunReport["stages"]["staging"];
-  if (cap("staging")?.willRun === "ready") {
-    const result = await timer.time("staging", () => runEditorialStaging({ dryRun: true, now }));
-    const d = result.summary;
-    staging = {
-      outcome: result.success ? "ran" : "error",
-      wouldStage: d.candidateCount,
-      core: d.coreCount,
-      context: d.contextCount,
-      evergreenFiltered: d.candidatesFilteredEvergreen,
-      crossDateWouldSkip: d.notionRowsSkippedDuplicateAcrossDates,
-      detail: d.dryRunDetail,
-      // If Notion was unreachable/uncredentialed, the P4 cross-date dedup leg is
-      // degraded even though selection ran — surface that, never hide it.
-      p4DedupNote: cap("staging")?.skipReason,
-    };
-  } else {
-    timer.markSkipped("staging");
-    staging = { outcome: "skipped", skipReason: cap("staging")?.skipReason };
-  }
+  // ---- map newsletter ----
+  const nlItems = (nl.summary as { fetchedMessageCount?: number }).fetchedMessageCount ?? 0;
+  const newsletter: FullDryRunReport["stages"]["newsletter"] = {
+    outcome: threw.newsletter ? "error" : !nl.success ? "error" : nlItems === 0 ? "degraded" : "ran",
+    itemsProcessed: nlItems,
+    truncated: (nl.summary as { newsletterTruncated?: boolean }).newsletterTruncated,
+    message: nl.summary.message,
+    error: threw.newsletter,
+    note: !nl.success || threw.newsletter ? predictedNote(matrix, "newsletter") : undefined,
+  };
+
+  // ---- map RSS ----
+  const rssSummary = rssResult.summary as {
+    rawItemCount?: number;
+    clusterCount?: number;
+    degraded?: boolean;
+    message?: string;
+  };
+  const rss: FullDryRunReport["stages"]["rss"] = {
+    outcome: threw.rss ? "error" : !rssResult.success ? "error" : rssSummary.degraded ? "degraded" : "ran",
+    candidateCount: rssSummary.rawItemCount,
+    clusterCount: rssSummary.clusterCount,
+    degraded: rssSummary.degraded,
+    message: rssSummary.message,
+    error: threw.rss,
+    note: !rssResult.success || threw.rss ? predictedNote(matrix, "rss") : undefined,
+  };
+
+  // ---- map staging ----
+  const d = st.summary;
+  const staging: FullDryRunReport["stages"]["staging"] = {
+    outcome: threw.editorial_staging ? "error" : st.success ? "ran" : "error",
+    wouldStage: d.candidateCount,
+    core: d.coreCount,
+    context: d.contextCount,
+    evergreenFiltered: d.candidatesFilteredEvergreen,
+    crossDateWouldSkip: d.notionRowsSkippedDuplicateAcrossDates,
+    detail: d.dryRunDetail,
+    message: d.message,
+    error: threw.editorial_staging,
+    note: !st.success || threw.editorial_staging ? predictedNote(matrix, "staging") : undefined,
+  };
 
   return {
     startedAt: now.toISOString(),
@@ -175,16 +192,18 @@ export function formatFullDryRunReport(report: FullDryRunReport): string {
   lines.push("=== Full-pipeline dry-run report ===");
   lines.push(report.note);
   lines.push("");
+  lines.push("pre-check (capability matrix — names missing deps; stages run anyway, like prod):");
   lines.push(formatCapabilityMatrix(report.capabilityMatrix));
   lines.push("");
   lines.push(`stage_ms: ${Object.entries(report.stageMs).map(([k, v]) => `${k}=${v}`).join(" ")}`);
   lines.push("");
   for (const [name, s] of Object.entries(report.stages)) {
     const extra = Object.entries(s)
-      .filter(([k]) => !["outcome", "skipReason", "error", "detail"].includes(k))
+      .filter(([k]) => !["outcome", "note", "error", "detail"].includes(k))
       .map(([k, v]) => `${k}=${v}`)
       .join(" ");
-    lines.push(`${name.padEnd(11)} ${String(s.outcome).toUpperCase().padEnd(9)} ${s.skipReason ?? s.error ?? ""} ${extra}`.trimEnd());
+    const reason = s.error ?? s.note ?? "";
+    lines.push(`${name.padEnd(11)} ${String(s.outcome).toUpperCase().padEnd(9)} ${reason} ${extra}`.trimEnd());
   }
   return lines.join("\n");
 }


### PR DESCRIPTION
## ⚠️ Stacked on #303 — merge #303 first

This branches off `feat/full-pipeline-dry-run-harness` (#303), so the diff here is **only** PR-1's changes. **Merge #303 first**, then I'll rebase this onto `main` and retarget the base. Do not merge this before #303.

## What & why

Follow-up to the #303 pre-merge review, which found the harness had its **own copy** of the stage sequence and ran the RSS leg through `runControlledPipeline` instead of the production `runDailyNewsCron`. So a green `npm run pipeline:dry` never exercised the function prod actually calls for RSS — its seed-fallback gate, `signal_posts` snapshot path, and degraded logic were all unvalidated. The fork could silently drift from prod.

This **unifies both onto one shared body**, so the dry run mimics the 12:00 UTC cron as closely as a local process can.

## Changes

- **New `src/lib/pipeline/editorial-ingestion-pipeline.ts`** — `runEditorialIngestionPipeline({ dryRun, now, runStage })`: the single newsletter → RSS → staging sequence (prod order). Called by **both**:
  - the cron route `/api/cron/fetch-editorial-inputs` (`dryRun: false`, inside its existing run-lock + 55s internal-timeout + Pipeline-Log/Source-Health wrapper), and
  - the harness `runFullPipelineDryRun` (`dryRun: true`).
  - Each injects a `runStage` wrapper for its own concerns (route: stageRef timeout attribution + degrade-don't-throw; harness: `StageTimer` + outcome capture).
- **`runDailyNewsCron` gains a `dryRun` param** — gates `persistPipelineCandidates: !dryRun`, the `persistSignalPostsForBriefing` snapshot write, and the RSS cron-monitor check-in. Defaults `false` → the prod call is **byte-for-byte unchanged**.
- **Harness now runs ALL stages like prod** (no skip). The capability matrix is a **pre-check** that names missing deps; a missing credential surfaces as the stage's real `error`/`degrade` with the matrix reason attached — identical control flow to the cron.

## The only difference between a dry run and the 12:00 UTC cron is now: dry mode persists nothing.

## Safety / fidelity evidence

- **Prod path unchanged:** all **23 route tests green**; `runNewsletterIngestion` still called with `{ writeCandidates: true }`, same order, run-lock + timeout + observability wrapper untouched.
- **RSS dry leg is zero-write:** `ingestRawItems` performs no Supabase writes; the only writers (`persistNormalizedArticleCandidates`/cluster/ranking) sit inside `if (shouldPersistArticleCandidates)`, and the `signal_posts` snapshot + check-in are now `dryRun`-gated.
- **Fidelity gain proven live:** `npm run pipeline:dry` in a no-creds sandbox now exercises the **real** `runDailyNewsCron` and correctly reports its seed-fallback gate as an RSS error — the real prod RSS path is finally in the loop.
- **925 unit tests green**, lint + build clean, governance gate PASS (PRD-65 Phase 7.6).

## Still owed (PR-2, next)

Does **NOT** certify the Vercel 60s fit (`certifies60sFit: false`). PR-2 adds a guarded, read-only `?dryRun=1` trigger on the cron route so this unified body can be run on a **preview deployment** under the real serverless budget on demand — closing the runtime-fidelity gap without the 24h wait.

Maps to **PRD-65** (Phase 7.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)