### PR TITLE
fix(observability): make RSS/sweep observability tsx-safe so pipeline:dry stops crashing

### DIFF
--- a/docs/engineering/bug-fixes/2026-06-08-pipeline-dry-sentry-unguarded-tsx-crash.md
+++ b/docs/engineering/bug-fixes/2026-06-08-pipeline-dry-sentry-unguarded-tsx-crash.md
@@ -1,0 +1,46 @@
+# pipeline:dry collapses to seed-fallback — unguarded Sentry calls crash under tsx — Bug-Fix Record
+
+- **Date:** 2026-06-08
+- **PR:** (pending)
+- **Branch:** fix/prd-38-rss-observability-tsx-safe
+- **Head SHA:** (pending)
+- **Merge SHA:** (pending)
+- **Related PRD:** None
+- **Object level:** Infrastructure
+
+---
+
+## Symptom
+
+`npm run pipeline:dry` (the blessed zero-write local validation command) was useless: every RSS feed failed with `failure_reason: "Sentry.captureMessage is not a function"` and the `needs_review` sweep failed with the same error, so the RSS stage harvested 0 real items and fell back to deterministic seed data (`candidateCount=10`, "Cron run skipped editorial persistence because live feeds fell back to deterministic seed data"). A developer could not validate any pipeline change locally — the recurrence of the "Sentry shim fails every feed in non-prod" failure mode.
+
+## Root cause
+
+Outside the Next.js server runtime (the `pipeline:dry` harness, any CLI/tsx process, CI), the `@sentry/nextjs` SDK is never `Sentry.init`-ed and several of its functions are undefined. Three pipeline **observability writers** called `Sentry.captureMessage` / `Sentry.captureException` / `Sentry.flush` **without a guard**, so the first invocation threw `Sentry.captureMessage is not a function`:
+
+- `src/lib/observability/source-health-log.ts` — `captureSourceHealthNoop` fires once per source (38/day) when the source-health log env is unconfigured (the local/dry case), so it threw on the FIRST feed and aborted ingestion for every feed.
+- `src/lib/observability/pipeline-log.ts` — `captureWriterNoop` + the write-failure capture.
+- `src/lib/editorial-sweep/needs-review-sweep.ts` — 8 `captureMessage` calls + 6 `Sentry.flush` calls, crashing the sweep stage.
+
+The RSS observability helpers in `src/lib/observability/rss.ts` were already guarded (`isSentryConfigured("server")` + `typeof Sentry.withScope !== "function"`); these three writers had simply never been given the same guard. The throws were swallowed as per-feed/per-stage failures, masking the cause as a generic feed/ingestion failure.
+
+## Blast radius
+
+**Affected:**
+- `pipeline:dry` and any tsx/CLI/CI invocation of the ingestion pipeline (source-health write, pipeline-log write, needs_review sweep). Best-effort telemetry crashed the run instead of no-op'ing.
+
+**Not affected:**
+- Production (the Next.js server runtime, where Sentry is initialized and these functions exist). The prod cron always worked.
+- Scoring / event_importance / the PRD-38 recalibration / feed lists / selection — untouched.
+
+## Fix
+
+Added three tsx-safe wrappers and routed the unguarded calls through them — the same `isSentryConfigured("server") + typeof` guard the RSS helpers already use, so best-effort telemetry can never crash the run.
+
+- `src/lib/sentry-config.ts` — new `captureMessageSafe`, `captureExceptionSafe`, `flushSafe` (no-op unless Sentry is BOTH configured AND live).
+- `src/lib/observability/source-health-log.ts`, `src/lib/observability/pipeline-log.ts`, `src/lib/editorial-sweep/needs-review-sweep.ts` — replaced bare `Sentry.*` calls with the safe wrappers; dropped the now-unused `@sentry/nextjs` import.
+- Tests: `src/lib/sentry-config.tsx-safe.test.ts` (wrappers no-op when unconfigured); the three writers' existing tests now set `SENTRY_DSN` so their "telemetry fires when configured" assertions reflect the prod/server runtime.
+
+## Prevention
+
+The guard pattern is now centralized in three reusable wrappers; new pipeline observability code should call `captureMessageSafe` / `captureExceptionSafe` / `flushSafe` rather than `Sentry.*` directly. (Other unguarded `Sentry.*` sites outside the RSS/sweep ingestion path — `gmail.ts`, the cron route, the Next.js error boundaries — were left out of scope; they do not run under `pipeline:dry`.)

--- a/src/lib/editorial-sweep/needs-review-sweep.test.ts
+++ b/src/lib/editorial-sweep/needs-review-sweep.test.ts
@@ -153,16 +153,21 @@ function buildSweepClient(rows: Row[]) {
 }
 
 describe("needs_review TTL sweep", () => {
+  const originalDsn = process.env.SENTRY_DSN;
+
   beforeEach(() => {
     logServerEvent.mockReset();
     writePipelineLogEntry.mockReset();
     writePipelineLogEntry.mockResolvedValue({ written: true, pageId: "log-1" });
     sentryCaptureMessage.mockReset();
     sentryFlush.mockClear();
+    process.env.SENTRY_DSN = "https://test@example.test/1"; // wrappers only emit when Sentry is configured
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    if (originalDsn === undefined) delete process.env.SENTRY_DSN;
+    else process.env.SENTRY_DSN = originalDsn;
   });
 
   const liveEnv = {

--- a/src/lib/editorial-sweep/needs-review-sweep.ts
+++ b/src/lib/editorial-sweep/needs-review-sweep.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs";
+import { captureMessageSafe, flushSafe } from "@/lib/sentry-config";
 
 import { createSupabaseServiceRoleClient } from "@/lib/supabase/server";
 import { errorContext, logServerEvent } from "@/lib/observability";
@@ -227,11 +227,11 @@ export async function runNeedsReviewSweep(options: {
       error: "Supabase service role client is not configured.",
     };
     logServerEvent("error", "needs_review sweep skipped: no service-role client", toLogSummary(summary));
-    Sentry.captureMessage("needs_review sweep could not run: service-role client unavailable.", {
+    captureMessageSafe("needs_review sweep could not run: service-role client unavailable.", {
       level: "error",
       tags: { failure_type: "needs_review_sweep_no_client" },
     });
-    await Sentry.flush(2_000).catch(() => { /* best-effort */ });
+    await flushSafe(2_000).catch(() => { /* best-effort */ });
     return summary;
   }
 
@@ -256,12 +256,12 @@ export async function runNeedsReviewSweep(options: {
         ...toLogSummary(summary),
         ...errorContext(result.error),
       });
-      Sentry.captureMessage("needs_review sweep read failed.", {
+      captureMessageSafe("needs_review sweep read failed.", {
         level: "error",
         tags: { failure_type: "needs_review_sweep_read_failed" },
         extra: { reason: result.error.message },
       });
-      await Sentry.flush(2_000).catch(() => { /* best-effort */ });
+      await flushSafe(2_000).catch(() => { /* best-effort */ });
       return summary;
     }
 
@@ -275,11 +275,11 @@ export async function runNeedsReviewSweep(options: {
       ...toLogSummary(summary),
       ...errorContext(error),
     });
-    Sentry.captureMessage("needs_review sweep read threw.", {
+    captureMessageSafe("needs_review sweep read threw.", {
       level: "error",
       tags: { failure_type: "needs_review_sweep_read_threw" },
     });
-    await Sentry.flush(2_000).catch(() => { /* best-effort */ });
+    await flushSafe(2_000).catch(() => { /* best-effort */ });
     return summary;
   }
 
@@ -302,7 +302,7 @@ export async function runNeedsReviewSweep(options: {
       ...toLogSummary(summary),
       max: config.max,
     });
-    Sentry.captureMessage(
+    captureMessageSafe(
       `needs_review sweep aborted: ${disposeRows.length} aged-never-drafted rows exceed cap ${config.max}. ` +
         "A purge this large must be a human decision.",
       {
@@ -311,7 +311,7 @@ export async function runNeedsReviewSweep(options: {
         extra: { disposeSetSize: disposeRows.length, cap: config.max, cutoffDate },
       },
     );
-    await Sentry.flush(2_000).catch(() => { /* best-effort */ });
+    await flushSafe(2_000).catch(() => { /* best-effort */ });
     await writeSweepPipelineLog(summary, runDate, config);
     return summary;
   }
@@ -351,12 +351,12 @@ export async function runNeedsReviewSweep(options: {
           ...toLogSummary(summary),
           ...errorContext(updateResult.error),
         });
-        Sentry.captureMessage("needs_review sweep update failed.", {
+        captureMessageSafe("needs_review sweep update failed.", {
           level: "error",
           tags: { failure_type: "needs_review_sweep_update_failed" },
           extra: { reason: updateResult.error.message },
         });
-        await Sentry.flush(2_000).catch(() => { /* best-effort */ });
+        await flushSafe(2_000).catch(() => { /* best-effort */ });
         await writeSweepPipelineLog(summary, runDate, config);
         return summary;
       }
@@ -384,11 +384,11 @@ export async function runNeedsReviewSweep(options: {
         ...toLogSummary(summary),
         ...errorContext(error),
       });
-      Sentry.captureMessage("needs_review sweep update threw.", {
+      captureMessageSafe("needs_review sweep update threw.", {
         level: "error",
         tags: { failure_type: "needs_review_sweep_update_threw" },
       });
-      await Sentry.flush(2_000).catch(() => { /* best-effort */ });
+      await flushSafe(2_000).catch(() => { /* best-effort */ });
       await writeSweepPipelineLog(summary, runDate, config);
       return summary;
     }
@@ -449,7 +449,7 @@ async function writeSweepPipelineLog(
   } catch (error) {
     // writePipelineLogEntry is documented never to throw; guard anyway.
     logServerEvent("warn", "needs_review sweep pipeline-log write threw", errorContext(error));
-    Sentry.captureMessage("needs_review sweep pipeline-log writer threw.", {
+    captureMessageSafe("needs_review sweep pipeline-log writer threw.", {
       level: "warning",
       tags: { failure_type: "needs_review_sweep_pipeline_log_threw" },
     });
@@ -459,7 +459,7 @@ async function writeSweepPipelineLog(
   if (!result.written && !/not configured/i.test(result.reason)) {
     // The writer is down (Notion API failure), not merely unconfigured.
     logServerEvent("warn", "needs_review sweep pipeline-log write failed", { reason: result.reason });
-    Sentry.captureMessage("needs_review sweep pipeline-log write failed (writer down).", {
+    captureMessageSafe("needs_review sweep pipeline-log write failed (writer down).", {
       level: "warning",
       tags: { failure_type: "needs_review_sweep_pipeline_log_failed" },
       extra: { reason: result.reason },

--- a/src/lib/observability/pipeline-log.test.ts
+++ b/src/lib/observability/pipeline-log.test.ts
@@ -20,10 +20,12 @@ describe("writePipelineLogEntry — observability hygiene (#272 P2)", () => {
   const originalFetch = globalThis.fetch;
   const originalDbId = process.env.NOTION_PIPELINE_LOG_DB_ID;
   const originalToken = process.env.NOTION_TOKEN;
+  const originalDsn = process.env.SENTRY_DSN;
 
   beforeEach(() => {
     vi.resetModules();
     vi.resetAllMocks();
+    process.env.SENTRY_DSN = "https://test@example.test/1"; // wrappers only emit when Sentry is configured
     delete process.env.NOTION_PIPELINE_LOG_DB_ID;
     delete process.env.NOTION_TOKEN;
   });
@@ -34,6 +36,8 @@ describe("writePipelineLogEntry — observability hygiene (#272 P2)", () => {
     else process.env.NOTION_PIPELINE_LOG_DB_ID = originalDbId;
     if (originalToken === undefined) delete process.env.NOTION_TOKEN;
     else process.env.NOTION_TOKEN = originalToken;
+    if (originalDsn === undefined) delete process.env.SENTRY_DSN;
+    else process.env.SENTRY_DSN = originalDsn;
   });
 
   const entry = {

--- a/src/lib/observability/pipeline-log.ts
+++ b/src/lib/observability/pipeline-log.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs";
+import { captureExceptionSafe, captureMessageSafe } from "@/lib/sentry-config";
 
 import { errorContext, logServerEvent } from "@/lib/observability";
 
@@ -67,7 +67,7 @@ function richText(content: string) {
  * specific reason + run metadata for the issue body.
  */
 function captureWriterNoop(reason: string, extra: Record<string, unknown>) {
-  Sentry.captureMessage("Pipeline log writer no-op", {
+  captureMessageSafe("Pipeline log writer no-op", {
     level: "warning",
     fingerprint: ["pipeline-log-writer-noop", reason],
     tags: {
@@ -190,7 +190,7 @@ export async function writePipelineLogEntry(
       briefingDate: entry.briefingDate,
       ...errorContext(error),
     });
-    Sentry.captureException(error, {
+    captureExceptionSafe(error, {
       tags: {
         observability_surface: "pipeline_log",
         writer_noop_reason: "threw",

--- a/src/lib/observability/source-health-log.test.ts
+++ b/src/lib/observability/source-health-log.test.ts
@@ -19,10 +19,12 @@ describe("writeSourceHealthEntry — observability hygiene (#272 P2)", () => {
   const originalFetch = globalThis.fetch;
   const originalDbId = process.env.NOTION_SOURCE_HEALTH_LOG_DB_ID;
   const originalToken = process.env.NOTION_TOKEN;
+  const originalDsn = process.env.SENTRY_DSN;
 
   beforeEach(() => {
     vi.resetModules();
     vi.resetAllMocks();
+    process.env.SENTRY_DSN = "https://test@example.test/1"; // wrappers only emit when Sentry is configured
     delete process.env.NOTION_SOURCE_HEALTH_LOG_DB_ID;
     delete process.env.NOTION_TOKEN;
   });
@@ -33,6 +35,8 @@ describe("writeSourceHealthEntry — observability hygiene (#272 P2)", () => {
     else process.env.NOTION_SOURCE_HEALTH_LOG_DB_ID = originalDbId;
     if (originalToken === undefined) delete process.env.NOTION_TOKEN;
     else process.env.NOTION_TOKEN = originalToken;
+    if (originalDsn === undefined) delete process.env.SENTRY_DSN;
+    else process.env.SENTRY_DSN = originalDsn;
   });
 
   const entry = {

--- a/src/lib/observability/source-health-log.ts
+++ b/src/lib/observability/source-health-log.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs";
+import { captureExceptionSafe, captureMessageSafe } from "@/lib/sentry-config";
 
 import { errorContext, logServerEvent } from "@/lib/observability";
 
@@ -179,7 +179,7 @@ function buildProperties(
  * across the entire run, not one per source fetched (38 sources/day).
  */
 function captureSourceHealthNoop(reason: string, extra: Record<string, unknown>) {
-  Sentry.captureMessage("Source health log writer no-op", {
+  captureMessageSafe("Source health log writer no-op", {
     level: "warning",
     fingerprint: ["source-health-log-writer-noop", reason],
     tags: {
@@ -292,7 +292,7 @@ export async function writeSourceHealthEntry(
       date: entry.date,
       ...errorContext(error),
     });
-    Sentry.captureException(error, {
+    captureExceptionSafe(error, {
       tags: {
         observability_surface: "source_health_log",
         writer_noop_reason: "threw",

--- a/src/lib/sentry-config.ts
+++ b/src/lib/sentry-config.ts
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/nextjs";
+
 const DEFAULT_TRACES_SAMPLE_RATE = 0.05;
 const DEFAULT_REPLAYS_SESSION_SAMPLE_RATE = 0;
 const DEFAULT_REPLAYS_ON_ERROR_SAMPLE_RATE = 0.05;
@@ -35,6 +37,44 @@ export function readSentryDsn(runtime: "server" | "client" = "server") {
 
 export function isSentryConfigured(runtime: "server" | "client" = "server") {
   return Boolean(readSentryDsn(runtime));
+}
+
+/**
+ * tsx-safe Sentry capture/flush wrappers.
+ *
+ * Outside the Next.js server runtime (the `npm run pipeline:dry` harness, any
+ * CLI/tsx process, CI) the `@sentry/nextjs` SDK functions can be undefined even
+ * when SENTRY_DSN is set. A bare `Sentry.captureMessage(...)` then throws
+ * "Sentry.captureMessage is not a function" and crashes the caller on first use
+ * — which silently broke every RSS source-health write + the needs_review sweep
+ * in `pipeline:dry`, collapsing the dry-run to seed-fallback. These wrappers
+ * no-op unless Sentry is BOTH configured AND actually live (the same
+ * `isSentryConfigured` + `typeof` guard the RSS observability helpers already
+ * use), so best-effort pipeline telemetry can never crash the run.
+ */
+export function captureMessageSafe(...args: Parameters<typeof Sentry.captureMessage>): void {
+  if (!isSentryConfigured("server") || typeof Sentry.captureMessage !== "function") {
+    return;
+  }
+  Sentry.captureMessage(...args);
+}
+
+export function captureExceptionSafe(...args: Parameters<typeof Sentry.captureException>): void {
+  if (!isSentryConfigured("server") || typeof Sentry.captureException !== "function") {
+    return;
+  }
+  Sentry.captureException(...args);
+}
+
+export async function flushSafe(timeoutMs = 2000): Promise<boolean> {
+  if (!isSentryConfigured("server") || typeof Sentry.flush !== "function") {
+    return true;
+  }
+  try {
+    return await Sentry.flush(timeoutMs);
+  } catch {
+    return false;
+  }
 }
 
 export function readSentryEnvironment() {

--- a/src/lib/sentry-config.tsx-safe.test.ts
+++ b/src/lib/sentry-config.tsx-safe.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { captureExceptionSafe, captureMessageSafe, flushSafe } from "@/lib/sentry-config";
+
+/**
+ * Regression guard for the `pipeline:dry` crash: outside the Next.js server
+ * runtime the @sentry/nextjs SDK functions can be undefined, so the previously
+ * UNGUARDED `Sentry.captureMessage(...)` in the source-health / pipeline-log /
+ * needs_review-sweep writers threw "Sentry.captureMessage is not a function" and
+ * killed every RSS feed + the sweep, collapsing the dry-run to seed-fallback.
+ * The tsx-safe wrappers must no-op (never throw) when Sentry is unconfigured.
+ */
+describe("tsx-safe Sentry wrappers no-op when Sentry is unconfigured", () => {
+  let savedDsn: string | undefined;
+  let savedPublic: string | undefined;
+
+  beforeEach(() => {
+    savedDsn = process.env.SENTRY_DSN;
+    savedPublic = process.env.NEXT_PUBLIC_SENTRY_DSN;
+    delete process.env.SENTRY_DSN;
+    delete process.env.NEXT_PUBLIC_SENTRY_DSN;
+  });
+
+  afterEach(() => {
+    if (savedDsn === undefined) delete process.env.SENTRY_DSN;
+    else process.env.SENTRY_DSN = savedDsn;
+    if (savedPublic === undefined) delete process.env.NEXT_PUBLIC_SENTRY_DSN;
+    else process.env.NEXT_PUBLIC_SENTRY_DSN = savedPublic;
+  });
+
+  it("captureMessageSafe does not throw and no-ops (the per-feed crash path)", () => {
+    expect(() =>
+      captureMessageSafe("Source health log writer no-op", {
+        level: "warning",
+        tags: { observability_surface: "source_health_log" },
+      }),
+    ).not.toThrow();
+    expect(captureMessageSafe("noop")).toBeUndefined();
+  });
+
+  it("captureExceptionSafe does not throw and no-ops", () => {
+    expect(() => captureExceptionSafe(new Error("boom"), { tags: { x: "y" } })).not.toThrow();
+    expect(captureExceptionSafe(new Error("boom"))).toBeUndefined();
+  });
+
+  it("flushSafe resolves true without throwing (the sweep flush path)", async () => {
+    await expect(flushSafe(10)).resolves.toBe(true);
+  });
+});


### PR DESCRIPTION
# Summary

Makes the RSS / sweep ingestion **observability writers tsx-safe** so `npm run pipeline:dry` stops crashing. Independent of the PRD-38 recalibration (#312/#313) — this durably unbreaks local PR validation.

**Why.** `pipeline:dry` collapsed to seed-fallback: every RSS feed failed with `Sentry.captureMessage is not a function` and the `needs_review` sweep failed the same way, so the RSS stage harvested 0 real items (`candidateCount=10`, the deterministic seeds). Outside the Next.js server runtime (the dry-run harness, any CLI/tsx process, CI) the `@sentry/nextjs` SDK is never `init`-ed and its functions are undefined; three observability writers called `Sentry.captureMessage` / `captureException` / `flush` **unguarded**, throwing on the first feed + the sweep. (The RSS helpers in `rss.ts` were already guarded — these three writers had simply never been given the same guard.) Production (Next.js runtime) was never affected.

**Fix** — add tsx-safe wrappers using the **same** `isSentryConfigured("server")` + `typeof` guard the RSS helpers already use, and route the unguarded calls through them:
- `src/lib/sentry-config.ts` — new `captureMessageSafe` / `captureExceptionSafe` / `flushSafe` (no-op unless Sentry is BOTH configured AND live).
- `src/lib/observability/source-health-log.ts`, `src/lib/observability/pipeline-log.ts`, `src/lib/editorial-sweep/needs-review-sweep.ts` — bare `Sentry.*` → safe wrappers; dropped the now-unused `@sentry/nextjs` import.
- Tests: `src/lib/sentry-config.tsx-safe.test.ts` (wrappers no-op when unconfigured — the dry-run scenario); the three writers' existing tests now set `SENTRY_DSN` so their "telemetry fires when configured" assertions reflect the prod/server runtime.

**Scope.** ONLY the unguarded Sentry calls in the RSS/sweep ingestion observability writers. No scoring / recalibration / feed / selection changes. Other unguarded `Sentry.*` sites that never run under `pipeline:dry` (`gmail.ts`, the cron route, the Next.js error boundaries) were intentionally left out of scope.

## Validation
- [x] `src/lib/sentry-config.tsx-safe.test.ts` — wrappers no-op (no throw) when Sentry unconfigured
- [x] Full suite **1040 green** (the 3 writers' tests updated to set `SENTRY_DSN`); lint + build clean; governance gate PASS
- [x] Bug-fix record: `docs/engineering/bug-fixes/2026-06-08-pipeline-dry-sentry-unguarded-tsx-crash.md` (Related PRD: None — observability/infrastructure)
- [ ] Post-merge: `pipeline:dry` now loads live feeds (~200 candidates, not 10 seed) instead of seed-fallback

## Classification
- [x] Change type **bug-fix**; Object level **Infrastructure**; Related PRD **None**; no terminology blur; no secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
