### PR TITLE
docs(agents): add Diagnosis discipline operating rule (§14)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,7 +277,19 @@ These have cost this project real time. Recognize them on sight:
 
 ---
 
-## 14. Required Output Format
+## 14. Diagnosis discipline
+
+When investigating a question that will gate a code change, before giving any recommendation:
+
+1. **Ground every load-bearing claim.** List the claims your recommendation depends on. For each, paste the governing code (the actual predicate/function, not a paraphrase) with file:line — OR mark it `INFERRED — not verified`. A recommendation resting on an inferred claim is a hypothesis, not a finding. Confidence and citations are not evidence; the pasted code is.
+
+2. **State a falsifier.** End every diagnosis with: "This conclusion is WRONG if [specific observable]." If you can't name what would disprove it, you haven't tested it.
+
+3. **Steelman the alternative.** Before recommending, make the strongest case for the opposite choice and read the code that would make it correct. Only then recommend.
+
+---
+
+## 15. Required Output Format
 
 After every completed task, your final message must include:
 


### PR DESCRIPTION
## What

Adds **§14 "Diagnosis discipline"** to `AGENTS.md`, placed after §13 "Known Failure Modes"; renumbers "Required Output Format" to §15.

The new rule requires, before any recommendation that gates a code change:
1. **Ground every load-bearing claim** — paste governing code with `file:line`, or mark `INFERRED — not verified`.
2. **State a falsifier** — name the observable that would prove the conclusion wrong.
3. **Steelman the alternative** — read the code that would make the opposite choice correct, then recommend.

## Scope

Docs-only. No code, no CSV, no PRD changes.

## CI

- `release-governance-gate.py --base origin/main --head HEAD` → **PASS** (classification: `docs-only`, baseline tier).
- `feature-system-csv-validation` — N/A (CSV untouched).
- PRD index check — N/A (no bug-fix/incident record; `Related PRD: None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)