### PR TITLE
fix(editorial): surface all three layers on the review card + label The Signal in editor

### DIFF
--- a/docs/engineering/bug-fixes/editorial-review-card-single-layer-render-2026-06-09.md
+++ b/docs/engineering/bug-fixes/editorial-review-card-single-layer-render-2026-06-09.md
@@ -1,0 +1,23 @@
+# Editorial Review Card — Single-Layer Render — Bug-Fix Record
+
+## Summary
+- **Problem addressed:** The editorial-review cockpit (`/dashboard/signals/editorial-review`) showed **one** editorial block per candidate on the at-a-glance review card, even though each `signal_posts` row stores **three** distinct editorial layers: `edited_why_it_matters` → **The Signal**, `edited_what_led_to_it` → **Before This**, `edited_what_it_connects_to` → **The Ripple**. Reviewers could not see Before This / The Ripple without opening each card's editor, so the review surface did not match the Notion three-layer view. Confirmed on the live 2026-06-09 rows (all three columns populated and distinct).
+- **Root cause:** A **card-level presentation gap, NOT a read/data bug.** The loader already SELECTs and maps all three text columns + payloads (`src/lib/signals-editorial.ts`), and the *expanded* editor already read all three from their text columns (a NULL `*_payload` correctly falls back to text). But `CandidateRow` rendered only the WITM body via `getCandidateWitmBody` (`edited_why_it_matters || published_* || ai_*`); the two depth layers were absent from the card.
+- **Falsifier that resolved the diagnosis:** "Before This / The Ripple are missing or mirror The Signal in the *expanded editor*" — did **not** hold; the editor renders all three distinctly. That isolated the defect to the card, ruling out a NULL-`*_payload` read bug.
+- **Affected object level:** Admin UI only (review card + editor labeling). No row mutation.
+- **Related PR:** #321.
+
+## Fix
+- **(A) `src/components/admin/editorial-composer/CandidateRow.tsx`** — render three read-only **labeled** previews in fixed order **The Signal → Before This → The Ripple**. Each layer sources `edited_* → published_* → ai_*` (the card's existing WITM precedence; never `human_*`, never `*_payload`). 2-line clamp, labeled empty states, and the WITM rewrite-gate placeholder preserved on The Signal. `getCandidateWitmBody` was replaced by three layer getters + a `CardLayerPreview` component.
+- **(B) `src/app/dashboard/signals/editorial-review/StructuredEditorialFields.tsx`** — add a visible **"The Signal"** label (`LayerHeading`) above the structured sub-editor and present the three layers as labeled peers in the same order. The Signal's structured authoring controls (teaser / thesis / sections) are unchanged.
+
+## Tests
+- **New regression tests** (`editorial-composer-components.test.tsx`, `#321`): assert the card renders all three labels in fixed order with each layer's own body, and that absent depth layers show labeled empty states without leaking the WITM body into the other two layers.
+- Existing card/page/editor assertions (WITM body present, rewrite placeholder, `Homepage teaser` / `Thesis` editor labels) remain green.
+- Full suite: **1062/1062 across 126 files** (was 1060; +2 new). eslint clean.
+- **Visual confirmation:** live-rendered `CandidateRow` across three states (fully populated, rewrite-gated, partial-empty) and verified the three labeled layers, 2-line clamping, and labeled empty states.
+
+## Not addressed by this fix
+- The Signal's **structured authoring path** (`edited_why_it_matters_payload`, which the public homepage renders from via `SignalCard` / `readLayerBody`, structured-first with text fallback) — intentionally untouched; **not** collapsed to a plain textarea (that would be a public-homepage render change).
+- No change to the loader, the publish gate, the `edited_* → published_*` promotion, or `is_live` gating (publish still keeps `is_live=false` until publish).
+- No schema change. No row mutation. No change to the public homepage read path.

--- a/src/app/dashboard/signals/editorial-review/StructuredEditorialFields.tsx
+++ b/src/app/dashboard/signals/editorial-review/StructuredEditorialFields.tsx
@@ -392,6 +392,13 @@ export function StructuredEditorialFields({
         readOnly
       />
 
+      {/* The Signal — the lead editorial layer (why it matters). The rich
+          structured editor below composes the homepage teaser/expanded
+          payload; its hidden inputs (above) save to edited_why_it_matters. */}
+      <LayerHeading
+        title="The Signal"
+        help="Why it matters — the lead layer. Saves to edited_why_it_matters and is promoted to published_why_it_matters on publish. The homepage teaser and expanded view render from this layer."
+      />
       <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(22rem,0.8fr)]">
         <div className="space-y-4">
           <FieldBlock
@@ -529,12 +536,14 @@ export function StructuredEditorialFields({
       {/* #274 Before This + The Ripple. Simple textareas, no structured
           editor — the publish gate writes both the text and a
           legacy-text-derived payload to published_what_*. The editor can
-          clear either layer by emptying the textarea before saving. */}
-      <div className="grid gap-4 lg:grid-cols-2">
+          clear either layer by emptying the textarea before saving.
+          Presented as two labeled peer sections after The Signal, so the
+          three layers read in order: The Signal → Before This → The Ripple. */}
+      <div className="border-t border-[var(--border)] pt-5">
         <FieldBlock
           id={`editedWhatLedToIt-${postId}`}
-          label="Before This (what led to this)"
-          help="Causal / preceding context. Promoted to published_what_led_to_it on publish. Leave empty to suppress the layer from the public foldback."
+          label="Before This"
+          help="Causal / preceding context (what led to this). Saves to edited_what_led_to_it; promoted to published_what_led_to_it on publish. Leave empty to suppress the layer from the public foldback."
         >
           <textarea
             id={`editedWhatLedToIt-${postId}`}
@@ -544,10 +553,12 @@ export function StructuredEditorialFields({
             className="w-full resize-y rounded-card border border-[var(--border)] bg-[var(--card)] px-3 py-3 text-sm leading-6 text-[var(--text-primary)] outline-none transition focus:border-[var(--accent)]"
           />
         </FieldBlock>
+      </div>
+      <div className="border-t border-[var(--border)] pt-5">
         <FieldBlock
           id={`editedWhatItConnectsTo-${postId}`}
-          label="The Ripple (what it connects to)"
-          help="Trajectory / downstream implications. Promoted to published_what_it_connects_to on publish. Leave empty to suppress the layer from the public foldback."
+          label="The Ripple"
+          help="Trajectory / downstream implications (what it connects to). Saves to edited_what_it_connects_to; promoted to published_what_it_connects_to on publish. Leave empty to suppress the layer from the public foldback."
         >
           <textarea
             id={`editedWhatItConnectsTo-${postId}`}
@@ -580,6 +591,22 @@ function FieldBlock({
       </label>
       <span className="mt-1 block text-sm leading-6 text-[var(--text-secondary)]">{help}</span>
       <span className="mt-2 block">{children}</span>
+    </div>
+  );
+}
+
+/**
+ * Section heading for a top-level editorial layer. Mirrors FieldBlock's
+ * label + help typography so the three layers — The Signal, Before This,
+ * The Ripple — read as uniform peer sections. Used for The Signal, which
+ * wraps a composite editor rather than a single labelled input; Before
+ * This / The Ripple reuse FieldBlock directly.
+ */
+function LayerHeading({ title, help }: { title: string; help: string }) {
+  return (
+    <div>
+      <p className="text-sm font-medium text-[var(--text-primary)]">{title}</p>
+      <span className="mt-1 block text-sm leading-6 text-[var(--text-secondary)]">{help}</span>
     </div>
   );
 }

--- a/src/components/admin/editorial-composer/CandidateRow.tsx
+++ b/src/components/admin/editorial-composer/CandidateRow.tsx
@@ -26,7 +26,9 @@ export function CandidateRow({
   const requiresRewrite = candidate.whyItMattersValidationStatus === "requires_human_rewrite";
   const canAssign = isCandidateAssignable(candidate, storageReady) && !requiresRewrite;
   const status = getCandidateStatus(candidate);
-  const witmBody = getCandidateWitmBody(candidate);
+  const signalBody = getCandidateSignalBody(candidate);
+  const beforeThisBody = getCandidateBeforeThisBody(candidate);
+  const rippleBody = getCandidateRippleBody(candidate);
 
   return (
     <article className="rounded-[var(--bu-radius-lg)] border border-[var(--bu-border-subtle)] bg-[var(--bu-bg-surface)] p-[var(--bu-space-4)]">
@@ -43,16 +45,32 @@ export function CandidateRow({
             {candidate.title}
           </h3>
 
-          <p
-            className={cn(
-              "mt-2 font-heading text-[var(--bu-size-meta)] leading-[1.5] text-[var(--bu-text-secondary)]",
-              requiresRewrite && "italic text-[var(--bu-text-tertiary)]",
-            )}
-          >
-            {requiresRewrite
-              ? "Template placeholder language detected. WITM requires editorial rewrite before this candidate is publishable."
-              : witmBody}
-          </p>
+          {/* Three-layer at-a-glance preview (read-only), mirroring the
+              editor and the Notion three-layer view in the fixed order
+              The Signal → Before This → The Ripple. Each layer sources from
+              the same fields the editor reads (edited_* → published_* →
+              ai_*). The Signal keeps the WITM rewrite-gate placeholder. */}
+          <div className="mt-3 space-y-[var(--bu-space-3)]">
+            <CardLayerPreview
+              label="The Signal"
+              body={requiresRewrite ? "" : signalBody}
+              emptyText={
+                requiresRewrite
+                  ? "Template placeholder language detected. WITM requires editorial rewrite before this candidate is publishable."
+                  : "No WITM draft available."
+              }
+            />
+            <CardLayerPreview
+              label="Before This"
+              body={beforeThisBody}
+              emptyText="No Before This draft yet."
+            />
+            <CardLayerPreview
+              label="The Ripple"
+              body={rippleBody}
+              emptyText="No Ripple draft yet."
+            />
+          </div>
         </div>
 
         <div className="space-y-[var(--bu-space-2)]">
@@ -132,12 +150,62 @@ function getCandidateStatus(candidate: EditorialSignalPost) {
   return "failed" as const;
 }
 
-function getCandidateWitmBody(candidate: EditorialSignalPost) {
+// At-a-glance layer bodies. Same precedence the card has always used for
+// WITM (edited_* → published_* → ai_*); returns "" when every source is
+// empty so CardLayerPreview can render the labeled empty state. NEVER reads
+// the human_* override — that is a bridge-only field, not an editorial layer.
+function getCandidateSignalBody(candidate: EditorialSignalPost) {
   return (
     candidate.editedWhyItMatters ||
     candidate.publishedWhyItMatters ||
     candidate.aiWhyItMatters ||
-    "No WITM draft available."
+    ""
+  );
+}
+
+function getCandidateBeforeThisBody(candidate: EditorialSignalPost) {
+  return (
+    candidate.editedWhatLedToIt ||
+    candidate.publishedWhatLedToIt ||
+    candidate.aiWhatLedToIt ||
+    ""
+  );
+}
+
+function getCandidateRippleBody(candidate: EditorialSignalPost) {
+  return (
+    candidate.editedWhatItConnectsTo ||
+    candidate.publishedWhatItConnectsTo ||
+    candidate.aiWhatItConnectsTo ||
+    ""
+  );
+}
+
+function CardLayerPreview({
+  label,
+  body,
+  emptyText,
+}: {
+  label: string;
+  body: string;
+  emptyText: string;
+}) {
+  const hasBody = body.trim().length > 0;
+
+  return (
+    <div className="min-w-0">
+      <p className="text-[var(--bu-size-micro)] font-medium uppercase tracking-[0.08em] text-[var(--bu-text-tertiary)]">
+        {label}
+      </p>
+      <p
+        className={cn(
+          "mt-1 font-heading text-[var(--bu-size-meta)] leading-[1.5] line-clamp-2",
+          hasBody ? "text-[var(--bu-text-secondary)]" : "italic text-[var(--bu-text-tertiary)]",
+        )}
+      >
+        {hasBody ? body : emptyText}
+      </p>
+    </div>
   );
 }
 

--- a/src/components/admin/editorial-composer/editorial-composer-components.test.tsx
+++ b/src/components/admin/editorial-composer/editorial-composer-components.test.tsx
@@ -295,6 +295,48 @@ describe("editorial composer components", () => {
     expect(screen.getByText(/Template placeholder language detected/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Assign Candidate title to a slot/i)).toBeDisabled();
   });
+
+  // #321 — the card must surface all three editorial layers at a glance,
+  // labeled and in fixed order, each from its own column. Regression guard
+  // against the "one block per signal" bug where only WITM was shown.
+  it("renders all three layers labeled in order, each from its own column (#321)", () => {
+    render(
+      <CandidateRow
+        candidate={createCandidate({
+          editedWhyItMatters: "Signal body — what this means now.",
+          editedWhatLedToIt: "Before This body — what produced it.",
+          editedWhatItConnectsTo: "Ripple body — what it implies next.",
+        })}
+        openSlots={[1]}
+        storageReady
+        onAssign={vi.fn()}
+      />,
+    );
+
+    const labels = screen
+      .getAllByText(/^(The Signal|Before This|The Ripple)$/u)
+      .map((node) => node.textContent);
+    expect(labels).toEqual(["The Signal", "Before This", "The Ripple"]);
+
+    expect(screen.getByText("Signal body — what this means now.")).toBeInTheDocument();
+    expect(screen.getByText("Before This body — what produced it.")).toBeInTheDocument();
+    expect(screen.getByText("Ripple body — what it implies next.")).toBeInTheDocument();
+  });
+
+  it("shows labeled empty states for absent depth layers without leaking WITM (#321)", () => {
+    render(
+      <CandidateRow
+        candidate={createCandidate({ editedWhyItMatters: "Only the signal." })}
+        openSlots={[1]}
+        storageReady
+        onAssign={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Only the signal.")).toBeInTheDocument();
+    expect(screen.getByText("No Before This draft yet.")).toBeInTheDocument();
+    expect(screen.getByText("No Ripple draft yet.")).toBeInTheDocument();
+  });
 });
 
 describe("BulkApproveForm", () => {


### PR DESCRIPTION
## What & why

The editorial-review cockpit (`/dashboard/signals/editorial-review`) rendered **one** editorial block per signal — only the WITM layer (`edited_why_it_matters`) — even though each `signal_posts` row stores three distinct layers. BM verified the three columns are populated and distinct on the live June-9 rows.

**Diagnosis (file:line-grounded):** This was a **card-level presentation gap, not a read bug.**
- The loader already SELECTs and maps all three text columns + payloads (`src/lib/signals-editorial.ts`).
- The *expanded* editor already read all three from their **text** columns; a NULL `*_payload` correctly falls back to text (refuting the "renders from NULL payload" theory).
- The at-a-glance candidate card (`CandidateRow`) rendered only the WITM body → the "one block per signal" symptom. Falsifier (Before This/The Ripple absent or mirroring The Signal in the editor) did not hold.

## Changes (presentation only)

- **`CandidateRow.tsx`** — render three read-only **labeled** previews in fixed order **The Signal → Before This → The Ripple**, each sourced `edited_* → published_* → ai_*` (the card's existing WITM precedence; no `human_*`, no `*_payload`). 2-line clamp, labeled empty states, and the WITM rewrite-gate placeholder preserved on The Signal.
- **`StructuredEditorialFields.tsx`** — add a visible **"The Signal"** label above the structured sub-editor and present the three layers as labeled peers in the same order.

## Explicitly NOT changed (out of scope / risk-managed)

- The Signal's **structured authoring path** (`edited_why_it_matters_payload`, which the public homepage renders from via `SignalCard`/`readLayerBody`) — left intact; **not** collapsed to a plain textarea.
- Loader, publish gate, `edited_* → published_*` promotion, `is_live` gating, and the public homepage read path — untouched.

## Validation

- `eslint`: clean on both files.
- `vitest` full suite: **126 files / 1060 tests pass**.
- Adversarial multi-agent review: 4/4 lenses pass, 0 blockers (scope, card correctness, "don't collapse The Signal", regression hazards).
- Live-rendered the card and visually verified all three states: fully-populated, rewrite-gated, and partial-empty.

## Notes

- The Signal's at-a-glance card preview is now clamped to 2 lines (previously showed full WITM text on the card). Full text remains in the expanded editor.
- Related PRD: None (UI presentation bug fix; no schema/pipeline change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)