### PR TITLE
fix(homepage): force-dynamic so it never serves a stale published slate

### DIFF
--- a/docs/engineering/bug-fixes/homepage-stale-published-slate-cache-2026-06-09.md
+++ b/docs/engineering/bug-fixes/homepage-stale-published-slate-cache-2026-06-09.md
@@ -1,0 +1,22 @@
+# Homepage Served a Stale Published Slate — Bug-Fix Record
+
+## Summary
+- **Problem addressed:** After publishing the daily slate, the public homepage (`/`) showed **fewer signals than were actually published** (e.g. 5 — or even 0 — while `/signals` correctly showed 7). The DB had 7 live, published rows for the briefing date; the homepage was serving a **stale render**.
+- **Root cause:** `/` was **not** `force-dynamic` (unlike `/signals`), so Next.js cached / statically rendered it. The production deploy for #322 landed at **21:14:04 UTC**, but that day's slate wasn't published until **21:17:49 UTC** — ~3.5 minutes later. The build-time render of `/` therefore captured the **pre-publish (empty) state**, and the edge cache kept serving that stale render. `/signals` was unaffected because it already declares `export const dynamic = "force-dynamic"`.
+- **Not the cause (ruled out):** the cap-to-7 code (every homepage data path returns up to 7 — `getHomepageSignalSnapshot` → `slice(0, TOP_SIGNAL_SET_SIZE=7)`; the view-model renders 7 from 7 items), the data (7 live rows confirmed in the DB), and the deployment (the #322 build was READY and current — nothing was reverted). The discrepancy was purely caching.
+- **Affected object level:** Public homepage SSR/caching. No data change, no schema change.
+- **Related:** follow-up to #322 (cap 5 → 7 / Pick → Publish).
+
+## Fix
+- **`src/app/page.tsx`** — add `export const dynamic = "force-dynamic"` and `export const revalidate = 0`, matching `/signals`. The homepage now always renders from the live published signal set, so it can never serve a stale build-time slate again.
+
+## Tests
+- **`src/app/page.test.tsx`** — new regression test asserting the homepage module exports `dynamic === "force-dynamic"` and `revalidate === 0`.
+- Full homepage page tests pass; lint clean.
+
+## Operator note
+- The immediate live incident is cleared by a **fresh production redeploy** (rebuilds now that the slate is published, re-warming the cache with 7). This PR is the **durable** fix so the race (deploy lands before publish) can't recur.
+
+## Not addressed by this fix
+- No change to the publish path, the signal data, the cap, or `/signals` (already dynamic).
+- No schema change.

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -133,4 +133,10 @@ describe("homepage SSR auth snapshot", () => {
       }),
     );
   }, 10000);
+
+  it("renders the homepage dynamically so it never serves a stale published slate", async () => {
+    const pageModule = await import("@/app/page");
+    expect(pageModule.dynamic).toBe("force-dynamic");
+    expect(pageModule.revalidate).toBe(0);
+  });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,6 +33,14 @@ export const metadata: Metadata = {
   },
 };
 
+// Always render the homepage from the live published signal set, like
+// `/signals`. Without this the homepage is cached/statically rendered and can
+// serve a stale slate — e.g. if a deploy lands moments before the day's slate
+// is published, the build-time render captures the pre-publish (empty) state
+// and the edge cache keeps serving it. force-dynamic keeps it always-fresh.
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
 export default async function Page({ searchParams }: PageProps) {
   // Keep homepage SSR on persisted read models only. Do not route this page
   // through the ingestion pipeline or feed parser import chain.


### PR DESCRIPTION
## What & why
After publishing the daily slate, the public homepage `/` showed **fewer signals than were actually published** — 5 (or 0) — while `/signals` correctly showed **7**. The DB had 7 live, published rows.

**Root cause: caching, not the cap or the data.** `/` was **not** `force-dynamic` (unlike `/signals`), so it was cached/statically rendered. The #322 production deploy landed at **21:14:04 UTC**, but that day's slate wasn't published until **21:17:49 UTC** (~3.5 min later). The build-time render of `/` captured the **pre-publish (empty) state**, and the edge cache kept serving that stale render.

**Ruled out:** the cap-to-7 code (every homepage path returns up to 7; the view-model renders 7 from 7 items), the data (7 live rows verified in the DB), and the deployment (the #322 build was READY/current — nothing reverted).

## The fix
- **`src/app/page.tsx`**: `export const dynamic = "force-dynamic"` + `export const revalidate = 0`, matching `/signals`. The homepage now always renders from the live published set, so it can't serve a stale build-time slate again.
- **`src/app/page.test.tsx`**: regression test pinning both exports.
- Bug-fix record under `docs/engineering/bug-fixes/`.

## Validation
- Homepage page tests pass (incl. the new export assertion); lint clean.
- Trade-off: the homepage now renders per-request (like `/signals`) instead of from cache — correct for an always-fresh published slate.

## Operator note
The **immediate** live incident clears with a fresh production redeploy (rebuilds now that the slate is published). This PR is the **durable** fix so the deploy-lands-before-publish race can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)