### PR TITLE
fix(newsletter): atomic single bulk insert so a stage timeout can't poison the slate (Task 1, PR1/4)

### DIFF
--- a/docs/engineering/bug-fixes/newsletter-timeout-atomic-candidate-write-2026-06-17.md
+++ b/docs/engineering/bug-fixes/newsletter-timeout-atomic-candidate-write-2026-06-17.md
@@ -1,0 +1,30 @@
+# Newsletter-Ingestion Timeout Poisons the Daily Slate — Atomicity Fix (PR1)
+
+## Summary
+- **Problem addressed:** On a slow-Gmail morning the newsletter stage exceeded its internal 55s budget **mid-run**. Because it inserted `signal_posts` candidate rows **one at a time inside the per-email loop** with no transaction and no rollback, a timeout left **partial junk rows** committed for the briefing date. Those leftover rows occupied all 20 candidate ranks, so the later RSS stage early-outs ("the daily signal snapshot already exists") and stages **zero** real articles — a slate of newsletter boilerplate and no news.
+- **Root cause (proven in code):** the only `signal_posts` write was a per-story `.insert(...)` at `promotion.ts` inside the `processWritableRun` loop (`runner.ts`); the 55s `Promise.race` in `cron-endpoint-runtime.ts` only **rejected the awaiter** — it never aborted the in-flight work — so already-committed rows persisted. No `.delete`/`.rpc`/transaction existed anywhere in the path.
+- **Affected object level:** newsletter ingestion stage write path only. No schema change, no migration, no publish/render/`published_slates` change.
+
+## Fix (Option A — withhold the single bulk insert; no migration)
+- **`src/lib/newsletter-ingestion/promotion.ts`**
+  - `buildNewsletterCandidateRow()` — one shared, byte-identical candidate-row builder (the `needs_review` contract the cockpit depends on).
+  - `planNewsletterStoryPromotions()` — **pure** planner that resolves already-linked / invalid-url / dup-by-url / dup-by-title / next-rank entirely in memory against a **single** pre-fetched `existingRows` snapshot. This collapses the old ~480 per-story DB round-trips (incl. the "pull 100 rows, filter in JS" title check) into one read, and is the latency fix *and* the correctness fix.
+  - `promoteNewsletterStoryBatch()` — plans the whole run, then performs **exactly one** multi-row `signal_posts` insert (one PostgREST request → one Postgres `INSERT` → all-or-nothing). Net effect on timeout/error: **zero partial rows**.
+  - **Self-heal seam:** links run *after* the committed insert and are best-effort; a crash between insert and link is repaired next run because the planner sees the row by `source_url` and plans `link`, never a duplicate insert (backed by `UNIQUE(briefing_date, source_url)`).
+  - `promoteNewsletterStoryToCandidate()` is now a thin wrapper over the batch (single code path; existing callers/tests unchanged).
+- **`src/lib/newsletter-ingestion/runner.ts`** — `processWritableRun` buffers stories across the whole email loop and calls the batch promoter **once after the loop**. `newsletter_emails` / `newsletter_story_extractions` writes stay incremental (idempotent, dedup-keyed, and not the public slate).
+- **AbortSignal threading (status reflects reality):** the 55s wall now `abort()`s an `AbortController` (`cron-endpoint-runtime.ts` `runWithStageTimeout` `onTimeout`) whose signal is forwarded to the newsletter stage (`editorial-ingestion-pipeline.ts` → `runner.ts` → `promotion.ts` and the Gmail raw-message fetch in `gmail.ts`/`storage.ts`). On timeout: in-flight Gmail fetches abort, the email loop stops, and the atomic write is **skipped** — so a timeout deterministically leaves an **empty** slate (never partial), and the reported status matches DB reality. rss/staging ignore the signal.
+
+## Constraints respected
+- No migration; `signal_posts` already has every column the insert uses. `rank` allocation stays descending 20→1, preserving `CHECK(rank 1..20)` and `UNIQUE(briefing_date, rank)`.
+- No edits to the publish/render path, `published_slates`/`published_slate_items`, or `is_live` / `why_it_matters_validation_status` on candidate rows.
+
+## Tests
+- **`src/lib/newsletter-ingestion/promotion-batch.test.ts`** (new): exactly-one bulk insert with descending unique ranks; aborted-signal → zero rows; self-heal link of an orphan row → zero inserts; idempotent re-run → zero inserts; within-batch `source_url` dedupe → one insert; bulk-insert error → no partial rows; pure-planner shape; and a **runner-level timeout test** proving buffered candidates are discarded (insert never called) when the deadline fires mid-loop.
+- Existing newsletter / cron / pipeline suites unchanged and green. `npm run pipeline:dry` exercises the signal-threaded wiring end-to-end (no regression).
+
+## Not addressed by this fix (separate PRs)
+- RSS rank-band backstop so leaked rows can't grab every slot (Task 2 / PR3).
+- Newsletter content quality — mojibake decode, tracking-redirect drop, chrome filter (Task 3 / PR2).
+- Throughput / bounded concurrency (Task 4 / PR4 — must not ship without this PR).
+- Cleanup of already-poisoned historical dates (separate data operation).

--- a/src/app/api/cron/ingest-newsletters/route.test.ts
+++ b/src/app/api/cron/ingest-newsletters/route.test.ts
@@ -67,7 +67,11 @@ describe("/api/cron/ingest-newsletters", () => {
 
     await runAfter();
 
-    expect(runNewsletterIngestion).toHaveBeenCalledWith({ writeCandidates: true });
+    // The newsletter stage now receives the run's internal-timeout AbortSignal so
+    // its atomic candidate write can hard-stop on the 55s wall (zero partial rows).
+    expect(runNewsletterIngestion).toHaveBeenCalledWith(
+      expect.objectContaining({ writeCandidates: true, signal: expect.any(AbortSignal) }),
+    );
     // Decoupled: this endpoint runs ONLY newsletter — never RSS / staging / sweep.
     expect(runDailyNewsCron).not.toHaveBeenCalled();
     expect(runEditorialStaging).not.toHaveBeenCalled();

--- a/src/lib/cron/cron-endpoint-runtime.ts
+++ b/src/lib/cron/cron-endpoint-runtime.ts
@@ -72,15 +72,22 @@ export class StageTimeoutError extends Error {
   }
 }
 
-/** Race `work` against the internal budget; on timeout, reject naming `stageRef.current`. */
+/**
+ * Race `work` against the internal budget; on timeout, reject naming
+ * `stageRef.current`. `onTimeout` fires synchronously when the budget expires
+ * (before the rejection propagates) so the caller can abort the in-flight work —
+ * the rejection alone never cancels `work`, it only stops the awaiter.
+ */
 export function runWithStageTimeout<T>(
   stageRef: { current: string },
   work: Promise<T>,
   timeoutMs: number,
+  onTimeout?: () => void,
 ): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | null = null;
   const timeoutPromise = new Promise<T>((_, reject) => {
     timer = setTimeout(() => {
+      onTimeout?.();
       reject(new StageTimeoutError(stageRef.current, timeoutMs));
     }, timeoutMs);
   });
@@ -148,12 +155,24 @@ export async function runEditorialStagesWithTiming(input: {
   const timer = new StageTimer();
   const stageRef: { current: EditorialPipelineStageName } = { current: input.stages[0] };
   const runStage = createTimedStageRunner({ stageRef, timer, routeName: input.routeName });
+  // When the internal budget expires, abort the in-flight pipeline so the
+  // newsletter stage hard-stops BEFORE its atomic candidate write (zero partial
+  // rows). The signal is forwarded only to the newsletter stage; rss/staging
+  // ignore it. The Promise.race rejection still drives the timeout finalize.
+  const abortController = new AbortController();
 
   try {
     const results = await runWithStageTimeout(
       stageRef,
-      runEditorialIngestionPipeline({ dryRun: false, now: input.now, runStage, stages: input.stages }),
+      runEditorialIngestionPipeline({
+        dryRun: false,
+        now: input.now,
+        runStage,
+        stages: input.stages,
+        signal: abortController.signal,
+      }),
       INTERNAL_STAGE_TIMEOUT_MS,
+      () => abortController.abort(new StageTimeoutError(stageRef.current, INTERNAL_STAGE_TIMEOUT_MS)),
     );
     return { results, stageMs: timer.snapshot(), timedOut: false, inFlightStage: stageRef.current };
   } catch (error) {

--- a/src/lib/newsletter-ingestion/gmail.ts
+++ b/src/lib/newsletter-ingestion/gmail.ts
@@ -52,8 +52,24 @@ export type GmailApiClient = {
     sinceDate: Date;
     maxResults: number;
   }): Promise<GmailMessageRef[]>;
-  getRawMessage(messageId: string): Promise<GmailRawMessage>;
+  getRawMessage(messageId: string, options?: { signal?: AbortSignal }): Promise<GmailRawMessage>;
 };
+
+/**
+ * Combine an outer run-deadline AbortSignal with a per-call timeout controller so
+ * a single Gmail fetch aborts on WHICHEVER fires first. Returns the per-call
+ * signal alone when no outer signal is supplied (the common case).
+ */
+function combineAbortSignals(perCall: AbortSignal, outer?: AbortSignal): AbortSignal {
+  if (!outer) return perCall;
+  if (typeof AbortSignal.any === "function") return AbortSignal.any([perCall, outer]);
+  if (outer.aborted) return outer;
+  const controller = new AbortController();
+  const onAbort = () => controller.abort();
+  perCall.addEventListener("abort", onAbort, { once: true });
+  outer.addEventListener("abort", onAbort, { once: true });
+  return controller.signal;
+}
 
 type GmailListResponse = {
   messages?: Array<{
@@ -141,11 +157,12 @@ async function fetchWithTimeout(
   init: RequestInit,
   failureLabel: string,
   timeoutMs: number = GMAIL_PER_CALL_TIMEOUT_MS,
+  outerSignal?: AbortSignal,
 ): Promise<Response> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    return await fetchImpl(url, { ...init, signal: controller.signal });
+    return await fetchImpl(url, { ...init, signal: combineAbortSignals(controller.signal, outerSignal) });
   } catch (error) {
     const aborted =
       (error instanceof DOMException && error.name === "AbortError") ||
@@ -223,12 +240,22 @@ async function gmailFetchJson<T>(
     failureLabel: string;
     fetchImpl: GmailFetch;
     maxRetries?: number;
+    /** Outer run-deadline signal — once fired, stop fetching and DON'T retry. */
+    signal?: AbortSignal;
   },
 ): Promise<T> {
   const maxRetries = input.maxRetries ?? 2;
   let attempt = 0;
 
   while (true) {
+    // Past the run deadline a retry is pointless — fail fast, non-retryable.
+    if (input.signal?.aborted) {
+      throw new GmailApiError(`${input.failureLabel} aborted: run deadline reached.`, {
+        status: null,
+        retryable: false,
+      });
+    }
+
     let response: Response;
     try {
       response = await fetchWithTimeout(
@@ -240,15 +267,19 @@ async function gmailFetchJson<T>(
           },
         },
         input.failureLabel,
+        GMAIL_PER_CALL_TIMEOUT_MS,
+        input.signal,
       );
     } catch (error) {
       // fetchWithTimeout already converts AbortError -> retryable
       // GmailApiError. Apply the same retry policy as for HTTP failures
-      // so a transient timeout is retried with backoff.
+      // so a transient timeout is retried with backoff — UNLESS the outer
+      // run deadline fired, in which case we stop immediately.
       if (
         error instanceof GmailApiError &&
         error.retryable &&
-        attempt < maxRetries
+        attempt < maxRetries &&
+        !input.signal?.aborted
       ) {
         attempt += 1;
         await wait(100 * attempt);
@@ -263,7 +294,8 @@ async function gmailFetchJson<T>(
       if (
         error instanceof GmailApiError &&
         error.retryable &&
-        attempt < maxRetries
+        attempt < maxRetries &&
+        !input.signal?.aborted
       ) {
         attempt += 1;
         await wait(100 * attempt);
@@ -335,7 +367,7 @@ export function createGmailApiClient(input: {
         }));
     },
 
-    async getRawMessage(messageId) {
+    async getRawMessage(messageId, options) {
       const accessToken = await getAccessToken();
       const url = new URL(`https://gmail.googleapis.com/gmail/v1/users/me/messages/${encodeURIComponent(messageId)}`);
       url.searchParams.set("format", "raw");
@@ -345,6 +377,7 @@ export function createGmailApiClient(input: {
         accessToken,
         fetchImpl,
         failureLabel: "Gmail raw message fetch",
+        signal: options?.signal,
       });
 
       if (!body.id || !body.threadId || !body.raw) {

--- a/src/lib/newsletter-ingestion/promotion-batch.test.ts
+++ b/src/lib/newsletter-ingestion/promotion-batch.test.ts
@@ -1,0 +1,378 @@
+import { describe, expect, it } from "vitest";
+
+import type { GmailApiClient, GmailRawMessage } from "@/lib/newsletter-ingestion/gmail";
+import {
+  promoteNewsletterStoryBatch,
+  type NewsletterCandidatePlan,
+  planNewsletterStoryPromotions,
+} from "@/lib/newsletter-ingestion/promotion";
+import { runNewsletterIngestion } from "@/lib/newsletter-ingestion/runner";
+import type { NewsletterDbClient, NewsletterStoryExtractionRow } from "@/lib/newsletter-ingestion/storage";
+import type { NewsletterIngestionConfig } from "@/lib/newsletter-ingestion/config";
+
+type Row = Record<string, unknown>;
+type TableName = "newsletter_emails" | "newsletter_story_extractions" | "signal_posts";
+
+/**
+ * In-memory Supabase double that ALSO records every signal_posts insert call —
+ * the load-bearing assertion for atomicity is "exactly one bulk insert, with N
+ * rows, never partial." `failSignalPostsInsert` makes the bulk insert return a
+ * PostgREST error WITHOUT persisting (a failed multi-row INSERT commits nothing).
+ */
+function createCountingDb(
+  initial: Partial<Record<TableName, Row[]>> = {},
+  options: { failSignalPostsInsert?: boolean } = {},
+) {
+  const tables: Record<TableName, Row[]> = {
+    newsletter_emails: [...(initial.newsletter_emails ?? [])],
+    newsletter_story_extractions: [...(initial.newsletter_story_extractions ?? [])],
+    signal_posts: [...(initial.signal_posts ?? [])],
+  };
+  let idCounter = 1;
+  const signalPostsInserts: { count: number; sizes: number[] } = { count: 0, sizes: [] };
+
+  function createBuilder(tableName: TableName) {
+    const filters: Array<{ column: string; value: unknown }> = [];
+    const inFilters: Array<{ column: string; values: unknown[] }> = [];
+    let operation: "select" | "insert" | "update" = "select";
+    let inserted: Row[] = [];
+    let updated: Row = {};
+    let limitCount: number | null = null;
+    let insertFailed = false;
+
+    function applyFilters(rows: Row[]) {
+      return rows.filter((row) =>
+        filters.every((filter) => row[filter.column] === filter.value) &&
+        inFilters.every((filter) => filter.values.includes(row[filter.column])),
+      );
+    }
+
+    function execute() {
+      if (operation === "insert") {
+        if (insertFailed) {
+          return { data: null, error: { message: "signal_posts bulk insert boom" } };
+        }
+        const rows = inserted.map((row) => ({
+          id: row.id ?? `${tableName}-${idCounter++}`,
+          ...row,
+        }));
+        tables[tableName].push(...rows);
+        return { data: rows, error: null };
+      }
+
+      if (operation === "update") {
+        const rows = applyFilters(tables[tableName]);
+        rows.forEach((row) => Object.assign(row, updated));
+        return { data: rows, error: null };
+      }
+
+      const selected = applyFilters(tables[tableName]);
+      return { data: limitCount === null ? selected : selected.slice(0, limitCount), error: null };
+    }
+
+    const builder = {
+      select() {
+        operation = operation === "insert" || operation === "update" ? operation : "select";
+        return builder;
+      },
+      eq(column: string, value: unknown) {
+        filters.push({ column, value });
+        return builder;
+      },
+      in(column: string, values: unknown[]) {
+        inFilters.push({ column, values });
+        return builder;
+      },
+      limit(count: number) {
+        limitCount = count;
+        return builder;
+      },
+      insert(value: Row | Row[]) {
+        operation = "insert";
+        inserted = Array.isArray(value) ? value : [value];
+        if (tableName === "signal_posts") {
+          signalPostsInserts.count += 1;
+          signalPostsInserts.sizes.push(inserted.length);
+          insertFailed = Boolean(options.failSignalPostsInsert);
+        }
+        return builder;
+      },
+      update(value: Row) {
+        operation = "update";
+        updated = value;
+        return builder;
+      },
+      async single() {
+        const result = execute();
+        return { data: (result.data as Row[] | null)?.[0] ?? null, error: result.error };
+      },
+      async maybeSingle() {
+        const result = execute();
+        return { data: (result.data as Row[] | null)?.[0] ?? null, error: result.error };
+      },
+      then(resolve: (value: { data: Row[] | null; error: unknown }) => void) {
+        resolve(execute());
+      },
+    };
+
+    return builder;
+  }
+
+  return {
+    tables,
+    signalPostsInserts,
+    db: {
+      from(tableName: TableName) {
+        return createBuilder(tableName);
+      },
+    } as unknown as NewsletterDbClient,
+  };
+}
+
+function story(overrides: Partial<NewsletterStoryExtractionRow> & { id: string }): NewsletterStoryExtractionRow {
+  return {
+    newsletter_email_id: "email-1",
+    headline: `Headline ${overrides.id}`,
+    snippet: `Snippet for ${overrides.id}.`,
+    source_url: `https://example.com/${overrides.id}`,
+    source_domain: "example.com",
+    category: "Tech",
+    extraction_confidence: 0.9,
+    signal_post_id: null,
+    ...overrides,
+  };
+}
+
+const BRIEFING_DATE = "2026-06-17";
+
+describe("promoteNewsletterStoryBatch — atomic bulk insert", () => {
+  it("performs EXACTLY ONE bulk insert for the whole run, with descending unique ranks, and links each extraction", async () => {
+    const { db, tables, signalPostsInserts } = createCountingDb({
+      newsletter_story_extractions: [story({ id: "a" }), story({ id: "b" }), story({ id: "c" })],
+    });
+
+    const results = await promoteNewsletterStoryBatch({
+      db,
+      briefingDate: BRIEFING_DATE,
+      stories: [story({ id: "a" }), story({ id: "b" }), story({ id: "c" })],
+      now: new Date("2026-06-17T08:00:00.000Z"),
+    });
+
+    // ONE insert call, carrying all three rows (not three single-row inserts).
+    expect(signalPostsInserts.count).toBe(1);
+    expect(signalPostsInserts.sizes).toEqual([3]);
+
+    expect(tables.signal_posts).toHaveLength(3);
+    expect(tables.signal_posts.map((row) => row.rank).sort((x, y) => Number(y) - Number(x))).toEqual([20, 19, 18]);
+    expect(new Set(tables.signal_posts.map((row) => row.rank)).size).toBe(3);
+
+    expect(results.every((result) => result.status === "created")).toBe(true);
+    // insert -> link seam: every extraction is linked to its committed row.
+    expect(tables.newsletter_story_extractions.every((row) => Boolean(row.signal_post_id))).toBe(true);
+  });
+
+  it("writes ZERO rows when the run signal is already aborted (timeout leaves an empty slate)", async () => {
+    const { db, tables, signalPostsInserts } = createCountingDb();
+    const controller = new AbortController();
+    controller.abort();
+
+    const results = await promoteNewsletterStoryBatch({
+      db,
+      briefingDate: BRIEFING_DATE,
+      stories: [story({ id: "a" }), story({ id: "b" })],
+      now: new Date("2026-06-17T08:00:00.000Z"),
+      signal: controller.signal,
+    });
+
+    // The single bulk insert is the only signal_posts write — never reached.
+    expect(signalPostsInserts.count).toBe(0);
+    expect(tables.signal_posts).toHaveLength(0);
+    expect(results).toHaveLength(2);
+    expect(results.every((result) => result.status === "skipped" && result.reason === "aborted")).toBe(true);
+  });
+
+  it("self-heals a prior crash between insert and link: links the orphan row, inserts nothing", async () => {
+    // A prior run's bulk insert committed this row, then died before linking.
+    const { db, tables, signalPostsInserts } = createCountingDb({
+      signal_posts: [{
+        id: "orphan-row",
+        briefing_date: BRIEFING_DATE,
+        rank: 20,
+        title: "Headline a",
+        source_url: "https://example.com/a",
+        editorial_status: "needs_review",
+        is_live: false,
+        published_at: null,
+      }],
+    });
+
+    const results = await promoteNewsletterStoryBatch({
+      db,
+      briefingDate: BRIEFING_DATE,
+      stories: [story({ id: "a", signal_post_id: null })],
+      now: new Date("2026-06-17T08:00:00.000Z"),
+    });
+
+    expect(signalPostsInserts.count).toBe(0);
+    expect(tables.signal_posts).toHaveLength(1);
+    expect(results[0]).toEqual({ status: "linked_existing", extractionId: "a", signalPostId: "orphan-row" });
+    expect(tables.newsletter_story_extractions).toHaveLength(0);
+  });
+
+  it("is idempotent: a second run over the same stories inserts nothing (source_url dedupe)", async () => {
+    const { db, signalPostsInserts } = createCountingDb();
+    const stories = [story({ id: "a" }), story({ id: "b" })];
+
+    await promoteNewsletterStoryBatch({ db, briefingDate: BRIEFING_DATE, stories, now: new Date("2026-06-17T08:00:00.000Z") });
+    expect(signalPostsInserts.count).toBe(1);
+
+    // Re-run with the same stories: the rows now exist by source_url, so the
+    // planner links instead of inserting — no second insert call.
+    await promoteNewsletterStoryBatch({ db, briefingDate: BRIEFING_DATE, stories, now: new Date("2026-06-17T08:05:00.000Z") });
+    expect(signalPostsInserts.count).toBe(1);
+  });
+
+  it("dedupes duplicate source_urls WITHIN one batch: one insert, the rest linked to it", async () => {
+    const { db, tables, signalPostsInserts } = createCountingDb();
+
+    const results = await promoteNewsletterStoryBatch({
+      db,
+      briefingDate: BRIEFING_DATE,
+      stories: [
+        story({ id: "a", source_url: "https://example.com/same" }),
+        story({ id: "b", source_url: "https://example.com/same" }),
+      ],
+      now: new Date("2026-06-17T08:00:00.000Z"),
+    });
+
+    expect(signalPostsInserts.count).toBe(1);
+    expect(signalPostsInserts.sizes).toEqual([1]);
+    expect(tables.signal_posts).toHaveLength(1);
+    expect(results[0].status).toBe("created");
+    expect(results[1].status).toBe("linked_existing");
+    const onlyRowId = tables.signal_posts[0]?.id;
+    expect(tables.newsletter_story_extractions.every((row) => row.signal_post_id === onlyRowId)).toBe(true);
+  });
+
+  it("never leaves partial rows when the bulk insert errors (all-or-nothing)", async () => {
+    const { db, tables } = createCountingDb({}, { failSignalPostsInsert: true });
+
+    const results = await promoteNewsletterStoryBatch({
+      db,
+      briefingDate: BRIEFING_DATE,
+      stories: [story({ id: "a" }), story({ id: "b" })],
+      now: new Date("2026-06-17T08:00:00.000Z"),
+    });
+
+    expect(tables.signal_posts).toHaveLength(0);
+    expect(results.every((result) => result.status === "skipped" && result.reason === "storage_error")).toBe(true);
+  });
+});
+
+describe("planNewsletterStoryPromotions — pure planner", () => {
+  it("plans skips/links/inserts against one snapshot with no duplicate ranks", () => {
+    const plans = planNewsletterStoryPromotions({
+      stories: [
+        story({ id: "linked", signal_post_id: "already" }),
+        story({ id: "noUrl", source_url: null }),
+        story({ id: "fresh1", source_url: "https://example.com/1" }),
+        story({ id: "fresh2", source_url: "https://example.com/2" }),
+      ],
+      existingRows: [],
+      briefingDate: BRIEFING_DATE,
+      nowIso: "2026-06-17T08:00:00.000Z",
+    });
+
+    const byAction = (action: NewsletterCandidatePlan["action"]) => plans.filter((plan) => plan.action === action);
+    expect(byAction("skip")).toHaveLength(2);
+    const inserts = byAction("insert") as Extract<NewsletterCandidatePlan, { action: "insert" }>[];
+    expect(inserts.map((plan) => plan.rank)).toEqual([20, 19]);
+  });
+});
+
+// ---- Runner-level integration: the timeout must discard buffered stories ----
+
+function rawEmail(headline: string, url: string) {
+  return Buffer.from(
+    [
+      "From: TLDR <newsletter@tldr.tech>",
+      "Subject: TLDR Daily",
+      "Content-Type: text/plain",
+      "",
+      headline,
+      `${headline} is a real development with clear stakes for the market this week. ${url}`,
+    ].join("\r\n"),
+    "utf8",
+  ).toString("base64url");
+}
+
+function writableConfig(): NewsletterIngestionConfig {
+  return {
+    enabled: true,
+    dryRun: false,
+    writeCandidates: true,
+    label: "bootup-news-benchmark",
+    maxEmailsPerRun: 10,
+    sinceHours: 36,
+    targetEnvironment: "local",
+    allowProductionWrites: false,
+    gmailClientId: "client-id",
+    gmailClientSecret: "client-secret",
+    gmailRefreshToken: "refresh-token",
+  };
+}
+
+describe("runNewsletterIngestion — timeout discards buffered candidates", () => {
+  it("never calls the signal_posts insert when the deadline fires mid-loop, even after earlier emails parsed stories", async () => {
+    const { db, tables, signalPostsInserts } = createCountingDb();
+    const controller = new AbortController();
+    const refs = [
+      { id: "gmail-1", threadId: "t-1" },
+      { id: "gmail-2", threadId: "t-2" },
+      { id: "gmail-3", threadId: "t-3" },
+    ];
+    const rawByMessage: Record<string, string> = {
+      "gmail-1": rawEmail("Microsoft expands data center capacity", "https://example.com/cloud"),
+      "gmail-2": rawEmail("Treasury yields climb on inflation data", "https://example.com/yields"),
+      "gmail-3": rawEmail("Late breaking story", "https://example.com/late"),
+    };
+
+    let rawCalls = 0;
+    const gmailClient: GmailApiClient = {
+      async getLabelByName() {
+        return { id: "Label_1", name: "bootup-news-benchmark", messagesTotal: 3, messagesUnread: 0 };
+      },
+      async listNewsletterMessages() {
+        return refs;
+      },
+      async getRawMessage(messageId): Promise<GmailRawMessage> {
+        rawCalls += 1;
+        // Simulate the 55s wall firing while the THIRD email is being fetched.
+        if (rawCalls === 3) {
+          controller.abort();
+          throw new Error("Gmail raw message fetch aborted: run deadline reached.");
+        }
+        return {
+          id: messageId,
+          threadId: `t-${messageId}`,
+          raw: rawByMessage[messageId] ?? rawEmail("Fallback", "https://example.com/fallback"),
+          internalDate: "1781000000000",
+        };
+      },
+    };
+
+    const result = await runNewsletterIngestion(
+      { writeCandidates: true, signal: controller.signal, now: new Date("2026-06-17T08:00:00.000Z") },
+      { db, gmailClient, config: writableConfig() },
+    );
+
+    // Emails 1 and 2 parsed stories and buffered them, but the deadline fired —
+    // so the atomic write is skipped and ZERO candidate rows are persisted.
+    expect(signalPostsInserts.count).toBe(0);
+    expect(tables.signal_posts).toHaveLength(0);
+    expect(result.summary.promotedCandidateCount).toBe(0);
+    // The extracted stories were genuinely buffered (proving they were discarded,
+    // not simply never produced).
+    expect(result.summary.extractedStoryCount).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/newsletter-ingestion/promotion.ts
+++ b/src/lib/newsletter-ingestion/promotion.ts
@@ -1,5 +1,6 @@
 import { isValidPublicSourceUrl } from "@/lib/final-slate-readiness";
 import type { NewsletterDbClient, NewsletterStoryExtractionRow } from "@/lib/newsletter-ingestion/storage";
+import { errorContext, logServerEvent } from "@/lib/observability";
 
 type ExistingSignalPostCandidate = {
   id: string;
@@ -31,9 +32,12 @@ export type NewsletterPromotionResult =
         | "invalid_source_url"
         | "duplicate_public_row"
         | "no_available_candidate_rank"
-        | "storage_error";
+        | "storage_error"
+        | "aborted";
       message: string;
     };
+
+type NewsletterSkipReason = Extract<NewsletterPromotionResult, { status: "skipped" }>["reason"];
 
 export type NewsletterPromotionPreviewStory = {
   headline: string;
@@ -99,71 +103,23 @@ async function linkExtractionToSignalPost(
   }
 }
 
-async function findExistingBySourceUrl(input: {
-  db: NewsletterDbClient;
-  briefingDate: string;
-  sourceUrl: string;
-}) {
-  const result = await input.db
-    .from("signal_posts")
-    .select("id, title, source_url, rank, editorial_status, is_live, published_at")
-    .eq("briefing_date", input.briefingDate)
-    .eq("source_url", input.sourceUrl)
-    .limit(1);
-
-  if (result.error) {
-    throw new Error(`signal_posts duplicate source_url check failed: ${result.error.message}`);
+async function safeLinkExtractionToSignalPost(
+  db: NewsletterDbClient,
+  extractionId: string,
+  signalPostId: string,
+) {
+  // Best-effort: the candidate row is already committed. A failed FK link is
+  // self-healed on the next run — the planner re-reads the row by source_url and
+  // plans `link` (never a duplicate insert, guarded by UNIQUE(briefing_date, source_url)).
+  try {
+    await linkExtractionToSignalPost(db, extractionId, signalPostId);
+  } catch (error) {
+    logServerEvent("warn", "Newsletter ingestion: extraction link failed (will self-heal next run)", {
+      extractionId,
+      signalPostId,
+      ...errorContext(error),
+    });
   }
-
-  return ((result.data ?? []) as ExistingSignalPostCandidate[])[0] ?? null;
-}
-
-async function findExistingByTitle(input: {
-  db: NewsletterDbClient;
-  briefingDate: string;
-  title: string;
-}) {
-  const normalizedTitle = normalizeTitle(input.title);
-  const result = await input.db
-    .from("signal_posts")
-    .select("id, title, source_url, rank, editorial_status, is_live, published_at")
-    .eq("briefing_date", input.briefingDate)
-    .limit(100);
-
-  if (result.error) {
-    throw new Error(`signal_posts duplicate title check failed: ${result.error.message}`);
-  }
-
-  return ((result.data ?? []) as ExistingSignalPostCandidate[])
-    .find((row) => normalizeTitle(row.title) === normalizedTitle) ?? null;
-}
-
-async function getNextCandidateRank(input: {
-  db: NewsletterDbClient;
-  briefingDate: string;
-}) {
-  const result = await input.db
-    .from("signal_posts")
-    .select("rank")
-    .eq("briefing_date", input.briefingDate);
-
-  if (result.error) {
-    throw new Error(`signal_posts rank check failed: ${result.error.message}`);
-  }
-
-  const usedRanks = new Set(
-    ((result.data ?? []) as Array<{ rank: number | null }>)
-      .map((row) => row.rank)
-      .filter((rank): rank is number => typeof rank === "number"),
-  );
-
-  for (let rank = 20; rank >= 1; rank -= 1) {
-    if (!usedRanks.has(rank)) {
-      return rank;
-    }
-  }
-
-  return null;
 }
 
 async function getExistingSignalPostCandidates(input: {
@@ -205,6 +161,326 @@ function nextAvailablePreviewRank(
   }
 
   return null;
+}
+
+/**
+ * Single source of truth for a newsletter candidate's `signal_posts` row shape.
+ * The byte-for-byte column set MUST match what the editorial cockpit's
+ * `needs_review` contract expects — do not let it drift. Both the per-story
+ * wrapper and the batch promoter build their rows here.
+ */
+export function buildNewsletterCandidateRow(input: {
+  extraction: NewsletterStoryExtractionRow;
+  briefingDate: string;
+  rank: number;
+  sourceUrl: string;
+  nowIso: string;
+}) {
+  const { extraction, briefingDate, rank, sourceUrl, nowIso } = input;
+
+  return {
+    briefing_date: briefingDate,
+    rank,
+    title: extraction.headline,
+    source_name: sourceNameFromExtraction(extraction),
+    source_url: sourceUrl,
+    summary: extraction.snippet ?? "",
+    tags: extraction.category ? [extraction.category] : [],
+    signal_score: extraction.extraction_confidence
+      ? Number((extraction.extraction_confidence * 100).toFixed(2))
+      : null,
+    selection_reason: "Newsletter discovery candidate; BM review required.",
+    ai_why_it_matters: "",
+    edited_why_it_matters: null,
+    published_why_it_matters: null,
+    why_it_matters_validation_status: "requires_human_rewrite",
+    why_it_matters_validation_failures: ["incomplete_sentence"],
+    why_it_matters_validation_details: ["BM must write structural why-it-matters manually before publication."],
+    why_it_matters_validated_at: null,
+    editorial_status: "needs_review",
+    final_slate_rank: null,
+    final_slate_tier: null,
+    editorial_decision: "pending_review",
+    decision_note: null,
+    rejected_reason: null,
+    held_reason: null,
+    replacement_of_row_id: null,
+    reviewed_by: null,
+    reviewed_at: null,
+    edited_by: null,
+    edited_at: null,
+    approved_by: null,
+    approved_at: null,
+    published_at: null,
+    is_live: false,
+    context_material: getContextMaterial(extraction),
+    source_cluster_id: null,
+    witm_draft_generated_by: null,
+    witm_draft_generated_at: null,
+    witm_draft_model: null,
+    created_at: nowIso,
+    updated_at: nowIso,
+  };
+}
+
+export type NewsletterCandidatePlan =
+  | {
+      action: "insert";
+      extractionId: string;
+      rank: number;
+      sourceUrl: string;
+      normalizedTitle: string;
+      row: ReturnType<typeof buildNewsletterCandidateRow>;
+    }
+  | {
+      action: "link";
+      extractionId: string;
+      /** A row already present in `existingRows` (prior run / prior story). */
+      existingSignalPostId: string | null;
+      /** An insert planned earlier in THIS batch, resolved to an id post-insert. */
+      batchSourceUrl: string | null;
+    }
+  | {
+      action: "skip";
+      extractionId: string;
+      reason: NewsletterSkipReason;
+      message: string;
+    };
+
+/**
+ * PURE planner — decides what every story in a run WOULD become against a single
+ * pre-fetched `existingRows` snapshot, with NO database calls. Replaces the old
+ * per-story round-trips (dup-by-url / dup-by-title / next-rank) that each hit the
+ * DB; everything is now resolved in memory against one read. Ranks are allocated
+ * descending (20→1) exactly as before, deduped within the batch via
+ * `nextAvailablePreviewRank`'s `allocatedRanks` accumulator, so the resulting
+ * bulk insert respects CHECK(rank 1..20) and UNIQUE(briefing_date, rank).
+ */
+export function planNewsletterStoryPromotions(input: {
+  stories: NewsletterStoryExtractionRow[];
+  existingRows: ExistingSignalPostCandidate[];
+  briefingDate: string;
+  nowIso: string;
+}): NewsletterCandidatePlan[] {
+  const { stories, existingRows, briefingDate, nowIso } = input;
+  const allocatedRanks = new Set<number>();
+  const plannedInsertSourceUrls = new Set<string>();
+  const plannedInsertTitleToUrl = new Map<string, string>();
+
+  return stories.map((extraction): NewsletterCandidatePlan => {
+    if (extraction.signal_post_id) {
+      return {
+        action: "skip",
+        extractionId: extraction.id,
+        reason: "already_linked",
+        message: "Newsletter story extraction is already linked to a signal_posts candidate.",
+      };
+    }
+
+    const sourceUrl = extraction.source_url?.trim() ?? "";
+
+    if (!isValidPublicSourceUrl(sourceUrl)) {
+      return {
+        action: "skip",
+        extractionId: extraction.id,
+        reason: "invalid_source_url",
+        message: "Newsletter story extraction was not promoted because it lacks a valid public source URL.",
+      };
+    }
+
+    const normalizedTitle = normalizeTitle(extraction.headline);
+
+    const existingByUrl = existingRows.find((row) => row.source_url === sourceUrl);
+    if (existingByUrl) {
+      if (isPublishedOrLive(existingByUrl)) {
+        return {
+          action: "skip",
+          extractionId: extraction.id,
+          reason: "duplicate_public_row",
+          message: "Newsletter story extraction matches an already live or published signal_posts row.",
+        };
+      }
+      return { action: "link", extractionId: extraction.id, existingSignalPostId: existingByUrl.id, batchSourceUrl: null };
+    }
+
+    const existingByTitle = existingRows.find((row) => normalizeTitle(row.title) === normalizedTitle);
+    if (existingByTitle) {
+      if (isPublishedOrLive(existingByTitle)) {
+        return {
+          action: "skip",
+          extractionId: extraction.id,
+          reason: "duplicate_public_row",
+          message: "Newsletter story extraction title matches an already live or published signal_posts row.",
+        };
+      }
+      return { action: "link", extractionId: extraction.id, existingSignalPostId: existingByTitle.id, batchSourceUrl: null };
+    }
+
+    // Within-batch dedupe: an earlier story in THIS run already planned an insert
+    // for the same URL or title — link to it (resolved to an id after the insert),
+    // matching the old sequential behavior where the 2nd story linked to the 1st's
+    // just-committed row instead of inserting a duplicate.
+    if (plannedInsertSourceUrls.has(sourceUrl)) {
+      return { action: "link", extractionId: extraction.id, existingSignalPostId: null, batchSourceUrl: sourceUrl };
+    }
+    const batchTitleOwnerUrl = plannedInsertTitleToUrl.get(normalizedTitle);
+    if (batchTitleOwnerUrl) {
+      return { action: "link", extractionId: extraction.id, existingSignalPostId: null, batchSourceUrl: batchTitleOwnerUrl };
+    }
+
+    const rank = nextAvailablePreviewRank(existingRows, allocatedRanks);
+    if (!rank) {
+      return {
+        action: "skip",
+        extractionId: extraction.id,
+        reason: "no_available_candidate_rank",
+        message: "Newsletter story extraction was not promoted because all 20 candidate ranks are already occupied.",
+      };
+    }
+
+    plannedInsertSourceUrls.add(sourceUrl);
+    plannedInsertTitleToUrl.set(normalizedTitle, sourceUrl);
+
+    return {
+      action: "insert",
+      extractionId: extraction.id,
+      rank,
+      sourceUrl,
+      normalizedTitle,
+      row: buildNewsletterCandidateRow({ extraction, briefingDate, rank, sourceUrl, nowIso }),
+    };
+  });
+}
+
+function planToAbortedResult(plan: NewsletterCandidatePlan): NewsletterPromotionResult {
+  if (plan.action === "skip") {
+    return { status: "skipped", extractionId: plan.extractionId, reason: plan.reason, message: plan.message };
+  }
+  return {
+    status: "skipped",
+    extractionId: plan.extractionId,
+    reason: "aborted",
+    message: "Newsletter promotion aborted before the atomic candidate write (run deadline reached); no row persisted.",
+  };
+}
+
+function planToStorageErrorResult(plan: NewsletterCandidatePlan, message: string): NewsletterPromotionResult {
+  if (plan.action === "skip") {
+    return { status: "skipped", extractionId: plan.extractionId, reason: plan.reason, message: plan.message };
+  }
+  return { status: "skipped", extractionId: plan.extractionId, reason: "storage_error", message };
+}
+
+/**
+ * ATOMIC-BY-BATCH newsletter promotion. Plans every story in the run against ONE
+ * pre-fetched `existingRows` snapshot, then performs exactly ONE multi-row
+ * `signal_posts` insert (a single PostgREST request → one Postgres INSERT →
+ * all-or-nothing). Net effect on timeout/error: ZERO partial rows for the
+ * briefing_date — the slate can never be left half-written.
+ *
+ * - `signal` (the run's internal-timeout AbortSignal): if it has already fired
+ *   when we reach the write, we persist NOTHING and report `aborted`, so a
+ *   timeout deterministically leaves an EMPTY slate (status matches DB reality).
+ * - insert→link seam: links run AFTER the committed insert and are best-effort;
+ *   a crash in between is repaired next run (planner sees the row by source_url
+ *   and plans `link`, never a duplicate insert).
+ */
+export async function promoteNewsletterStoryBatch(input: {
+  db: NewsletterDbClient;
+  briefingDate: string;
+  stories: NewsletterStoryExtractionRow[];
+  now?: Date;
+  signal?: AbortSignal;
+}): Promise<NewsletterPromotionResult[]> {
+  const briefingDate = normalizeDateValue(input.briefingDate);
+
+  if (input.stories.length === 0) {
+    return [];
+  }
+
+  const nowIso = (input.now ?? new Date()).toISOString();
+  const existingRows = await getExistingSignalPostCandidates({ db: input.db, briefingDate });
+  const plans = planNewsletterStoryPromotions({ stories: input.stories, existingRows, briefingDate, nowIso });
+  const inserts = plans.filter(
+    (plan): plan is Extract<NewsletterCandidatePlan, { action: "insert" }> => plan.action === "insert",
+  );
+
+  // Atomicity gate. The single bulk insert below is the ONLY signal_posts write
+  // in the whole run; if the deadline already fired we skip it entirely so the
+  // briefing_date is left with zero newsletter rows (never a partial slate).
+  if (input.signal?.aborted) {
+    logServerEvent("warn", "Newsletter ingestion: bulk candidate write skipped (aborted before insert)", {
+      briefingDate,
+      plannedInserts: inserts.length,
+    });
+    return plans.map(planToAbortedResult);
+  }
+
+  const sourceUrlToId = new Map<string, string>();
+
+  if (inserts.length > 0) {
+    const insertResult = await input.db
+      .from("signal_posts")
+      .insert(inserts.map((plan) => plan.row))
+      .select("id, rank, source_url");
+
+    if (insertResult.error) {
+      logServerEvent("error", "Newsletter ingestion: bulk candidate insert failed", {
+        briefingDate,
+        attempted: inserts.length,
+        message: insertResult.error.message,
+      });
+      // A failed multi-row INSERT commits nothing — no partial slate to clean up.
+      return plans.map((plan) => planToStorageErrorResult(plan, insertResult.error!.message));
+    }
+
+    for (const row of (insertResult.data ?? []) as Array<{ id: string; rank: number | null; source_url: string | null }>) {
+      if (row.source_url) {
+        sourceUrlToId.set(row.source_url, row.id);
+      }
+    }
+  }
+
+  const results: NewsletterPromotionResult[] = [];
+
+  for (const plan of plans) {
+    if (plan.action === "skip") {
+      results.push({ status: "skipped", extractionId: plan.extractionId, reason: plan.reason, message: plan.message });
+      continue;
+    }
+
+    if (plan.action === "insert") {
+      const signalPostId = sourceUrlToId.get(plan.sourceUrl);
+      if (!signalPostId) {
+        results.push({
+          status: "skipped",
+          extractionId: plan.extractionId,
+          reason: "storage_error",
+          message: "Inserted signal_posts row id could not be resolved for the newsletter extraction.",
+        });
+        continue;
+      }
+      await safeLinkExtractionToSignalPost(input.db, plan.extractionId, signalPostId);
+      results.push({ status: "created", extractionId: plan.extractionId, signalPostId, rank: plan.rank });
+      continue;
+    }
+
+    const signalPostId = plan.existingSignalPostId
+      ?? (plan.batchSourceUrl ? sourceUrlToId.get(plan.batchSourceUrl) ?? null : null);
+    if (!signalPostId) {
+      results.push({
+        status: "skipped",
+        extractionId: plan.extractionId,
+        reason: "storage_error",
+        message: "Link target signal_posts row could not be resolved for the newsletter extraction.",
+      });
+      continue;
+    }
+    await safeLinkExtractionToSignalPost(input.db, plan.extractionId, signalPostId);
+    results.push({ status: "linked_existing", extractionId: plan.extractionId, signalPostId });
+  }
+
+  return results;
 }
 
 export async function previewNewsletterStoryPromotions(input: {
@@ -296,14 +572,19 @@ export async function previewNewsletterStoryPromotions(input: {
   });
 }
 
+/**
+ * Promote a SINGLE newsletter story by id. Thin wrapper over the batch promoter
+ * so there is one code path for planning + the atomic insert. Reads the
+ * extraction row, then delegates to `promoteNewsletterStoryBatch([story])`.
+ * The hot ingestion loop uses the batch promoter directly with in-memory
+ * extraction rows; this entry point exists for targeted/single-story callers.
+ */
 export async function promoteNewsletterStoryToCandidate(input: {
   db: NewsletterDbClient;
   extractionId: string;
   briefingDate: string;
   now?: Date;
 }): Promise<NewsletterPromotionResult> {
-  const briefingDate = normalizeDateValue(input.briefingDate);
-
   try {
     const extractionResult = await input.db
       .from("newsletter_story_extractions")
@@ -316,153 +597,21 @@ export async function promoteNewsletterStoryToCandidate(input: {
     }
 
     const extraction = extractionResult.data as NewsletterStoryExtractionRow;
-
-    if (extraction.signal_post_id) {
-      return {
-        status: "skipped",
-        extractionId: extraction.id,
-        reason: "already_linked",
-        message: "Newsletter story extraction is already linked to a signal_posts candidate.",
-      };
-    }
-
-    const sourceUrl = extraction.source_url?.trim() ?? "";
-
-    if (!isValidPublicSourceUrl(sourceUrl)) {
-      return {
-        status: "skipped",
-        extractionId: extraction.id,
-        reason: "invalid_source_url",
-        message: "Newsletter story extraction was not promoted because it lacks a valid public source URL.",
-      };
-    }
-
-    const existingByUrl = await findExistingBySourceUrl({
+    const [result] = await promoteNewsletterStoryBatch({
       db: input.db,
-      briefingDate,
-      sourceUrl,
+      briefingDate: input.briefingDate,
+      stories: [extraction],
+      now: input.now,
     });
 
-    if (existingByUrl) {
-      if (isPublishedOrLive(existingByUrl)) {
-        return {
-          status: "skipped",
-          extractionId: extraction.id,
-          reason: "duplicate_public_row",
-          message: "Newsletter story extraction matches an already live or published signal_posts row.",
-        };
+    return (
+      result ?? {
+        status: "skipped",
+        extractionId: input.extractionId,
+        reason: "storage_error",
+        message: "Newsletter promotion produced no result for the extraction.",
       }
-
-      await linkExtractionToSignalPost(input.db, extraction.id, existingByUrl.id);
-
-      return {
-        status: "linked_existing",
-        extractionId: extraction.id,
-        signalPostId: existingByUrl.id,
-      };
-    }
-
-    const existingByTitle = await findExistingByTitle({
-      db: input.db,
-      briefingDate,
-      title: extraction.headline,
-    });
-
-    if (existingByTitle) {
-      if (isPublishedOrLive(existingByTitle)) {
-        return {
-          status: "skipped",
-          extractionId: extraction.id,
-          reason: "duplicate_public_row",
-          message: "Newsletter story extraction title matches an already live or published signal_posts row.",
-        };
-      }
-
-      await linkExtractionToSignalPost(input.db, extraction.id, existingByTitle.id);
-
-      return {
-        status: "linked_existing",
-        extractionId: extraction.id,
-        signalPostId: existingByTitle.id,
-      };
-    }
-
-    const rank = await getNextCandidateRank({
-      db: input.db,
-      briefingDate,
-    });
-
-    if (!rank) {
-      return {
-        status: "skipped",
-        extractionId: extraction.id,
-        reason: "no_available_candidate_rank",
-        message: "Newsletter story extraction was not promoted because all 20 candidate ranks are already occupied.",
-      };
-    }
-
-    const now = (input.now ?? new Date()).toISOString();
-    const insertResult = await input.db
-      .from("signal_posts")
-      .insert({
-        briefing_date: briefingDate,
-        rank,
-        title: extraction.headline,
-        source_name: sourceNameFromExtraction(extraction),
-        source_url: sourceUrl,
-        summary: extraction.snippet ?? "",
-        tags: extraction.category ? [extraction.category] : [],
-        signal_score: extraction.extraction_confidence
-          ? Number((extraction.extraction_confidence * 100).toFixed(2))
-          : null,
-        selection_reason: "Newsletter discovery candidate; BM review required.",
-        ai_why_it_matters: "",
-        edited_why_it_matters: null,
-        published_why_it_matters: null,
-        why_it_matters_validation_status: "requires_human_rewrite",
-        why_it_matters_validation_failures: ["incomplete_sentence"],
-        why_it_matters_validation_details: ["BM must write structural why-it-matters manually before publication."],
-        why_it_matters_validated_at: null,
-        editorial_status: "needs_review",
-        final_slate_rank: null,
-        final_slate_tier: null,
-        editorial_decision: "pending_review",
-        decision_note: null,
-        rejected_reason: null,
-        held_reason: null,
-        replacement_of_row_id: null,
-        reviewed_by: null,
-        reviewed_at: null,
-        edited_by: null,
-        edited_at: null,
-        approved_by: null,
-        approved_at: null,
-        published_at: null,
-        is_live: false,
-        context_material: getContextMaterial(extraction),
-        source_cluster_id: null,
-        witm_draft_generated_by: null,
-        witm_draft_generated_at: null,
-        witm_draft_model: null,
-        created_at: now,
-        updated_at: now,
-      })
-      .select("id, rank")
-      .single();
-
-    if (insertResult.error) {
-      throw new Error(`signal_posts newsletter candidate insert failed: ${insertResult.error.message}`);
-    }
-
-    const inserted = insertResult.data as { id: string; rank: number };
-    await linkExtractionToSignalPost(input.db, extraction.id, inserted.id);
-
-    return {
-      status: "created",
-      extractionId: extraction.id,
-      signalPostId: inserted.id,
-      rank: inserted.rank,
-    };
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
 

--- a/src/lib/newsletter-ingestion/runner.ts
+++ b/src/lib/newsletter-ingestion/runner.ts
@@ -15,7 +15,7 @@ import {
 } from "@/lib/newsletter-ingestion/gmail";
 import { parseRawNewsletterEmail } from "@/lib/newsletter-ingestion/email-content";
 import { parseNewsletterStories } from "@/lib/newsletter-ingestion/parser";
-import { promoteNewsletterStoryToCandidate, type NewsletterPromotionResult } from "@/lib/newsletter-ingestion/promotion";
+import { promoteNewsletterStoryBatch, type NewsletterPromotionResult } from "@/lib/newsletter-ingestion/promotion";
 import {
   extractStoriesFromEmail,
   insertNewsletterEmail,
@@ -34,6 +34,13 @@ export type NewsletterIngestionRunOptions = {
   label?: string;
   testRunId?: string | null;
   now?: Date;
+  /**
+   * The run's internal-timeout AbortSignal (threaded from the cron endpoint's
+   * 55s wall). When it fires, in-flight Gmail fetches abort, the email loop
+   * stops, and the atomic candidate write is skipped — so a timeout leaves a
+   * clean, empty briefing slate rather than partial junk rows.
+   */
+  signal?: AbortSignal;
 };
 
 export type NewsletterIngestionRunSummary = {
@@ -213,19 +220,34 @@ async function processWritableRun(input: {
   config: NewsletterIngestionConfig;
   briefingDate: string;
   now: Date;
+  signal?: AbortSignal;
 }) {
   let storedEmailCount = 0;
   let extractedStoryCount = 0;
   let failedEmailCount = 0;
-  const promotions: NewsletterPromotionResult[] = [];
+  // Stories are buffered ACROSS the whole email loop and promoted in a SINGLE
+  // atomic bulk insert after the loop (see promoteNewsletterStoryBatch). The
+  // newsletter_emails / newsletter_story_extractions writes stay incremental —
+  // they are idempotent (gmail_message_id / email-id keyed) and are NOT the
+  // public slate; only the signal_posts write must be all-or-nothing.
+  const candidateStories: NewsletterStoryExtractionRow[] = [];
+  const canWriteCandidates =
+    input.config.writeCandidates && canWriteNewsletterIngestionRecords(input.config);
 
   for (const ref of input.refs) {
+    // Stop pulling new emails once the run's deadline has fired; the buffered
+    // stories are discarded (never written) by the aborted batch below.
+    if (input.signal?.aborted) {
+      break;
+    }
+
     try {
       const inserted = await insertNewsletterEmail({
         db: input.db,
         gmailClient: input.gmailClient,
         messageRef: ref,
         label: input.config.label,
+        signal: input.signal,
       });
       const newsletterEmailId = inserted.email.id;
 
@@ -245,31 +267,35 @@ async function processWritableRun(input: {
 
       extractedStoryCount += extraction.stories.length;
 
-      if (!input.config.writeCandidates || !canWriteNewsletterIngestionRecords(input.config)) {
-        continue;
-      }
-
-      for (const story of extraction.stories) {
-        const promotion = await promoteNewsletterStoryToCandidate({
-          db: input.db,
-          extractionId: story.id,
-          briefingDate: input.briefingDate,
-          now: input.now,
-        });
-        promotions.push(promotion);
-
-        if (promotion.status === "skipped") {
-          logServerEvent("warn", "Newsletter ingestion: story promotion skipped", {
-            reason: promotion.reason,
-            extractionId: promotion.extractionId,
-          });
-        }
+      if (canWriteCandidates) {
+        candidateStories.push(...extraction.stories);
       }
     } catch (error) {
       failedEmailCount += 1;
       logServerEvent("warn", "Newsletter ingestion skipped one email after a safe processing failure", {
         gmailMessageId: ref.id,
         ...errorContext(error),
+      });
+    }
+  }
+
+  // SINGLE atomic candidate write for the whole run. A timeout anywhere in the
+  // loop above means control reaches the batch with the signal already aborted
+  // (or never reaches it because the awaiter rejected) — either way ZERO partial
+  // signal_posts rows are persisted for the briefing_date.
+  const promotions: NewsletterPromotionResult[] = await promoteNewsletterStoryBatch({
+    db: input.db,
+    briefingDate: input.briefingDate,
+    stories: candidateStories,
+    now: input.now,
+    signal: input.signal,
+  });
+
+  for (const promotion of promotions) {
+    if (promotion.status === "skipped") {
+      logServerEvent("warn", "Newsletter ingestion: story promotion skipped", {
+        reason: promotion.reason,
+        extractionId: promotion.extractionId,
       });
     }
   }
@@ -288,6 +314,7 @@ async function processWritableRun(input: {
 
     logServerEvent("info", "Newsletter ingestion: promotion summary", {
       briefingDate: input.briefingDate,
+      aborted: Boolean(input.signal?.aborted),
       promotedCandidateCount: promotionSummary.promotedCandidateCount,
       linkedExistingCandidateCount: promotionSummary.linkedExistingCandidateCount,
       skippedPromotionCount: promotionSummary.skippedPromotionCount,
@@ -458,6 +485,7 @@ route: "/api/cron/fetch-editorial-inputs",
       config,
       briefingDate,
       now,
+      signal: options.signal,
     });
 
     return buildResult({

--- a/src/lib/newsletter-ingestion/storage.ts
+++ b/src/lib/newsletter-ingestion/storage.ts
@@ -95,6 +95,8 @@ export async function insertNewsletterEmail(input: {
   gmailClient: GmailApiClient;
   messageRef: GmailMessageRef;
   label: string;
+  /** Run deadline signal — aborts the in-flight Gmail raw-message fetch on timeout. */
+  signal?: AbortSignal;
 }): Promise<InsertNewsletterEmailResult> {
   const existing = await getExistingNewsletterEmailByGmailId(input.db, input.messageRef.id);
 
@@ -105,7 +107,7 @@ export async function insertNewsletterEmail(input: {
     };
   }
 
-  const rawMessage = await input.gmailClient.getRawMessage(input.messageRef.id);
+  const rawMessage = await input.gmailClient.getRawMessage(input.messageRef.id, { signal: input.signal });
   const parsed = parseRawNewsletterEmail(rawMessage.raw, {
     internalDate: rawMessage.internalDate,
   });

--- a/src/lib/pipeline/editorial-ingestion-pipeline.ts
+++ b/src/lib/pipeline/editorial-ingestion-pipeline.ts
@@ -80,6 +80,12 @@ export async function runEditorialIngestionPipeline(options: {
   runStage?: EditorialPipelineStageRunner;
   /** Stage subset to run, in prod order. Defaults to all three. */
   stages?: EditorialPipelineStageName[];
+  /**
+   * Internal-timeout AbortSignal from the cron endpoint. Forwarded to the
+   * newsletter stage so its atomic candidate write is skipped on timeout
+   * (the slate is never left half-written). Ignored by rss/staging.
+   */
+  signal?: AbortSignal;
 }): Promise<EditorialPipelineResults> {
   const { dryRun, now } = options;
   const runStage = options.runStage ?? defaultRunStage;
@@ -91,7 +97,7 @@ export async function runEditorialIngestionPipeline(options: {
     results.newsletter = await runStage("newsletter", () =>
       dryRun
         ? runNewsletterIngestion({ dryRun: true, now })
-        : runNewsletterIngestion({ writeCandidates: true, now }),
+        : runNewsletterIngestion({ writeCandidates: true, now, signal: options.signal }),
     );
   }
 


### PR DESCRIPTION
**Stacked PR 1 of 4** — the highest-priority, load-bearing fix for *"newsletter-ingestion timeout poisons the daily slate."* Ships alone; PR2 (quality), PR3 (rank-band backstop), PR4 (throughput) follow. **Do not deploy from this PR — implement + validate only.**

## The bug
On a slow-Gmail morning the newsletter stage blew its 55s budget **mid-run**. It inserted `signal_posts` candidate rows **one at a time inside the per-email loop** with no transaction/rollback, and the 55s `Promise.race` only *rejects the awaiter* — it never aborts the work. So a timeout left **partial junk rows** committed, which occupied all 20 candidate ranks and starved the RSS stage (it early-outs *"snapshot already exists"* → 0 real articles).

## The fix — Option A (withhold the single bulk insert; **no migration**)
- **`promotion.ts`**: `buildNewsletterCandidateRow` (one shared, byte-identical `needs_review` row), `planNewsletterStoryPromotions` (**pure** planner against **one** pre-fetched snapshot — collapses the ~480 per-story round-trips incl. the *pull-100-filter-in-JS* title check), `promoteNewsletterStoryBatch` (plan → **one** multi-row insert → link). The per-story `promoteNewsletterStoryToCandidate` is now a thin wrapper (single code path).
- **`runner.ts`**: `processWritableRun` buffers stories across the loop, then writes **once**. `newsletter_emails` / `newsletter_story_extractions` stay incremental (idempotent, not the slate).
- **AbortSignal threading**: the 55s wall now `abort()`s a controller whose signal reaches the newsletter stage + Gmail fetches; the atomic write is **gated** on it, so a timeout deterministically leaves an **empty** slate (never partial) and status matches DB reality. rss/staging ignore the signal.
- **Self-heal**: links run *after* the committed insert; a crash in between is repaired next run via `source_url` dedupe (`UNIQUE(briefing_date, source_url)`).

## Guardrails honored
No schema change / migration. No publish/render/`published_slates*` change. No `is_live` / `why_it_matters_validation_status` writes on candidate rows. Candidate row shape byte-identical (shared builder). Respects `CHECK(rank 1..20)` + `UNIQUE(briefing_date, rank)`.

## Validation
- **New `promotion-batch.test.ts`** (8 cases): exactly-one bulk insert + descending unique ranks; aborted signal → **zero** rows; self-heal orphan link → 0 inserts; idempotent re-run → 0 inserts; within-batch `source_url` dedupe → 1 insert; bulk-insert error → **no partial**; pure-planner shape; **runner-level mid-loop timeout discards buffered candidates** (insert never called).
- Full suite green (**127 files / 1071 tests**). `npm run pipeline:dry` exercises the signal-threaded wiring end-to-end (no regression).
- Governance gate: PASS (bug-fix lane, doc added).

## Out of scope (separate PRs / ops)
PR2 quality (mojibake/tracking/chrome) · PR3 RSS rank-band backstop · PR4 throughput (must not ship without this) · cleanup of already-poisoned historical dates (data op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)