### PR TITLE
fix(pipeline): reserve candidate ranks 1-7 for RSS so a newsletter flood can't starve the slate (PR2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ project.md
 # controlled pipeline run artifacts
 /.pipeline-runs/
 .env*.local
+.gstack/

--- a/docs/engineering/bug-fixes/rss-rank-band-reservation-2026-06-21.md
+++ b/docs/engineering/bug-fixes/rss-rank-band-reservation-2026-06-21.md
@@ -31,5 +31,36 @@ Code-only; **no migration**.
 ## Known behavior to confirm in verification
 When RSS provides **more than 7** items AND newsletter is **sparse** (< 13 rows), RSS fills the band slots newsletter didn't use (e.g. 5 newsletter → ranks 8–12, RSS → 1–7 and 13–20). The **public slate (top 7) is still entirely RSS**; newsletter stays below the cut. This retains more RSS discovery candidates than capping RSS at 7. If strict "RSS owns only 1–7, newsletter owns all of 8–20" is preferred, that is a small follow-up (cap RSS candidates at `RSS_RESERVED_TOP_RANKS`) — deferred per the locked PR2 scope (two changes only).
 
+## PR-A — harden the eviction against the RESTRICT FK (added to this branch)
+**Problem:** the relocation-side degrade DELETEs excess newsletter rows, but
+`published_slate_items.signal_post_id → signal_posts(id)` is **ON DELETE RESTRICT**.
+A delete targeting a referenced row throws **23503**; the test harness uses a mock
+db with no FKs, so the green suite cannot catch it. (Today's blast radius is low —
+`published_slate_items` references only briefing_dates ≤ June 9 — but re-restaging
+any published date would throw and could abort the reservation.)
+
+**Fix (two layers in `reserveNewsletterCandidateRanksForRssSnapshot`):**
+1. **FK-safe scope** — `fetchFkProtectedSignalPostIds` queries `published_slate_items`
+   for the movable candidate ids; a referenced row is **never** an eviction target.
+   Only the lowest-signal **unprotected** rows are dropped to make room; protected
+   rows are always kept (relocated, never deleted). Fails **safe**: if the reference
+   check itself errors, every candidate is treated as protected (evict none).
+2. **Belt-and-suspenders** — each delete is guarded; a 23503 / any error is caught,
+   the row is **left in place + logged**, and the reservation **continues** (never
+   `ok:false`-with-no-change). Free band ranks are recomputed **after** eviction, so
+   a skipped delete can never become a relocation target (no 23505).
+
+**Tests (use the harness's `publishedSlateItems` + `deleteErrors` hooks):**
+- FK scope: a `published_slate_items`-referenced row is excluded from eviction; the
+  next-lowest unprotected row is evicted instead.
+- Graceful degrade: inject a 23503 on the delete → run completes, the row remains,
+  never `ok:false`-no-change.
+- All 7 original #327 gates still green.
+
+Full suite **1142 passing** (was 1140 at #327); typecheck 0; lint clean. No migration.
+
+**Did NOT touch:** the publish path / cockpit / render / `published_*`/`edited_*`
+columns / `final_slate_rank` assignment / validation logic. Ingestion-staging only.
+
 ## Scope
-Stacked fix, PR2 of the newsletter-quality stack. PR3 (newsletter content quality: charset decode + chrome filter) is hygiene layered on top and is **not** in this PR.
+Stacked fix, PR2 of the newsletter-quality stack + its FK safety guard (PR-A). PR3 (newsletter content quality: charset decode + chrome filter) is hygiene layered on top and is **not** in this PR.

--- a/docs/engineering/bug-fixes/rss-rank-band-reservation-2026-06-21.md
+++ b/docs/engineering/bug-fixes/rss-rank-band-reservation-2026-06-21.md
@@ -1,0 +1,35 @@
+# RSS Rank-Band Reservation (PR2) — 2026-06-21
+
+Canonical PRD required: `No` — pipeline reliability bug fix (slate starvation), not a product feature.
+
+## Problem
+On junk-heavy newsletter days (verified 06-18, 06-19) **zero** RSS articles reached the editorial slate, even though ~33–39 clean, body-extracted RSS articles surfaced. Root cause is **rank-slot contention**, not content:
+
+- Newsletter promotion assigned `signal_posts.rank` bottom-first via `nextAvailablePreviewRank` (`promotion.ts`), scanning `20→1` for the highest free slot. One row took rank 20; ~20 rows walked all the way up into ranks 1–7.
+- `reserveNewsletterCandidateRanksForRssSnapshot` (`signals-editorial.ts`) is meant to relocate newsletter rows down to free the top for RSS, but it needed one free target rank per movable row. At 20 movable rows it needed the entire space, hit the `targetRanks.length < movableNewsletterRows.length` branch, returned **`ok:false` / "No rows were changed"**, and bailed — so newsletter kept ranks 1–20 and RSS was filtered out entirely.
+
+Corroborated in prod: newsletter held rank 20 with 1 row and **all of 1–20** with 20 rows; RSS placed 8 vs **0** respectively.
+
+## Fix — hard-reserve the top band so newsletter can never occupy it
+Keyed off the existing public-slate size (`RSS_RESERVED_TOP_RANKS = FINAL_SLATE_MAX_PUBLIC_ROWS = 7`); never hardcoded. New single source of truth in `final-slate-readiness.ts` (`SIGNAL_POST_CANDIDATE_DEPTH_LIMIT`, `RSS_RESERVED_TOP_RANKS`), imported by both writers.
+
+1. **Write-side cap** (`nextAvailablePreviewRank`): the scan is confined to the discovery band `RSS_RESERVED_TOP_RANKS+1 .. depth limit` (8..20) and fills **floor-up** (8, then 9, …). Ranks 1..7 are never claimed by newsletter. When the band is full the function returns `null` and the caller drops the candidate; callers plan in **importance order** (`extraction_confidence` DESC — the only signal a story carries at promotion time), so band overflow drops the lowest-signal stories.
+
+2. **Relocation-side degrade** (`reserveNewsletterCandidateRanksForRssSnapshot`): caps the target band at 8..20 and, when movable rows exceed the 13-slot band, **DELETES the lowest-signal excess** (a candidate row can't exist without a 1..20 rank) instead of returning `ok:false` and changing nothing. Collision-safe by construction: the only relocations move newsletter rows OUT of 1..7 INTO free band ranks, and overflow rows are deleted before any relocation, so in-place `rank` UPDATEs never trip `UNIQUE(briefing_date, rank)`. Preserves the #324 atomic newsletter bulk insert (untouched).
+
+Code-only; **no migration**.
+
+## Result (verified by the regression suite — the acceptance gate)
+- 20 newsletter + RSS → ranks 1–7 RSS, newsletter 8–20, 7 lowest-signal newsletter rows dropped, zero 23505.
+- 3 RSS + 20 newsletter → ranks 1–3 RSS, **ranks 4–7 empty** (not newsletter), newsletter in the band.
+- 1 newsletter + RSS → RSS 1–7, newsletter at rank 8.
+- 0 newsletter → RSS fills the top untouched.
+- Mid-run abort → zero rows written (#324 preserved).
+- The 20-movable-row reserve case **degrades** (evicts excess); never returns `ok:false`-with-no-change.
+- Full suite green; typecheck 0; lint clean.
+
+## Known behavior to confirm in verification
+When RSS provides **more than 7** items AND newsletter is **sparse** (< 13 rows), RSS fills the band slots newsletter didn't use (e.g. 5 newsletter → ranks 8–12, RSS → 1–7 and 13–20). The **public slate (top 7) is still entirely RSS**; newsletter stays below the cut. This retains more RSS discovery candidates than capping RSS at 7. If strict "RSS owns only 1–7, newsletter owns all of 8–20" is preferred, that is a small follow-up (cap RSS candidates at `RSS_RESERVED_TOP_RANKS`) — deferred per the locked PR2 scope (two changes only).
+
+## Scope
+Stacked fix, PR2 of the newsletter-quality stack. PR3 (newsletter content quality: charset decode + chrome filter) is hygiene layered on top and is **not** in this PR.

--- a/src/lib/final-slate-readiness.ts
+++ b/src/lib/final-slate-readiness.ts
@@ -4,6 +4,17 @@ export const FINAL_SLATE_MIN_PUBLIC_ROWS = 1;
 // PRD-36 (amended): the public slate holds the full final-slate set —
 // 5 core ("Signal") + 2 context ("Context") = 7 rows.
 export const FINAL_SLATE_MAX_PUBLIC_ROWS = 7;
+
+// Candidate `rank` space: signal_posts.rank is NOT NULL, CHECK(1..20),
+// UNIQUE(briefing_date, rank). At most this many candidate rows per briefing day.
+export const SIGNAL_POST_CANDIDATE_DEPTH_LIMIT = 20;
+
+// RSS rank-band reservation (PR2): ranks 1..RSS_RESERVED_TOP_RANKS are reserved
+// for the RSS/article path (the public slate). Newsletter discovery candidates
+// are confined to the band BELOW it (RSS_RESERVED_TOP_RANKS+1 .. depth limit), so
+// a flood of newsletter rows can never crowd real news out of the public cut.
+// Keyed to the public-slate size so the two move together — never hardcode 7.
+export const RSS_RESERVED_TOP_RANKS = FINAL_SLATE_MAX_PUBLIC_ROWS;
 export const FINAL_SLATE_CORE_RANKS = [1, 2, 3, 4, 5] as const;
 export const FINAL_SLATE_CONTEXT_RANKS = [6, 7] as const;
 export const FINAL_SLATE_RANKS = [

--- a/src/lib/newsletter-ingestion/dry-run-report.test.ts
+++ b/src/lib/newsletter-ingestion/dry-run-report.test.ts
@@ -156,7 +156,8 @@ describe("newsletter dry-run report", () => {
       title: "Microsoft expands data center capacity",
       sourceUrl: "https://example.com/cloud",
       previewAction: "create_candidate",
-      rank: 20,
+      // PR2: newsletter discovery band fills floor-up from 8 (ranks 1..7 = RSS).
+      rank: 8,
     });
     expect(report.privacy).toEqual({
       rawContentIncluded: false,

--- a/src/lib/newsletter-ingestion/promotion-batch.test.ts
+++ b/src/lib/newsletter-ingestion/promotion-batch.test.ts
@@ -146,7 +146,7 @@ function story(overrides: Partial<NewsletterStoryExtractionRow> & { id: string }
 const BRIEFING_DATE = "2026-06-17";
 
 describe("promoteNewsletterStoryBatch — atomic bulk insert", () => {
-  it("performs EXACTLY ONE bulk insert for the whole run, with descending unique ranks, and links each extraction", async () => {
+  it("performs EXACTLY ONE bulk insert for the whole run, with unique band ranks (8..20), and links each extraction", async () => {
     const { db, tables, signalPostsInserts } = createCountingDb({
       newsletter_story_extractions: [story({ id: "a" }), story({ id: "b" }), story({ id: "c" })],
     });
@@ -163,12 +163,61 @@ describe("promoteNewsletterStoryBatch — atomic bulk insert", () => {
     expect(signalPostsInserts.sizes).toEqual([3]);
 
     expect(tables.signal_posts).toHaveLength(3);
-    expect(tables.signal_posts.map((row) => row.rank).sort((x, y) => Number(y) - Number(x))).toEqual([20, 19, 18]);
+    // PR2: newsletter fills the discovery band from the floor up (8, 9, 10);
+    // ranks 1..7 are reserved for RSS.
+    expect(tables.signal_posts.map((row) => row.rank).sort((x, y) => Number(y) - Number(x))).toEqual([10, 9, 8]);
     expect(new Set(tables.signal_posts.map((row) => row.rank)).size).toBe(3);
 
     expect(results.every((result) => result.status === "created")).toBe(true);
     // insert -> link seam: every extraction is linked to its committed row.
     expect(tables.newsletter_story_extractions.every((row) => Boolean(row.signal_post_id))).toBe(true);
+  });
+
+  // PR2 GATE (write-side) — the newsletter band holds 13 slots (8..20). A flood of
+  // 20 stories must fill the band with the 13 HIGHEST-confidence stories and DROP
+  // the 7 lowest; ranks 1..7 are never touched.
+  it("confines a 20-story flood to the band (8..20) and drops the 7 lowest-confidence stories", async () => {
+    // Distinct ascending confidence: s0=0.01 (lowest) .. s19=0.20 (highest).
+    const stories = Array.from({ length: 20 }, (_, index) =>
+      story({
+        id: `s${index}`,
+        source_url: `https://example.com/${index}`,
+        extraction_confidence: (index + 1) / 100,
+      }),
+    );
+    const { db, tables, signalPostsInserts } = createCountingDb({ newsletter_story_extractions: stories });
+
+    const results = await promoteNewsletterStoryBatch({
+      db,
+      briefingDate: BRIEFING_DATE,
+      stories,
+      now: new Date("2026-06-17T08:00:00.000Z"),
+    });
+
+    // Still ONE bulk insert (#324), carrying exactly the 13 band rows.
+    expect(signalPostsInserts.count).toBe(1);
+    expect(tables.signal_posts).toHaveLength(13);
+    expect(tables.signal_posts.every((row) => Number(row.rank) >= 8 && Number(row.rank) <= 20)).toBe(true);
+    expect(tables.signal_posts.map((row) => Number(row.rank)).sort((a, b) => a - b))
+      .toEqual([8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
+
+    // The 7 dropped are the LOWEST confidence (s0..s6), via no_available_candidate_rank.
+    const dropped = results.filter(
+      (result) => result.status === "skipped" && result.reason === "no_available_candidate_rank",
+    );
+    expect(dropped).toHaveLength(7);
+
+    // Highest-confidence story (s19) sits at the band floor (rank 8); the dropped
+    // ids are exactly the 7 lowest-confidence stories.
+    const rankFloorRow = tables.signal_posts.find((row) => Number(row.rank) === 8);
+    expect(rankFloorRow?.title).toBe("Headline s19");
+    const insertedTitles = new Set(tables.signal_posts.map((row) => row.title));
+    for (let i = 0; i <= 6; i += 1) {
+      expect(insertedTitles.has(`Headline s${i}`)).toBe(false);
+    }
+    for (let i = 7; i <= 19; i += 1) {
+      expect(insertedTitles.has(`Headline s${i}`)).toBe(true);
+    }
   });
 
   it("writes ZERO rows when the run signal is already aborted (timeout leaves an empty slate)", async () => {
@@ -286,7 +335,8 @@ describe("planNewsletterStoryPromotions — pure planner", () => {
     const byAction = (action: NewsletterCandidatePlan["action"]) => plans.filter((plan) => plan.action === action);
     expect(byAction("skip")).toHaveLength(2);
     const inserts = byAction("insert") as Extract<NewsletterCandidatePlan, { action: "insert" }>[];
-    expect(inserts.map((plan) => plan.rank)).toEqual([20, 19]);
+    // PR2: newsletter band fills floor-up (8, 9); ranks 1..7 reserved for RSS.
+    expect(inserts.map((plan) => plan.rank)).toEqual([8, 9]);
   });
 });
 

--- a/src/lib/newsletter-ingestion/promotion.ts
+++ b/src/lib/newsletter-ingestion/promotion.ts
@@ -1,4 +1,8 @@
-import { isValidPublicSourceUrl } from "@/lib/final-slate-readiness";
+import {
+  isValidPublicSourceUrl,
+  RSS_RESERVED_TOP_RANKS,
+  SIGNAL_POST_CANDIDATE_DEPTH_LIMIT,
+} from "@/lib/final-slate-readiness";
 import type { NewsletterDbClient, NewsletterStoryExtractionRow } from "@/lib/newsletter-ingestion/storage";
 import { errorContext, logServerEvent } from "@/lib/observability";
 
@@ -153,7 +157,15 @@ function nextAvailablePreviewRank(
     usedRanks.add(rank);
   }
 
-  for (let rank = 20; rank >= 1; rank -= 1) {
+  // PR2 — RSS rank-band reservation. Newsletter discovery candidates may only
+  // claim ranks in the band BELOW the RSS-reserved top: RSS_RESERVED_TOP_RANKS+1
+  // .. depth limit (8..20). Ranks 1..RSS_RESERVED_TOP_RANKS stay free for the
+  // RSS/article path so a flood of newsletter rows can never occupy the public
+  // slate. The band fills from the FLOOR up (8, then 9, ...) so the most
+  // important story (callers plan in importance order — see
+  // sortStoriesByImportanceDesc) sits directly below the RSS slate, and band
+  // overflow returns null → the caller drops the lowest-signal candidate.
+  for (let rank = RSS_RESERVED_TOP_RANKS + 1; rank <= SIGNAL_POST_CANDIDATE_DEPTH_LIMIT; rank += 1) {
     if (!usedRanks.has(rank)) {
       allocatedRanks.add(rank);
       return rank;
@@ -161,6 +173,26 @@ function nextAvailablePreviewRank(
   }
 
   return null;
+}
+
+/**
+ * Order stories most-important-first so that when the newsletter band (8..20)
+ * overflows, the rows that get dropped are the LOWEST signal. The only
+ * importance signal a story carries at promotion time is `extraction_confidence`
+ * (newsletter co-occurrence and source-trust tier are computed downstream, not
+ * here), so that is the sort key; nulls sort last. Stable on ties (preserves the
+ * original within-batch order, which keeps dedup ownership deterministic).
+ */
+function sortStoriesByImportanceDesc(
+  stories: NewsletterStoryExtractionRow[],
+): NewsletterStoryExtractionRow[] {
+  return stories
+    .map((story, index) => ({ story, index }))
+    .sort((a, b) => {
+      const confDelta = (b.story.extraction_confidence ?? -1) - (a.story.extraction_confidence ?? -1);
+      return confDelta !== 0 ? confDelta : a.index - b.index;
+    })
+    .map((entry) => entry.story);
 }
 
 /**
@@ -252,9 +284,11 @@ export type NewsletterCandidatePlan =
  * pre-fetched `existingRows` snapshot, with NO database calls. Replaces the old
  * per-story round-trips (dup-by-url / dup-by-title / next-rank) that each hit the
  * DB; everything is now resolved in memory against one read. Ranks are allocated
- * descending (20→1) exactly as before, deduped within the batch via
+ * descending within the newsletter discovery band (depth limit → RSS_RESERVED_TOP_RANKS+1,
+ * i.e. 20→8 — PR2 reserves 1..7 for RSS), deduped within the batch via
  * `nextAvailablePreviewRank`'s `allocatedRanks` accumulator, so the resulting
- * bulk insert respects CHECK(rank 1..20) and UNIQUE(briefing_date, rank).
+ * bulk insert respects CHECK(rank 1..20) and UNIQUE(briefing_date, rank). Stories
+ * are planned in importance order so band overflow drops the lowest signal.
  */
 export function planNewsletterStoryPromotions(input: {
   stories: NewsletterStoryExtractionRow[];
@@ -267,7 +301,9 @@ export function planNewsletterStoryPromotions(input: {
   const plannedInsertSourceUrls = new Set<string>();
   const plannedInsertTitleToUrl = new Map<string, string>();
 
-  return stories.map((extraction): NewsletterCandidatePlan => {
+  // Plan in importance order so that when the newsletter band (8..20) overflows,
+  // the lowest-signal stories are the ones dropped (no available rank).
+  return sortStoriesByImportanceDesc(stories).map((extraction): NewsletterCandidatePlan => {
     if (extraction.signal_post_id) {
       return {
         action: "skip",
@@ -334,7 +370,7 @@ export function planNewsletterStoryPromotions(input: {
         action: "skip",
         extractionId: extraction.id,
         reason: "no_available_candidate_rank",
-        message: "Newsletter story extraction was not promoted because all 20 candidate ranks are already occupied.",
+        message: `Newsletter story extraction was not promoted because the newsletter discovery band (ranks ${RSS_RESERVED_TOP_RANKS + 1}..${SIGNAL_POST_CANDIDATE_DEPTH_LIMIT}) is full; ranks 1..${RSS_RESERVED_TOP_RANKS} are reserved for RSS.`,
       };
     }
 
@@ -556,7 +592,7 @@ export async function previewNewsletterStoryPromotions(input: {
         rank: null,
         existingSignalPostId: null,
         matchedBy: null,
-        reason: "All 20 candidate ranks are already occupied for the briefing date.",
+        reason: `The newsletter discovery band (ranks ${RSS_RESERVED_TOP_RANKS + 1}..${SIGNAL_POST_CANDIDATE_DEPTH_LIMIT}) is full for the briefing date; ranks 1..${RSS_RESERVED_TOP_RANKS} are reserved for RSS.`,
       };
     }
 

--- a/src/lib/newsletter-ingestion/storage-promotion.test.ts
+++ b/src/lib/newsletter-ingestion/storage-promotion.test.ts
@@ -274,7 +274,9 @@ describe("newsletter candidate promotion", () => {
     expect(result).toMatchObject({
       status: "created",
       signalPostId: expect.any(String),
-      rank: 20,
+      // PR2: newsletter discovery candidates fill the band floor-up (8..20);
+      // ranks 1..7 are reserved for RSS. A lone story lands at the floor, 8.
+      rank: 8,
     });
     expect(tables.signal_posts[0]).toMatchObject({
       editorial_status: "needs_review",
@@ -380,7 +382,8 @@ describe("newsletter candidate promotion", () => {
       sourceUrl: "https://example.com/cloud",
       sourceDomain: "example.com",
       category: "Tech",
-      rank: 20,
+      // PR2: band floor-up — a lone preview candidate lands at rank 8 (1..7 = RSS).
+      rank: 8,
       existingSignalPostId: null,
       matchedBy: null,
       reason: "Newsletter story would create a non-live needs_review candidate.",

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -1703,8 +1703,122 @@ describe("signals editorial workflow", () => {
     const rssRows = rows.filter((row) => row.title.startsWith("Generated Signal"));
     const newsletterRows = rows.filter((row) => row.title.startsWith("Newsletter Candidate"));
     expect(rssRows).toHaveLength(15);
-    expect(rssRows.map((row) => row.rank)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
-    expect(newsletterRows.map((row) => row.rank)).toEqual([16, 17, 18, 19, 20]);
+    // PR2: the 5 newsletter rows (originally ranks 1-5, inside the RSS-reserved
+    // top) are relocated DOWN into the discovery band, floor-first (8..12). RSS
+    // takes the reserved top (1-7) plus the band slots newsletter didn't use (13-20).
+    expect(rssRows.map((row) => row.rank)).toEqual([1, 2, 3, 4, 5, 6, 7, 13, 14, 15, 16, 17, 18, 19, 20]);
+    expect(newsletterRows.map((row) => row.rank)).toEqual([8, 9, 10, 11, 12]);
+  });
+
+  // PR2 GATE — the 06-18/19 failure: a 20-row newsletter flood. The OLD reserve
+  // fn could not fit 20 movable rows and returned ok:false / "No rows were
+  // changed", leaving newsletter in ranks 1-20 and starving RSS. It must now
+  // DEGRADE: confine newsletter to the 13-slot band (8..20), DELETE the excess,
+  // and free ranks 1-7 for RSS.
+  it("degrades a 20-row newsletter flood: confines to ranks 8-20, deletes the excess, frees 1-7 for RSS", async () => {
+    const rows = Array.from({ length: 20 }, (_, index) =>
+      createRow({
+        id: `newsletter-${index + 1}`,
+        briefing_date: "2026-06-19",
+        rank: index + 1,
+        title: `Newsletter Candidate ${index + 1}`,
+        selection_reason: "Newsletter discovery candidate; BM review required.",
+        editorial_status: "needs_review",
+        final_slate_rank: null,
+        final_slate_tier: null,
+        editorial_decision: "pending_review",
+        is_live: false,
+        published_at: null,
+      }),
+    );
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+
+    const { persistSignalPostsForBriefing } = await loadEditorialModule();
+    const result = await persistSignalPostsForBriefing({
+      briefingDate: "2026-06-19",
+      items: Array.from({ length: 7 }, (_, index) => createBriefingItem(index + 1)),
+    });
+
+    // Degrades, never the old ok:false-with-no-change.
+    expect(result.ok).toBe(true);
+    expect(result.message).not.toContain("No rows were changed");
+
+    const rssRows = rows.filter((row) => row.title.startsWith("Generated Signal"));
+    const newsletterRows = rows.filter((row) => row.title.startsWith("Newsletter Candidate"));
+    // 7 newsletter rows evicted (20 - 13-slot band); 13 remain, confined to 8..20.
+    expect(newsletterRows).toHaveLength(13);
+    expect(newsletterRows.map((row) => row.rank).sort((a, b) => Number(a) - Number(b)))
+      .toEqual([8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
+    // RSS takes the reserved top.
+    expect(rssRows.map((row) => row.rank).sort((a, b) => Number(a) - Number(b))).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(rssRows.every((row) => row.rank <= 7)).toBe(true);
+  });
+
+  // PR2 GATE — RSS shortfall must NOT be backfilled by newsletter. Reserved top
+  // ranks left empty by RSS stay empty; newsletter stays in the band.
+  it("leaves reserved ranks empty when RSS is short: 3 RSS at 1-3, ranks 4-7 empty, newsletter in the band", async () => {
+    const rows = Array.from({ length: 20 }, (_, index) =>
+      createRow({
+        id: `newsletter-${index + 1}`,
+        briefing_date: "2026-06-19",
+        rank: index + 1,
+        title: `Newsletter Candidate ${index + 1}`,
+        selection_reason: "Newsletter discovery candidate; BM review required.",
+        editorial_status: "needs_review",
+        final_slate_rank: null,
+        final_slate_tier: null,
+        editorial_decision: "pending_review",
+        is_live: false,
+        published_at: null,
+      }),
+    );
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+
+    const { persistSignalPostsForBriefing } = await loadEditorialModule();
+    const result = await persistSignalPostsForBriefing({
+      briefingDate: "2026-06-19",
+      items: Array.from({ length: 3 }, (_, index) => createBriefingItem(index + 1)),
+    });
+
+    expect(result.ok).toBe(true);
+    const rssRows = rows.filter((row) => row.title.startsWith("Generated Signal"));
+    const newsletterRows = rows.filter((row) => row.title.startsWith("Newsletter Candidate"));
+    expect(rssRows.map((row) => row.rank).sort((a, b) => Number(a) - Number(b))).toEqual([1, 2, 3]);
+    // Ranks 4-7 are reserved and stay EMPTY — newsletter never backfills them.
+    expect(rows.some((row) => typeof row.rank === "number" && row.rank >= 4 && row.rank <= 7)).toBe(false);
+    expect(newsletterRows.every((row) => typeof row.rank === "number" && (row.rank as number) >= 8)).toBe(true);
+  });
+
+  // PR2 GATE — a single newsletter row lands at the band floor (8), RSS owns 1-7.
+  it("places a single newsletter row at the band floor (rank 8) with RSS at 1-7", async () => {
+    const rows = [
+      createRow({
+        id: "newsletter-1",
+        briefing_date: "2026-06-20",
+        rank: 8,
+        title: "Newsletter Candidate 1",
+        selection_reason: "Newsletter discovery candidate; BM review required.",
+        editorial_status: "needs_review",
+        final_slate_rank: null,
+        final_slate_tier: null,
+        editorial_decision: "pending_review",
+        is_live: false,
+        published_at: null,
+      }),
+    ];
+    createSupabaseServiceRoleClient.mockReturnValue(createSupabaseMock(rows));
+
+    const { persistSignalPostsForBriefing } = await loadEditorialModule();
+    const result = await persistSignalPostsForBriefing({
+      briefingDate: "2026-06-20",
+      items: Array.from({ length: 7 }, (_, index) => createBriefingItem(index + 1)),
+    });
+
+    expect(result.ok).toBe(true);
+    const rssRows = rows.filter((row) => row.title.startsWith("Generated Signal"));
+    const newsletterRows = rows.filter((row) => row.title.startsWith("Newsletter Candidate"));
+    expect(newsletterRows.map((row) => row.rank)).toEqual([8]);
+    expect(rssRows.map((row) => row.rank).sort((a, b) => Number(a) - Number(b))).toEqual([1, 2, 3, 4, 5, 6, 7]);
   });
 
   it("append mode adds only new-URL items at POST-MAX ranks without churning existing rows (CRON-2)", async () => {

--- a/src/lib/signals-editorial.test.ts
+++ b/src/lib/signals-editorial.test.ts
@@ -1821,6 +1821,90 @@ describe("signals editorial workflow", () => {
     expect(rssRows.map((row) => row.rank).sort((a, b) => Number(a) - Number(b))).toEqual([1, 2, 3, 4, 5, 6, 7]);
   });
 
+  // PR-A GATE (FK scope) — published_slate_items.signal_post_id is ON DELETE
+  // RESTRICT. A referenced row must NEVER be an eviction target; the next-lowest
+  // UNPROTECTED row is evicted instead. (The mock has no FKs, so this scope check
+  // is what protects prod — not the constraint.)
+  it("never evicts a published_slate_items-referenced row; drops the next-lowest unprotected instead", async () => {
+    // 14 movable rows → band capacity 13 → 1 overflow. rank 14 = lowest signal AND
+    // FK-protected; rank 13 = next-lowest, unprotected.
+    const rows = Array.from({ length: 14 }, (_, index) =>
+      createRow({
+        id: `newsletter-${index + 1}`,
+        briefing_date: "2026-06-19",
+        rank: index + 1,
+        title: `Newsletter Candidate ${index + 1}`,
+        selection_reason: "Newsletter discovery candidate; BM review required.",
+        editorial_status: "needs_review",
+        final_slate_rank: null,
+        final_slate_tier: null,
+        editorial_decision: "pending_review",
+        is_live: false,
+        published_at: null,
+        signal_score: index + 1 === 14 ? 10 : index + 1 === 13 ? 20 : 90,
+      }),
+    );
+    createSupabaseServiceRoleClient.mockReturnValue(
+      createSupabaseMock(rows, {
+        publishedSlateItems: [createPublishedSlateItemRow({ signal_post_id: "newsletter-14" })],
+      }),
+    );
+
+    const { persistSignalPostsForBriefing } = await loadEditorialModule();
+    const result = await persistSignalPostsForBriefing({
+      briefingDate: "2026-06-19",
+      items: Array.from({ length: 7 }, (_, index) => createBriefingItem(index + 1)),
+    });
+
+    expect(result.ok).toBe(true);
+    const survivingIds = new Set(rows.map((row) => row.id));
+    // Protected lowest-signal row survives; next-lowest UNPROTECTED row was evicted.
+    expect(survivingIds.has("newsletter-14")).toBe(true);
+    expect(survivingIds.has("newsletter-13")).toBe(false);
+  });
+
+  // PR-A GATE (graceful degrade) — if a delete still throws (23503) the run must
+  // COMPLETE, leave the row in place, and never return ok:false-with-no-change.
+  it("degrades when an eviction delete throws (FK 23503): completes, leaves the row, never bails", async () => {
+    const rows = Array.from({ length: 14 }, (_, index) =>
+      createRow({
+        id: `newsletter-${index + 1}`,
+        briefing_date: "2026-06-19",
+        rank: index + 1,
+        title: `Newsletter Candidate ${index + 1}`,
+        selection_reason: "Newsletter discovery candidate; BM review required.",
+        editorial_status: "needs_review",
+        final_slate_rank: null,
+        final_slate_tier: null,
+        editorial_decision: "pending_review",
+        is_live: false,
+        published_at: null,
+      }),
+    );
+    createSupabaseServiceRoleClient.mockReturnValue(
+      createSupabaseMock(rows, {
+        deleteErrors: {
+          signal_posts:
+            'update or delete on table "signal_posts" violates foreign key constraint "published_slate_items_signal_post_id_fkey" (SQLSTATE 23503)',
+        },
+      }),
+    );
+
+    const { persistSignalPostsForBriefing } = await loadEditorialModule();
+    const result = await persistSignalPostsForBriefing({
+      briefingDate: "2026-06-19",
+      items: Array.from({ length: 7 }, (_, index) => createBriefingItem(index + 1)),
+    });
+
+    // Run completes; the old ok:false-with-no-change bug must NOT resurface.
+    expect(result.ok).toBe(true);
+    expect(result.message ?? "").not.toContain("could not evict");
+    expect(result.message ?? "").not.toContain("No rows were changed");
+    // The eviction target's delete failed, so the row is LEFT in place (not lost).
+    const newsletterRows = rows.filter((row) => row.title.startsWith("Newsletter Candidate"));
+    expect(newsletterRows).toHaveLength(14);
+  });
+
   it("append mode adds only new-URL items at POST-MAX ranks without churning existing rows (CRON-2)", async () => {
     // Today's existing slate from the 12:00 main run: ranks 1-2 (one already approved).
     const rows = [

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -13,7 +13,7 @@ import {
   computeCrossDateWindow,
   partitionByCrossDateRecurrence,
 } from "@/lib/editorial/cross-date-url-dedup";
-import { logServerEvent } from "@/lib/observability";
+import { errorContext, logServerEvent } from "@/lib/observability";
 import {
   createSupabaseServiceRoleClient,
   safeGetUser,
@@ -1751,6 +1751,41 @@ function compareNewsletterRowImportanceDesc(
 }
 
 /**
+ * PR-A — which of these candidate signal_posts are referenced by
+ * published_slate_items (FK is ON DELETE RESTRICT). Such a row must NEVER be an
+ * eviction target — a DELETE against it throws 23503 and would abort the
+ * reservation. Fails SAFE: if the reference check itself errors, every candidate
+ * is treated as protected (evict none), so we never risk a RESTRICT abort.
+ */
+async function fetchFkProtectedSignalPostIds(
+  client: EditorialClient,
+  candidateIds: string[],
+): Promise<Set<string>> {
+  if (candidateIds.length === 0) {
+    return new Set<string>();
+  }
+
+  const result = await client
+    .from("published_slate_items")
+    .select("signal_post_id")
+    .in("signal_post_id", candidateIds);
+
+  if (result.error) {
+    logServerEvent("warn", "Could not check published_slate_items references; treating all eviction candidates as protected", {
+      candidateCount: candidateIds.length,
+      ...errorContext(result.error),
+    });
+    return new Set<string>(candidateIds);
+  }
+
+  return new Set<string>(
+    ((result.data ?? []) as Array<{ signal_post_id: string | null }>)
+      .map((row) => row.signal_post_id)
+      .filter((id): id is string => typeof id === "string"),
+  );
+}
+
+/**
  * PR2 — reserve ranks 1..RSS_RESERVED_TOP_RANKS for the RSS/article path by
  * confining newsletter discovery candidates to the band BELOW it
  * (RSS_RESERVED_TOP_RANKS+1 .. depth limit). Newsletter rows currently sitting in
@@ -1763,10 +1798,15 @@ function compareNewsletterRowImportanceDesc(
  * starve RSS. With the write-side band cap in promotion.ts, new rows already land
  * in the band, so this is mostly defense-in-depth for pre-existing rows.
  *
+ * PR-A — eviction is FK-safe against published_slate_items (ON DELETE RESTRICT):
+ * a referenced row is never an eviction target (scope check via
+ * fetchFkProtectedSignalPostIds), and any delete that still throws (23503) is
+ * caught and skipped so the run never aborts. Free band ranks are recomputed after
+ * eviction so a skipped delete can never become a relocation target.
+ *
  * Collision-safe by construction: the only relocations move newsletter rows OUT of
  * the reserved top (1..N) INTO free band ranks (N+1..depth); sources and targets
- * never overlap, and overflow rows are deleted BEFORE any relocation, so in-place
- * rank UPDATEs never trip UNIQUE(briefing_date, rank).
+ * never overlap, so in-place rank UPDATEs never trip UNIQUE(briefing_date, rank).
  */
 async function reserveNewsletterCandidateRanksForRssSnapshot(
   client: EditorialClient,
@@ -1801,31 +1841,42 @@ async function reserveNewsletterCandidateRanksForRssSnapshot(
   }
   const capacity = availableBandRanks.length;
 
-  // Keep the highest-signal `capacity` rows; drop the rest (lowest signal first).
-  const byImportance = [...movableNewsletterRows].sort(compareNewsletterRowImportanceDesc);
-  const keptRows = byImportance.slice(0, capacity);
-  const droppedRows = byImportance.slice(capacity);
-
-  // Kept rows already parked at an available band rank stay; the rest (in the
-  // reserved top) move into the leftover band ranks (floor-first to stay contiguous).
   const availableBandSet = new Set(availableBandRanks);
-  const stayingRanks = new Set(
-    keptRows
-      .map((row) => row.rank)
-      .filter((rank): rank is number => typeof rank === "number" && availableBandSet.has(rank)),
-  );
-  const movingRows = keptRows.filter(
-    (row) => !(typeof row.rank === "number" && availableBandSet.has(row.rank)),
-  );
-  const freeBandRanks = availableBandRanks.filter((rank) => !stayingRanks.has(rank));
+  const byImportance = [...movableNewsletterRows].sort(compareNewsletterRowImportanceDesc);
 
+  // Only rows that overflow the band need to be removed, and only UNPROTECTED rows
+  // (PR-A: not referenced by published_slate_items, whose FK is ON DELETE RESTRICT)
+  // may be deleted. Protected rows are always kept (relocated, never deleted); the
+  // lowest-signal UNPROTECTED rows are evicted to make room.
+  const overflowCount = Math.max(0, movableNewsletterRows.length - capacity);
+  let droppedRows: ExistingSignalSnapshotRow[] = [];
+  if (overflowCount > 0) {
+    const protectedIds = await fetchFkProtectedSignalPostIds(
+      client,
+      movableNewsletterRows.map((row) => row.id),
+    );
+    // byImportance is highest-signal first; reverse the unprotected rows so the
+    // lowest-signal ones are evicted first.
+    const evictableLowestFirst = byImportance.filter((row) => !protectedIds.has(row.id)).reverse();
+    droppedRows = evictableLowestFirst.slice(0, overflowCount);
+
+    if (droppedRows.length < overflowCount) {
+      logServerEvent("warn", "Newsletter band overflow exceeds evictable (unprotected) rows; some rows remain above the band", {
+        overflowCount,
+        evictableCount: evictableLowestFirst.length,
+        protectedCount: movableNewsletterRows.length - evictableLowestFirst.length,
+      });
+    }
+  }
   const droppedIds = new Set(droppedRows.map((row) => row.id));
-  const updatedRows = existingRows
-    .filter((row) => !droppedIds.has(row.id))
-    .map((row) => ({ ...row }));
-  const rowsById = new Map(updatedRows.map((row) => [row.id, row]));
+  const keptRows = movableNewsletterRows.filter((row) => !droppedIds.has(row.id));
 
-  // Evict band overflow FIRST so their ranks are free before any relocation.
+  // Evict band overflow FIRST so their ranks free up before relocation.
+  // Belt-and-suspenders (PR-A): a delete that throws — e.g. an unexpected FK
+  // reference (23503) the scope check above didn't catch — is caught; that row is
+  // left in place and the reservation CONTINUES. It never aborts / returns
+  // ok:false-with-no-change (the old bug it replaced).
+  const evictedIds = new Set<string>();
   for (const dropped of droppedRows) {
     const deleteResult = await client
       .from("signal_posts")
@@ -1833,21 +1884,54 @@ async function reserveNewsletterCandidateRanksForRssSnapshot(
       .eq("id", dropped.id);
 
     if (deleteResult.error) {
-      return {
-        ok: false,
-        message: `RSS signal snapshot could not evict overflow newsletter candidate: ${deleteResult.error.message}`,
-      };
+      logServerEvent("warn", "Newsletter overflow eviction skipped (delete failed; row left in place)", {
+        signalPostId: dropped.id,
+        rank: dropped.rank,
+        ...errorContext(deleteResult.error),
+      });
+      continue;
     }
+    evictedIds.add(dropped.id);
   }
 
-  // Relocate reserved-top newsletter rows down into the free band ranks. Sources
-  // are in 1..RSS_RESERVED_TOP_RANKS, targets in the band — disjoint, no collision.
+  const updatedRows = existingRows
+    .filter((row) => !evictedIds.has(row.id))
+    .map((row) => ({ ...row }));
+  const rowsById = new Map(updatedRows.map((row) => [row.id, row]));
+
+  // Movers = kept rows still sitting in the reserved top (1..N), not yet in the band.
+  const movingRows = keptRows.filter(
+    (row) => !(typeof row.rank === "number" && availableBandSet.has(row.rank)),
+  );
+  const moverIds = new Set(movingRows.map((row) => row.id));
+
+  // Free band ranks = band ranks not held by any SURVIVING non-mover row (stayers
+  // PLUS any row whose eviction failed). Recomputed AFTER eviction so a failed
+  // delete can never become a relocation target — relocations stay collision-safe
+  // against UNIQUE(briefing_date, rank). Sources (1..N) and targets (band) are
+  // disjoint by construction.
+  const occupiedBandRanks = new Set<number>();
+  for (const row of updatedRows) {
+    if (moverIds.has(row.id)) continue;
+    if (typeof row.rank === "number" && availableBandSet.has(row.rank)) {
+      occupiedBandRanks.add(row.rank);
+    }
+  }
+  const freeBandRanks = availableBandRanks.filter((rank) => !occupiedBandRanks.has(rank));
+
   for (let index = 0; index < movingRows.length; index += 1) {
     const newsletterRow = movingRows[index]!;
     const targetRank = freeBandRanks[index];
 
     if (typeof targetRank !== "number") {
-      continue; // capacity guarantees a slot; defensive
+      // No free band slot (an eviction failed / over-capacity). Leave the row in
+      // the reserved top — RSS gets one fewer reserved rank this run, but the run
+      // never aborts.
+      logServerEvent("warn", "No free band rank for newsletter row; left in the reserved top this run", {
+        signalPostId: newsletterRow.id,
+        rank: newsletterRow.rank,
+      });
+      continue;
     }
 
     const updateResult = await client

--- a/src/lib/signals-editorial.ts
+++ b/src/lib/signals-editorial.ts
@@ -26,6 +26,8 @@ import {
   isFinalSlateRank,
   isValidPublicSourceUrl,
   MISSING_PUBLIC_SOURCE_URL_REASON,
+  RSS_RESERVED_TOP_RANKS,
+  SIGNAL_POST_CANDIDATE_DEPTH_LIMIT,
   validateFinalSlateReadiness,
   type FinalSlateTier,
   type FinalSlateValidationFailure,
@@ -173,7 +175,8 @@ const PUBLISHED_SLATE_SELECT = PUBLISHED_SLATE_REQUIRED_COLUMNS.join(", ");
 const PUBLISHED_SLATE_ITEM_SELECT = PUBLISHED_SLATE_ITEM_REQUIRED_COLUMNS.join(", ");
 
 const EDITORIAL_PAGE_SIZE = 20;
-const SIGNAL_POST_CANDIDATE_DEPTH_LIMIT = 20;
+// SIGNAL_POST_CANDIDATE_DEPTH_LIMIT + RSS_RESERVED_TOP_RANKS are imported from
+// final-slate-readiness (single source of truth for the candidate rank geometry).
 // The full public slate size (PRD-36 amended): 5 core + 2 context = 7.
 const TOP_SIGNAL_SET_SIZE = 7;
 // signal_posts.rank CHECK is `between 1 and 20`; append mode caps post-max ranks here.
@@ -1377,7 +1380,7 @@ async function persistSignalPostCandidates(
 
   const existingResult = await client
     .from("signal_posts")
-    .select("id, rank, selection_reason, editorial_status, final_slate_rank, is_live, published_at")
+    .select("id, rank, selection_reason, editorial_status, final_slate_rank, is_live, published_at, signal_score")
     .eq("briefing_date", briefingDate);
 
   if (existingResult.error) {
@@ -1707,6 +1710,7 @@ type ExistingSignalSnapshotRow = {
   final_slate_rank: number | null;
   is_live: boolean | null;
   published_at: string | null;
+  signal_score: number | null;
 };
 
 type NewsletterRankReservationResult =
@@ -1731,13 +1735,44 @@ function isMovableNewsletterDiscoveryRow(row: ExistingSignalSnapshotRow) {
   );
 }
 
+/**
+ * Eviction/relocation priority for newsletter discovery rows: highest signal_score
+ * first (nulls last), tiebroken by current rank ascending for determinism. Newsletter
+ * co-occurrence and source-trust tier are not carried on the snapshot row, so
+ * signal_score is the available signal — consistent with the write-side overflow drop.
+ */
+function compareNewsletterRowImportanceDesc(
+  left: ExistingSignalSnapshotRow,
+  right: ExistingSignalSnapshotRow,
+): number {
+  const scoreDelta = (right.signal_score ?? -1) - (left.signal_score ?? -1);
+  if (scoreDelta !== 0) return scoreDelta;
+  return (left.rank ?? Number.MAX_SAFE_INTEGER) - (right.rank ?? Number.MAX_SAFE_INTEGER);
+}
+
+/**
+ * PR2 — reserve ranks 1..RSS_RESERVED_TOP_RANKS for the RSS/article path by
+ * confining newsletter discovery candidates to the band BELOW it
+ * (RSS_RESERVED_TOP_RANKS+1 .. depth limit). Newsletter rows currently sitting in
+ * the reserved top are relocated DOWN into free band ranks; when the band cannot
+ * hold them all, the lowest-signal excess is DELETED (a candidate row cannot exist
+ * without a 1..20 rank), so the reserved top is always freed for RSS.
+ *
+ * This DEGRADES on a flood instead of the old behavior — returning ok:false and
+ * changing nothing — which let a 20-row newsletter day occupy the entire space and
+ * starve RSS. With the write-side band cap in promotion.ts, new rows already land
+ * in the band, so this is mostly defense-in-depth for pre-existing rows.
+ *
+ * Collision-safe by construction: the only relocations move newsletter rows OUT of
+ * the reserved top (1..N) INTO free band ranks (N+1..depth); sources and targets
+ * never overlap, and overflow rows are deleted BEFORE any relocation, so in-place
+ * rank UPDATEs never trip UNIQUE(briefing_date, rank).
+ */
 async function reserveNewsletterCandidateRanksForRssSnapshot(
   client: EditorialClient,
   existingRows: ExistingSignalSnapshotRow[],
 ): Promise<NewsletterRankReservationResult> {
-  const movableNewsletterRows = existingRows
-    .filter(isMovableNewsletterDiscoveryRow)
-    .sort((left, right) => (left.rank ?? 0) - (right.rank ?? 0));
+  const movableNewsletterRows = existingRows.filter(isMovableNewsletterDiscoveryRow);
 
   if (movableNewsletterRows.length === 0) {
     return {
@@ -1754,45 +1789,65 @@ async function reserveNewsletterCandidateRanksForRssSnapshot(
       .map((row) => row.rank)
       .filter((rank): rank is number => typeof rank === "number"),
   );
-  const targetRanks: number[] = [];
 
-  for (let rank = SIGNAL_POST_CANDIDATE_DEPTH_LIMIT; rank >= 1; rank -= 1) {
+  // Discovery band available to newsletter: ranks RSS_RESERVED_TOP_RANKS+1..depth
+  // not held by a fixed (non-movable) row, ascending. Its size is the capacity.
+  const bandFloor = RSS_RESERVED_TOP_RANKS + 1;
+  const availableBandRanks: number[] = [];
+  for (let rank = bandFloor; rank <= SIGNAL_POST_CANDIDATE_DEPTH_LIMIT; rank += 1) {
     if (!fixedRanks.has(rank)) {
-      targetRanks.push(rank);
-    }
-
-    if (targetRanks.length === movableNewsletterRows.length) {
-      break;
+      availableBandRanks.push(rank);
     }
   }
+  const capacity = availableBandRanks.length;
 
-  if (targetRanks.length < movableNewsletterRows.length) {
-    return {
-      ok: false,
-      message:
-        "RSS signal snapshot could not reserve rank space for existing newsletter candidates. No rows were changed.",
-    };
-  }
+  // Keep the highest-signal `capacity` rows; drop the rest (lowest signal first).
+  const byImportance = [...movableNewsletterRows].sort(compareNewsletterRowImportanceDesc);
+  const keptRows = byImportance.slice(0, capacity);
+  const droppedRows = byImportance.slice(capacity);
 
-  targetRanks.sort((left, right) => left - right);
-  const updatedRows = existingRows.map((row) => ({ ...row }));
+  // Kept rows already parked at an available band rank stay; the rest (in the
+  // reserved top) move into the leftover band ranks (floor-first to stay contiguous).
+  const availableBandSet = new Set(availableBandRanks);
+  const stayingRanks = new Set(
+    keptRows
+      .map((row) => row.rank)
+      .filter((rank): rank is number => typeof rank === "number" && availableBandSet.has(rank)),
+  );
+  const movingRows = keptRows.filter(
+    (row) => !(typeof row.rank === "number" && availableBandSet.has(row.rank)),
+  );
+  const freeBandRanks = availableBandRanks.filter((rank) => !stayingRanks.has(rank));
+
+  const droppedIds = new Set(droppedRows.map((row) => row.id));
+  const updatedRows = existingRows
+    .filter((row) => !droppedIds.has(row.id))
+    .map((row) => ({ ...row }));
   const rowsById = new Map(updatedRows.map((row) => [row.id, row]));
 
-  const rankAssignments = movableNewsletterRows
-    .map((newsletterRow, index) => ({
-      newsletterRow,
-      targetRank: targetRanks[index],
-    }))
-    .filter((assignment): assignment is { newsletterRow: ExistingSignalSnapshotRow; targetRank: number } =>
-      typeof assignment.targetRank === "number"
-    )
-    .sort((left, right) => right.targetRank - left.targetRank);
+  // Evict band overflow FIRST so their ranks are free before any relocation.
+  for (const dropped of droppedRows) {
+    const deleteResult = await client
+      .from("signal_posts")
+      .delete()
+      .eq("id", dropped.id);
 
-  for (const { newsletterRow, targetRank } of rankAssignments) {
-    const mutableRow = rowsById.get(newsletterRow.id);
+    if (deleteResult.error) {
+      return {
+        ok: false,
+        message: `RSS signal snapshot could not evict overflow newsletter candidate: ${deleteResult.error.message}`,
+      };
+    }
+  }
 
-    if (!mutableRow || mutableRow.rank === targetRank) {
-      continue;
+  // Relocate reserved-top newsletter rows down into the free band ranks. Sources
+  // are in 1..RSS_RESERVED_TOP_RANKS, targets in the band — disjoint, no collision.
+  for (let index = 0; index < movingRows.length; index += 1) {
+    const newsletterRow = movingRows[index]!;
+    const targetRank = freeBandRanks[index];
+
+    if (typeof targetRank !== "number") {
+      continue; // capacity guarantees a slot; defensive
     }
 
     const updateResult = await client
@@ -1807,13 +1862,22 @@ async function reserveNewsletterCandidateRanksForRssSnapshot(
       };
     }
 
-    mutableRow.rank = targetRank;
+    const mutableRow = rowsById.get(newsletterRow.id);
+    if (mutableRow) {
+      mutableRow.rank = targetRank;
+    }
   }
+
+  const reservedRanks = new Set<number>(
+    keptRows
+      .map((row) => rowsById.get(row.id)?.rank)
+      .filter((rank): rank is number => typeof rank === "number"),
+  );
 
   return {
     ok: true,
     rows: updatedRows,
-    reservedRanks: new Set(targetRanks),
+    reservedRanks,
   };
 }
 


### PR DESCRIPTION
> **Update — PR‑A (FK safety) added to this branch (commit `6efab8a`).** The eviction‑by‑DELETE in the reserve fn could hit `published_slate_items`'s `ON DELETE RESTRICT` (23503); the mock has no FKs so the suite couldn't catch it. Now: (1) **FK‑safe scope** — `fetchFkProtectedSignalPostIds` queries `published_slate_items`; a referenced row is **never** an eviction target (only lowest‑signal *unprotected* rows drop; fails safe — on query error, evict none); (2) **belt‑and‑suspenders** — a delete that still throws is caught, the row is left in place + logged, and the run **continues** (never `ok:false`‑no‑change); free band ranks are recomputed *after* eviction so a skipped delete can't become a relocation target (no 23505).
>
> **New gates:** FK‑scope (protected row excluded, next‑lowest unprotected evicted) + graceful degrade (inject 23503 → run completes, row remains). All 7 original gates still green. Suite **1142** · typecheck 0 · lint clean · governance PASS · no migration. **Did NOT touch** publish/cockpit/render/`published_*`/`final_slate_rank`/validation.
>
> **Checkpoint‑1 verification after this lands on a tick:** ranks 1–7 come back newsletter‑free, newsletter at rank 8+, **zero constraint errors (23503/23505)** in the run. Eviction query + scope predicate + 23503 catch: `reserveNewsletterCandidateRanksForRssSnapshot` / `fetchFkProtectedSignalPostIds` in `src/lib/signals-editorial.ts`. The single atomic newsletter insert (#324) is preserved.

---

## Summary

**PR2 of the newsletter stack — reserve candidate ranks 1–7 for RSS so a newsletter flood can't starve the slate.** This is the *unlock*: the diagnosed bottleneck is rank‑slot contention, not content.

**Root cause (line level).** Newsletter promotion assigned `signal_posts.rank` bottom‑first via [`nextAvailablePreviewRank`](src/lib/newsletter-ingestion/promotion.ts) (scanning `20→1` for the highest free slot), so 1 row took rank 20 but ~20 rows walked all the way up into ranks 1–7. [`reserveNewsletterCandidateRanksForRssSnapshot`](src/lib/signals-editorial.ts) is meant to relocate newsletter down to free the top, but it needed one free target rank per movable row; at 20 rows it needed the whole space, hit the `targetRanks.length < movableNewsletterRows.length` branch, returned **`ok:false` / "No rows were changed"**, and bailed → RSS filtered out entirely.

**Corroborated in prod:** newsletter held rank 20 with 1 row and **all of 1–20** with 20 rows; RSS placed **8 vs 0** respectively. ~33–39 clean, body‑extracted RSS articles surfaced every day, including the junk days — they just couldn't get a rank.

## The fix — hard‑reserve the top band
Keyed off the existing public‑slate size (`RSS_RESERVED_TOP_RANKS = FINAL_SLATE_MAX_PUBLIC_ROWS = 7`); never hardcoded. New single source of truth for candidate‑rank geometry lives in `final-slate-readiness.ts` and is imported by both writers (no god‑file import, no cycle).

1. **Write‑side cap** — `nextAvailablePreviewRank` confines newsletter to the band `8..20` and fills **floor‑up** (8, then 9, …). Ranks 1..7 are never claimed. Band overflow returns `null` → the caller drops the candidate; callers plan in **importance order** (`extraction_confidence` DESC — the only signal a story carries at promotion time), so the dropped rows are the lowest signal.
2. **Relocation‑side degrade** — the reserve fn caps the target band at `8..20` and, when movable rows exceed the 13‑slot band, **DELETES the lowest‑signal excess** (a candidate row can't exist without a 1..20 rank) instead of bailing. Collision‑safe by construction: relocations only move rows OUT of 1..7 INTO free band ranks, and overflow is deleted before any relocation, so in‑place `rank` UPDATEs never trip `UNIQUE(briefing_date, rank)`. The #324 atomic newsletter bulk insert is untouched.

**Code‑only; no migration.**

## Verification appendix — the must‑pass gates (all green in the suite)
| Gate | Expectation | Status |
|---|---|---|
| 20 newsletter + RSS | ranks 1–7 RSS, newsletter 8–20, 7 lowest‑signal dropped, zero 23505 | ✅ |
| 3 RSS + 20 newsletter | ranks 1–3 RSS, **ranks 4–7 EMPTY** (not newsletter), newsletter in band | ✅ |
| 1 newsletter + RSS | RSS 1–7, newsletter at rank **8** | ✅ |
| 0 newsletter | RSS fills the top untouched | ✅ |
| mid‑run abort | zero rows written (#324 preserved) | ✅ |
| reserve fn, 20 movable rows | **degrades** (evicts excess); never `ok:false`‑with‑no‑change | ✅ |
| write‑side flood (20 stories) | 13 highest‑confidence kept (8..20), 7 lowest dropped, ONE bulk insert | ✅ |

Suite: **1140 passing**; typecheck **0**; lint clean; governance **PASS**.

### How to verify against prod after merge (BM checkpoint)
1. **Existing rows** — confirm no newsletter discovery row sits in ranks 1–7 on a recent day:
   ```sql
   SELECT briefing_date, rank, left(title,50)
   FROM signal_posts
   WHERE selection_reason = 'Newsletter discovery candidate; BM review required.'
     AND rank <= 7 AND briefing_date >= current_date - 3
   ORDER BY briefing_date DESC, rank;   -- expect: 0 rows
   ```
2. **Next 12:00 UTC tick** — after the next `fetch-editorial-inputs` + `restage-with-bodies` run, assert ranks 1–7 are RSS‑class (not newsletter):
   ```sql
   SELECT rank,
          (selection_reason = 'Newsletter discovery candidate; BM review required.') AS is_newsletter,
          left(title,50)
   FROM signal_posts
   WHERE briefing_date = (now() AT TIME ZONE 'Asia/Taipei')::date
   ORDER BY rank;
   -- expect: ranks 1..7 → is_newsletter = false; newsletter only at rank >= 8
   ```

## Known behavior to confirm
When RSS provides **>7** items AND newsletter is **sparse** (<13 rows), RSS fills the band slots newsletter didn't use (e.g. 5 newsletter → 8–12, RSS → 1–7 **and** 13–20). The **public slate (top 7) is still entirely RSS**; newsletter stays below the cut. This keeps more RSS discovery than capping RSS at 7. If you'd rather newsletter own all of 8–20 (RSS strictly 1–7), that's a one‑line follow‑up — deferred per the locked PR2 scope (two changes only).

## Scope / next
Stacked fix. **PR3 (newsletter content quality — charset/mojibake decode + chrome filter) is NOT in this PR.** Per the checkpoint, this PR stops here for BM verification before PR3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

