### PR TITLE
fix(newsletter): extraction quality — charset decode, segmentation, chrome filter, tracking strip (PR-B)

### DIFF
--- a/docs/engineering/bug-fixes/newsletter-extraction-quality-2026-06-21.md
+++ b/docs/engineering/bug-fixes/newsletter-extraction-quality-2026-06-21.md
@@ -12,10 +12,14 @@ and chrome stored as headlines (subscribe CTAs, photo credits, mastheads, sectio
 
 **B1 — charset-aware MIME decode** (`email-content.ts`). `decodeQuotedPrintable` decoded each
 `=XX` byte with `String.fromCharCode`, mangling multi-byte UTF-8. Replaced with
-`decodeQuotedPrintableToBytes` (buffers raw bytes) + `decodeBytesWithCharset` (TextDecoder for
-the part's declared charset; utf-8/windows-1252/iso-8859-1; default + fallback utf-8). The
-part `Content-Type` charset is now threaded `collectTextParts → decodePartBody`. base64 + the
-MIME encoded-word (`=?charset?Q?…?=`) decoders fixed the same way.
+`decodeQuotedPrintableToBytes` (buffers raw bytes) + `decodeBytesWithCharset`, decoded by the
+part's declared charset. **ICU-independent** (CI/serverless Node may be small-ICU, where
+`new TextDecoder("windows-1252")` throws and a utf-8 fallback re-mangles smart quotes): utf-8
+uses `Buffer.toString("utf8")`; iso-8859-1/latin1/windows-1252 use a built-in
+`decodeWindows1252` (latin-1 + a static `0x80–0x9F` table); only exotic charsets try
+`TextDecoder` (utf-8 fallback). The part `Content-Type` charset is threaded
+`collectTextParts → decodePartBody`. base64 + the MIME encoded-word (`=?charset?Q?…?=`)
+decoders fixed the same way.
 
 **B2 — segmentation** (`parser.ts`). `stripLeadingEnumeratorNoise` (run in `cleanHeadline`)
 strips leading symbol/badge RUNS followed by whitespace and Semafor's DOUBLED item number

--- a/docs/engineering/bug-fixes/newsletter-extraction-quality-2026-06-21.md
+++ b/docs/engineering/bug-fixes/newsletter-extraction-quality-2026-06-21.md
@@ -1,0 +1,63 @@
+# Newsletter Extraction Quality (PR-B / Task 3) — 2026-06-21
+
+Canonical PRD required: `No` — newsletter ingestion quality bug fix, not a product feature.
+
+## Problem
+The newsletter extractor produced junk candidate rows (verified 06-16..19): mojibake
+(`Semaforâ€™s`), real headlines buried behind enumerator noise (`â â 2 2 Fed holds rates…`),
+and chrome stored as headlines (subscribe CTAs, photo credits, mastheads, section labels).
+#327 protects the public *slate* (rank-band), but these still pollute the review pool.
+
+## Fixes (ingestion/staging only — no publish/cockpit/render/final_slate_rank/validation changes)
+
+**B1 — charset-aware MIME decode** (`email-content.ts`). `decodeQuotedPrintable` decoded each
+`=XX` byte with `String.fromCharCode`, mangling multi-byte UTF-8. Replaced with
+`decodeQuotedPrintableToBytes` (buffers raw bytes) + `decodeBytesWithCharset` (TextDecoder for
+the part's declared charset; utf-8/windows-1252/iso-8859-1; default + fallback utf-8). The
+part `Content-Type` charset is now threaded `collectTextParts → decodePartBody`. base64 + the
+MIME encoded-word (`=?charset?Q?…?=`) decoders fixed the same way.
+
+**B2 — segmentation** (`parser.ts`). `stripLeadingEnumeratorNoise` (run in `cleanHeadline`)
+strips leading symbol/badge RUNS followed by whitespace and Semafor's DOUBLED item number
+(`2 2 `). Conservative: the `\s+` requirement leaves a leading smart quote (`‘We Proved…’`) or
+accented first letter untouched, and only a *doubled* number is stripped (never a lone
+`5 things to know`).
+
+**B3 — chrome filter extension** (`chrome-filter.ts`). New reject reasons: `subscribe_cta`
+(phrases, not bare "subscribe" → "subscribers" is safe), `masthead` (` // ` banner delimiter),
+`photo_credit` (`First Last/Agency` at end, known wires), `section_header` (exact match to a
+curated label list — precision over a risky generic heuristic). **Precision guard:** all
+MUST_KEEP fixtures (smart-quote / colon / Title-Case real headlines) are asserted NOT rejected.
+
+**B4 — tracking deny-list + PII strip** (`parser.ts`, `url-filtering.ts`). `normalizeUrl`
+strips `?email=<subscriber>` + `utm_*`/ESP click params (removes PII from `source_url`, fixes
+cross-recipient dedupe). TLDR tracker hosts added to the URL deny-list. **Scoped down (flagged):**
+full redirect-resolution of an opaque `semafor.com/s/<id>` to a different publisher needs a
+live HEAD-follow (SSRF surface + 55s budget) — out of scope; the chrome filter drops the chrome
+rows that carried these and the deny-list rejects the pure trackers.
+
+**B5 — signal_score inversion (INVESTIGATION — reported, not fixed; see below).**
+
+## B5 finding (the offending path)
+Newsletter `signal_score = extraction_confidence * 100` (`promotion.ts:221`) — a *parse*
+confidence (format base 0.74–0.94), not importance — so junk scores **86–94** vs real RSS
+**58–72**. The ONLY path that orders by `signal_score` is the editorial review/history list:
+`loadStoredSignalPosts` (`signals-editorial.ts:1305`, DB `.order("signal_score", desc)`) AND
+its in-memory re-sort `compareEditorialHistoryPosts` — both rank `signal_score` DESC (tertiary,
+after briefing_date + published_at). **Impact:** newsletter junk displays ABOVE real RSS within
+a day in the cockpit review list. Every OTHER ordering uses `rank` / `final_slate_rank` /
+`event_importance` — RSS-safe (#327 protects rank).
+
+**Not fixed in PR-B** (touches the cockpit/render boundary; PR-B already stops new junk at the
+source, and existing junk is PR-D's cleanup). **Recommended follow-up (contained, one-line):**
+order the review list by `rank` ASC instead of `signal_score` DESC — #327 made `rank` meaningful
+(RSS 1–7, newsletter 8–20), so it surfaces RSS first; OR stop deriving newsletter `signal_score`
+from `extraction_confidence`.
+
+## Result
+- New `extraction-quality.test.ts`: **30 tests** (B1 per-charset decode ×5, B2 segmentation +
+  5 MUST_NOT_STRIP, B3 9 MUST_REJECT + 7 MUST_KEEP, B4 deny-list + PII strip). All green.
+- Full suite **1142 → 1172** (+30). Typecheck 0. Lint clean. No migration.
+
+**Did NOT touch:** publish path, cockpit, render, `published_*`/`edited_*` columns,
+`final_slate_rank` assignment, validation logic. Atomic newsletter insert (#324) untouched.

--- a/src/lib/newsletter-ingestion/chrome-filter.ts
+++ b/src/lib/newsletter-ingestion/chrome-filter.ts
@@ -18,7 +18,11 @@ export type ChromeRejectionReason =
   | "boilerplate_phrase"
   | "postal_address"
   | "tracking_or_shortener_domain"
-  | "below_min_prose";
+  | "below_min_prose"
+  | "subscribe_cta"
+  | "masthead"
+  | "photo_credit"
+  | "section_header";
 
 export type ChromeRejection = {
   headline: string;
@@ -90,6 +94,68 @@ const TRACKING_URL_MARKERS = [
 const ZIP_STATE_PATTERN = /\b[A-Z]{2},?\s+\d{5}(?:-\d{4})?\b/;
 const STREET_NUMBER_PATTERN = /\b\d{1,6}\s+[A-Za-z]/;
 
+/**
+ * Subscribe / sign-up call-to-action phrases (distinct from the "unsubscribe"
+ * boilerplate). Real headlines do not say "subscribe to" / "sign up for"; these
+ * are Semafor/Brew cross-promo lines. Matched as a phrase (not a bare "subscribe"
+ * substring, which would wrongly hit "subscribers").
+ */
+const SUBSCRIBE_CTA_PHRASES = [
+  "subscribe to",
+  "subscribe now",
+  "subscribe at",
+  "sign up for",
+  "sign up to",
+] as const;
+
+/**
+ * Masthead delimiter: newsletters render their name/section banner as
+ * "Daily Brew // Morning Brew // Update". A spaced "//" in a title (URLs already
+ * stripped) is a masthead, not a story.
+ */
+const MASTHEAD_PATTERN = /\s\/\/\s/;
+
+/**
+ * Bare photo credit at the end of a title: "First Last/Agency" where Agency is a
+ * known wire/photo service. Catches "Eric Lee/Reuters" and
+ * "Billboard in Islamabad. Akhtar Soomro/Reuters".
+ */
+const PHOTO_CREDIT_AGENCIES =
+  "Reuters|AP|AFP|Getty(?:\\s+Images)?|Bloomberg|EPA(?:-EFE)?|Shutterstock|Anadolu(?:\\s+Agency)?|Xinhua|NurPhoto|Pool|AAP|dpa|Sipa|Zuma|The\\s+New\\s+York\\s+Times";
+const PHOTO_CREDIT_PATTERN = new RegExp(
+  `[A-Z][\\p{L}.'-]+(?:\\s+[A-Z][\\p{L}.'-]+)+\\s*/\\s*(?:${PHOTO_CREDIT_AGENCIES})\\b\\.?\\s*$`,
+  "u",
+);
+
+/**
+ * Known newsletter section dividers (TLDR/Brew rubric labels). Scoped to an exact
+ * (normalized) match list rather than a generic "short Title-Case noun phrase"
+ * heuristic — that would risk rejecting real short headlines, and precision matters
+ * more than recall here. NEW labels should be added explicitly.
+ */
+const SECTION_HEADER_LABELS = new Set(
+  [
+    "big tech & startups",
+    "science & futuristic technology",
+    "programming, design & data science",
+    "miscellaneous",
+    "quick links",
+    "around the web",
+    "in the news",
+    "today's top stories",
+    "the gist",
+    "what's happening",
+  ].map((label) => label.toLowerCase()),
+);
+
+function normalizeForLabelMatch(headline: string): string {
+  return headline
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .replace(/[.:;!?]+$/u, "")
+    .trim();
+}
+
 function stripLinks(value: string): string {
   return value
     .replace(/<[^>]*>/g, " ") // angle-bracket links/markup
@@ -136,6 +202,24 @@ export function classifyNewsletterChrome(candidate: ChromeCandidate):
     }
   }
 
+  for (const phrase of SUBSCRIBE_CTA_PHRASES) {
+    if (lower.includes(phrase)) {
+      return { rejected: true, reason: "subscribe_cta", detail: phrase };
+    }
+  }
+
+  if (SECTION_HEADER_LABELS.has(normalizeForLabelMatch(headline))) {
+    return { rejected: true, reason: "section_header", detail: headline.slice(0, 80) };
+  }
+
+  if (MASTHEAD_PATTERN.test(stripLinks(headline))) {
+    return { rejected: true, reason: "masthead", detail: headline.slice(0, 80) };
+  }
+
+  if (PHOTO_CREDIT_PATTERN.test(headline)) {
+    return { rejected: true, reason: "photo_credit", detail: headline.slice(0, 80) };
+  }
+
   if (looksLikePostalAddress(headline)) {
     return { rejected: true, reason: "postal_address", detail: headline.slice(0, 80) };
   }
@@ -167,6 +251,10 @@ export function summarizeChromeRejections(rejections: ChromeRejection[]): {
     postal_address: 0,
     tracking_or_shortener_domain: 0,
     below_min_prose: 0,
+    subscribe_cta: 0,
+    masthead: 0,
+    photo_credit: 0,
+    section_header: 0,
   };
   for (const rejection of rejections) {
     byReason[rejection.reason] += 1;

--- a/src/lib/newsletter-ingestion/email-content.ts
+++ b/src/lib/newsletter-ingestion/email-content.ts
@@ -51,12 +51,44 @@ function splitHeadersAndBody(raw: string): ParsedMimePart {
   return { headers, body };
 }
 
-function decodeQuotedPrintable(value: string) {
-  return value
-    .replace(/=\n/g, "")
-    .replace(/=([0-9a-f]{2})/gi, (_match, hex: string) =>
-      String.fromCharCode(Number.parseInt(hex, 16)),
-    );
+// Decode quoted-printable into RAW BYTES. The previous implementation decoded
+// each =XX escape with String.fromCharCode, treating every byte as its own Latin-1
+// code point — so multi-byte UTF-8 (smart quotes, em dashes, accents) came out as
+// mojibake ("Semaforâ€™s"). Buffering the bytes lets the caller re-decode them with
+// the part's declared charset.
+function decodeQuotedPrintableToBytes(value: string): Buffer {
+  const withoutSoftBreaks = value.replace(/=\r?\n/g, "");
+  const bytes: number[] = [];
+
+  for (let index = 0; index < withoutSoftBreaks.length; index += 1) {
+    const char = withoutSoftBreaks[index]!;
+
+    if (char === "=" && index + 2 < withoutSoftBreaks.length) {
+      const hex = withoutSoftBreaks.slice(index + 1, index + 3);
+      if (/^[0-9a-fA-F]{2}$/.test(hex)) {
+        bytes.push(Number.parseInt(hex, 16));
+        index += 2;
+        continue;
+      }
+    }
+
+    // QP literal chars are printable ASCII; mask to a single byte defensively.
+    bytes.push(char.charCodeAt(0) & 0xff);
+  }
+
+  return Buffer.from(bytes);
+}
+
+// Decode raw bytes using a MIME charset label. Defaults to utf-8 and falls back to
+// utf-8 for an unknown/unsupported label rather than throwing. WHATWG maps
+// iso-8859-1 -> windows-1252, so both labels decode 0x92 -> U+2019, etc.
+function decodeBytesWithCharset(bytes: Buffer, charset: string | undefined): string {
+  const label = (charset ?? "").toLowerCase().trim() || "utf-8";
+  try {
+    return new TextDecoder(label).decode(bytes);
+  } catch {
+    return new TextDecoder("utf-8").decode(bytes);
+  }
 }
 
 function decodeMimeWord(value: string) {
@@ -70,10 +102,13 @@ function decodeMimeWord(value: string) {
       }
 
       if (encoding.toLowerCase() === "b") {
-        return Buffer.from(encoded, "base64").toString("utf8");
+        return decodeBytesWithCharset(Buffer.from(encoded, "base64"), normalizedCharset);
       }
 
-      return decodeQuotedPrintable(encoded.replace(/_/g, " "));
+      return decodeBytesWithCharset(
+        decodeQuotedPrintableToBytes(encoded.replace(/_/g, " ")),
+        normalizedCharset,
+      );
     },
   );
 }
@@ -97,17 +132,20 @@ function getHeaderParams(headerValue: string | undefined) {
   return { value, params };
 }
 
-function decodePartBody(body: string, transferEncoding: string | undefined) {
+export function decodePartBody(body: string, transferEncoding: string | undefined, charset?: string) {
   const encoding = (transferEncoding ?? "").toLowerCase();
 
   if (encoding === "base64") {
-    return Buffer.from(body.replace(/\s+/g, ""), "base64").toString("utf8");
+    return decodeBytesWithCharset(Buffer.from(body.replace(/\s+/g, ""), "base64"), charset);
   }
 
   if (encoding === "quoted-printable") {
-    return decodeQuotedPrintable(body);
+    return decodeBytesWithCharset(decodeQuotedPrintableToBytes(body), charset);
   }
 
+  // 7bit / 8bit / none: the raw MIME was already read as utf-8 upstream
+  // (decodeGmailRawMessage), so the body is text. A non-utf-8 8bit part is a rare
+  // edge that would need re-reading the source bytes — out of scope here.
   return body;
 }
 
@@ -165,6 +203,7 @@ function normalizeContentText(value: string) {
 function collectTextParts(part: ParsedMimePart): string[] {
   const contentType = getHeaderParams(part.headers["content-type"]);
   const transferEncoding = part.headers["content-transfer-encoding"];
+  const charset = contentType.params.charset;
 
   if (contentType.value.startsWith("multipart/")) {
     const boundary = contentType.params.boundary;
@@ -179,11 +218,11 @@ function collectTextParts(part: ParsedMimePart): string[] {
   }
 
   if (contentType.value === "text/plain" || (!contentType.value && part.body.trim())) {
-    return [decodePartBody(part.body, transferEncoding)];
+    return [decodePartBody(part.body, transferEncoding, charset)];
   }
 
   if (contentType.value === "text/html") {
-    return [htmlToTextWithLinks(decodePartBody(part.body, transferEncoding))];
+    return [htmlToTextWithLinks(decodePartBody(part.body, transferEncoding, charset))];
   }
 
   return [];

--- a/src/lib/newsletter-ingestion/email-content.ts
+++ b/src/lib/newsletter-ingestion/email-content.ts
@@ -79,15 +79,55 @@ function decodeQuotedPrintableToBytes(value: string): Buffer {
   return Buffer.from(bytes);
 }
 
-// Decode raw bytes using a MIME charset label. Defaults to utf-8 and falls back to
-// utf-8 for an unknown/unsupported label rather than throwing. WHATWG maps
-// iso-8859-1 -> windows-1252, so both labels decode 0x92 -> U+2019, etc.
+// windows-1252 0x80–0x9F → Unicode (the bytes where it differs from latin-1).
+// Undefined slots (0x81/0x8D/0x8F/0x90/0x9D) fall through to the raw byte value.
+const WINDOWS_1252_C1: Record<number, number> = {
+  0x80: 0x20ac, 0x82: 0x201a, 0x83: 0x0192, 0x84: 0x201e, 0x85: 0x2026,
+  0x86: 0x2020, 0x87: 0x2021, 0x88: 0x02c6, 0x89: 0x2030, 0x8a: 0x0160,
+  0x8b: 0x2039, 0x8c: 0x0152, 0x8e: 0x017d, 0x91: 0x2018, 0x92: 0x2019,
+  0x93: 0x201c, 0x94: 0x201d, 0x95: 0x2022, 0x96: 0x2013, 0x97: 0x2014,
+  0x98: 0x02dc, 0x99: 0x2122, 0x9a: 0x0161, 0x9b: 0x203a, 0x9c: 0x0153,
+  0x9e: 0x017e, 0x9f: 0x0178,
+};
+
+// ICU-INDEPENDENT windows-1252 decoder: latin-1 for 0x00–0x7F + 0xA0–0xFF, the
+// table above for 0x80–0x9F. (Node's `new TextDecoder("windows-1252")` needs a
+// full-ICU build, which CI/serverless Node may NOT have — there it throws and a
+// utf-8 fallback re-mangles the smart quotes. This works everywhere.)
+function decodeWindows1252(bytes: Buffer): string {
+  let out = "";
+  for (const byte of bytes) {
+    const codePoint = byte >= 0x80 && byte <= 0x9f ? (WINDOWS_1252_C1[byte] ?? byte) : byte;
+    out += String.fromCodePoint(codePoint);
+  }
+  return out;
+}
+
+// Decode raw bytes using a MIME charset label, ICU-independent for the charsets
+// newsletters actually use. utf-8 and latin-1/windows-1252 are handled with
+// built-in Buffer/table decoders (no full-ICU dependency); anything exotic tries
+// TextDecoder and falls back to utf-8. WHATWG maps the iso-8859-1/latin1 LABELS to
+// the windows-1252 decoder (so a labelled-latin1 smart quote 0x92 → U+2019, as
+// mail clients render it), which is what we do here.
 function decodeBytesWithCharset(bytes: Buffer, charset: string | undefined): string {
-  const label = (charset ?? "").toLowerCase().trim() || "utf-8";
+  const label = (charset ?? "").toLowerCase().trim().replace(/[_\s]+/g, "-") || "utf-8";
+
+  if (label === "utf-8" || label === "utf8" || label === "us-ascii" || label === "ascii") {
+    return bytes.toString("utf8");
+  }
+
+  if (
+    label === "windows-1252" || label === "cp1252" || label === "windows1252" ||
+    label === "iso-8859-1" || label === "latin1" || label === "latin-1" ||
+    label === "iso8859-1" || label === "8859-1"
+  ) {
+    return decodeWindows1252(bytes);
+  }
+
   try {
     return new TextDecoder(label).decode(bytes);
   } catch {
-    return new TextDecoder("utf-8").decode(bytes);
+    return bytes.toString("utf8");
   }
 }
 

--- a/src/lib/newsletter-ingestion/extraction-quality.test.ts
+++ b/src/lib/newsletter-ingestion/extraction-quality.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import { decodePartBody } from "@/lib/newsletter-ingestion/email-content";
+import { classifyNewsletterChrome, type ChromeRejectionReason } from "@/lib/newsletter-ingestion/chrome-filter";
+import { parseNewsletterStoriesDetailed, stripLeadingEnumeratorNoise } from "@/lib/newsletter-ingestion/parser";
+import { classifyUrlForArticleEligibility } from "@/lib/url-filtering";
+
+/**
+ * PR-B — newsletter extraction quality (Task 3). Fixtures pulled from prod junk
+ * rows (06-16..19) + real RSS headlines that must survive.
+ */
+
+describe("B1 — charset-aware QP/MIME decode (no more mojibake)", () => {
+  it("decodes a UTF-8 quoted-printable smart quote to U+2019, not 'â€™'", () => {
+    // E2 80 99 = U+2019. The old String.fromCharCode decoder produced "Semaforâ€™s".
+    const out = decodePartBody("Semafor=E2=80=99s Energy briefing", "quoted-printable", "utf-8");
+    expect(out).toBe("Semafor’s Energy briefing");
+    expect(out).not.toContain("â");
+  });
+
+  it("decodes a windows-1252 quoted-printable byte (0x92 -> U+2019)", () => {
+    const out = decodePartBody("Semafor=92s Energy briefing", "quoted-printable", "windows-1252");
+    expect(out).toBe("Semafor’s Energy briefing");
+  });
+
+  it("decodes an iso-8859-1 quoted-printable byte (0xE9 -> é)", () => {
+    const out = decodePartBody("caf=E9 closes early", "quoted-printable", "iso-8859-1");
+    expect(out).toBe("café closes early");
+  });
+
+  it("decodes base64 parts with the declared charset", () => {
+    const body = Buffer.from("Fed holds rates", "utf8").toString("base64");
+    expect(decodePartBody(body, "base64", "utf-8")).toBe("Fed holds rates");
+  });
+
+  it("defaults to utf-8 when no charset is declared", () => {
+    expect(decodePartBody("Fed=E2=80=99s call", "quoted-printable", undefined)).toBe("Fed’s call");
+  });
+});
+
+describe("B2 — segmentation: strip leading enumerator/badge noise, recover the headline", () => {
+  it("recovers the real headline behind Semafor's badge + doubled item number", () => {
+    expect(stripLeadingEnumeratorNoise("â â 2 2 Fed holds rates in Warsh's first meeting"))
+      .toBe("Fed holds rates in Warsh's first meeting");
+  });
+
+  it("strips a decoded badge glyph + doubled number", () => {
+    expect(stripLeadingEnumeratorNoise("▪ 3 3 Senate passes the bill")).toBe("Senate passes the bill");
+  });
+
+  const MUST_NOT_STRIP = [
+    "‘We Proved That America Can Still Build Big Things’", // leading smart quote
+    "FERC Has a New Plan for Data Centers",
+    "Exclusive: Trump tells \"The Axios Show\" that Anthropic was a national security threat",
+    "5 things to know before the market opens", // lone leading number, not doubled
+    "Émigré founders raise $5M", // accented first letter, no following space
+  ];
+  it.each(MUST_NOT_STRIP)("leaves a legitimate headline unchanged: %s", (headline) => {
+    expect(stripLeadingEnumeratorNoise(headline)).toBe(headline);
+  });
+});
+
+describe("B3 — chrome filter rejects junk; precision guard keeps real headlines", () => {
+  const MUST_REJECT: Array<[string, ChromeRejectionReason]> = [
+    ["Subscribe to Semafor DC , a twice-daily briefing from inside Washington's halls of power.", "subscribe_cta"],
+    ["For more from the continent, subscribe to Semafor's Africa briefing .", "subscribe_cta"],
+    ["Billboard in Islamabad. Akhtar Soomro/Reuters", "photo_credit"],
+    ["Ronen Zvulun/Reuters", "photo_credit"],
+    ["Eric Lee/Reuters", "photo_credit"],
+    ["Daily Brew // Morning Brew // Update", "masthead"],
+    ["Big Tech & Startups", "section_header"],
+    ["Science & Futuristic Technology", "section_header"],
+    ["Programming, Design & Data Science", "section_header"],
+  ];
+  it.each(MUST_REJECT)("rejects junk %s", (headline, reason) => {
+    const verdict = classifyNewsletterChrome({ headline, snippet: "snippet", sourceUrl: null, sourceDomain: null });
+    expect(verdict.rejected).toBe(true);
+    if (verdict.rejected) {
+      expect(verdict.reason).toBe(reason);
+    }
+  });
+
+  const MUST_KEEP = [
+    "Trump says US and Iran will sign deal on Sunday to reopen Strait",
+    "‘We Proved That America Can Still Build Big Things’",
+    "Exclusive: Trump tells \"The Axios Show\" that Anthropic was a national security threat",
+    "Rocket Report: Rebuild begins at Blue Origin launch pad; Relativity targets Mars",
+    "FERC Has a New Plan for Data Centers",
+    "More Than 770,000 Children Are No Longer Receiving SNAP Benefits After New Rules",
+    "Meta faces calls for Congress to probe scam ads targeting seniors",
+  ];
+  it.each(MUST_KEEP)("keeps real headline %s", (headline) => {
+    const verdict = classifyNewsletterChrome({
+      headline,
+      snippet: "A substantial snippet about the story.",
+      sourceUrl: "https://reuters.com/world/article",
+      sourceDomain: "reuters.com",
+    });
+    expect(verdict.rejected).toBe(false);
+  });
+});
+
+describe("B4 — tracking deny-list + PII param strip", () => {
+  it("rejects TLDR tracking-redirector hosts as non-article URLs", () => {
+    expect(classifyUrlForArticleEligibility("https://tracking.tldrnewsletter.com/CL0/https://x.com/a").ok).toBe(false);
+    expect(classifyUrlForArticleEligibility("https://refer.tldr.tech/abc123").ok).toBe(false);
+  });
+
+  it("strips the ?email= PII param (and utm_*) from a stored source URL", () => {
+    const result = parseNewsletterStoriesDetailed({
+      sender: "news@example.com",
+      subject: "Daily wrap",
+      rawContent: [
+        "The Economy Shifts as Rates Hold Steady This Quarter",
+        "A substantial snippet describing the economic story in enough detail to pass.",
+        "https://example.com/markets/article?email=subscriber@example.com&utm_source=newsletter&id=42",
+      ].join("\n"),
+    });
+
+    expect(result.stories).toHaveLength(1);
+    const url = result.stories[0]!.sourceUrl ?? "";
+    expect(url).not.toContain("email=");
+    expect(url).not.toContain("utm_source");
+    expect(url).toContain("id=42"); // non-tracking params preserved
+  });
+});

--- a/src/lib/newsletter-ingestion/parser.ts
+++ b/src/lib/newsletter-ingestion/parser.ts
@@ -142,17 +142,39 @@ function normalizeLine(value: string) {
 }
 
 /**
+ * Strip leading list-marker / enumerator / badge-glyph noise that segmentation
+ * leaves glued to the front of a real Semafor/TLDR headline, e.g.
+ *   "▪ 2 2 Fed holds rates in Warsh's first meeting" → "Fed holds rates …"
+ * (the "▪"/decoded badge and Semafor's doubled item number "2 2").
+ *
+ * Conservative by construction — only strips:
+ *  - leading symbol/icon RUNS that are followed by whitespace (so a real leading
+ *    smart-quote like "'We Proved …'" or an accented first letter "Émigré …" is
+ *    NOT stripped — there is no space after it), and
+ *  - a leading DOUBLED number ("2 2 ") — Semafor's signature, never a lone "5
+ *    things to know".
+ */
+export function stripLeadingEnumeratorNoise(headline: string): string {
+  return headline
+    .replace(/^(?:[^\w\s]+\s+)+/u, "")
+    .replace(/^(\d{1,3})\s+\1\s+/u, "")
+    .trim();
+}
+
+/**
  * Strip URL / angle-bracket / parenthetical link wrappers out of a chosen
- * headline so a real title is never stored with a tracking link glued on.
+ * headline so a real title is never stored with a tracking link glued on, then
+ * remove leading enumerator/badge noise (see stripLeadingEnumeratorNoise).
  */
 function cleanHeadline(line: string): string {
-  return normalizeText(
+  const withoutLinkWrappers = normalizeText(
     line
       .replace(/\(\s*https?:\/\/[^\s)]+\s*\)/giu, " ")
       .replace(/<\s*https?:\/\/[^\s>]+\s*>/giu, " ")
       .replace(/https?:\/\/[^\s)<>"'\]]+/giu, " ")
       .replace(/\[\s*\]|\(\s*\)|<\s*>/gu, " "),
   ).trim();
+  return stripLeadingEnumeratorNoise(withoutLinkWrappers);
 }
 
 function detectNewsletterFormat(input: NewsletterStoryExtractionInput): NewsletterFormat {
@@ -202,6 +224,28 @@ function getSourceDomain(sourceUrl: string | null) {
   }
 }
 
+/**
+ * Tracking / PII query params to strip from a stored source URL. `?email=<user>`
+ * is the Semafor share-link's per-recipient tracker — storing it leaks a
+ * subscriber's email into source_url AND defeats cross-recipient dedupe. utm_*
+ * and the common ESP click params are removed for the same reasons.
+ */
+const TRACKING_QUERY_PARAMS = new Set([
+  "email",
+  "e",
+  "mc_eid",
+  "mc_cid",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "utm_id",
+  "_hsenc",
+  "_hsmi",
+  "vgo_ee",
+]);
+
 function normalizeUrl(value: string | null | undefined) {
   const url = value?.trim().replace(/[.,;:!?]+$/u, "") ?? "";
 
@@ -211,7 +255,20 @@ function normalizeUrl(value: string | null | undefined) {
 
   try {
     const parsed = new URL(url);
-    return /^https?:$/i.test(parsed.protocol) ? parsed.toString() : null;
+    if (!/^https?:$/i.test(parsed.protocol)) {
+      return null;
+    }
+    // Strip PII/tracking params (no network call). NOTE: opaque redirect links
+    // like semafor.com/s/<id> still resolve to their real destination only via a
+    // live HEAD-follow, which is out of scope here (SSRF surface + 55s budget) —
+    // the chrome filter drops the chrome rows that carried these, and the deny-
+    // list in url-filtering rejects the pure trackers.
+    for (const key of [...parsed.searchParams.keys()]) {
+      if (TRACKING_QUERY_PARAMS.has(key.toLowerCase())) {
+        parsed.searchParams.delete(key);
+      }
+    }
+    return parsed.toString();
   } catch {
     return null;
   }

--- a/src/lib/url-filtering.ts
+++ b/src/lib/url-filtering.ts
@@ -57,6 +57,9 @@ const TRACKING_HOST_PATTERNS = [
   "ctrk.klclick.com",
   ".rs6.net",                 // Constant Contact wrapper
   ".everestengagement.com",   // 1440 / Everest open-tracker (join1440.everestengagement.com)
+  "tracking.tldrnewsletter.com", // TLDR click-tracker
+  "refer.tldr.tech",          // TLDR referral wrapper
+  ".tldrnewsletter.com",      // TLDR tracker root
 ];
 
 /**


### PR DESCRIPTION
## Summary

**PR‑B / Task 3 — newsletter extraction quality.** Stops the junk the parser produced (verified prod rows 06‑16..19): mojibake, headlines buried behind enumerator noise, and chrome stored as headlines. Ingestion/staging only. Fresh branch from main (after #327 merged).

## What changed
- **B1 — charset‑aware MIME decode** (`email-content.ts`): `decodeQuotedPrintable` decoded each `=XX` byte with `String.fromCharCode`, mangling multi‑byte UTF‑8 → `Semaforâ€™s`. Now buffers raw bytes (`decodeQuotedPrintableToBytes`) and decodes with the part's declared charset (`decodeBytesWithCharset` → `TextDecoder`; utf‑8 / windows‑1252 / iso‑8859‑1; default + fallback utf‑8). Charset threaded `collectTextParts → decodePartBody`; base64 + the `=?charset?Q?…?=` encoded‑word fixed the same way.
- **B2 — segmentation** (`parser.ts`): `stripLeadingEnumeratorNoise` (in `cleanHeadline`) recovers a real headline behind Semafor badge glyphs + the doubled item number (`â â 2 2 Fed holds rates…` → `Fed holds rates…`). Conservative — a leading smart quote / accented letter / lone number is **not** stripped.
- **B3 — chrome filter** (`chrome-filter.ts`): new reasons `subscribe_cta`, `masthead`, `photo_credit` (`First Last/Agency`), `section_header` (curated label list). **Precision guard:** every MUST_KEEP fixture is asserted *not* rejected.
- **B4 — tracking** (`parser.ts` `normalizeUrl` + `url-filtering.ts`): strips `?email=<subscriber>` + `utm_*` from stored `source_url` (PII + dedupe); deny‑lists TLDR tracker hosts. **Scoped down (flagged):** resolving an opaque `semafor.com/s/<id>` to a different publisher needs a live HEAD‑follow (SSRF surface + 55s budget) — out of scope; chrome filter + deny‑list handle the junk.

## B5 — signal_score inversion (INVESTIGATION; reported, **not** fixed)
**Offending path found:** newsletter `signal_score = extraction_confidence * 100` (`promotion.ts:221`) — a *parse* confidence, not importance — so junk scores **86–94** vs real RSS **58–72**. The **only** path that orders by `signal_score` is the editorial review/history list: `loadStoredSignalPosts` (`signals-editorial.ts:1305`, DB `.order("signal_score", desc)`) **and** its in‑memory re‑sort `compareEditorialHistoryPosts` — both rank `signal_score` DESC (tertiary, after briefing_date + published_at). **Impact:** newsletter junk displays *above* real RSS within a day in the cockpit review list. Every other ordering uses `rank` / `final_slate_rank` / `event_importance` (RSS‑safe; #327 protects `rank`).

**Why not fixed here:** it's inside the cockpit/render hard boundary, and PR‑B stops *new* junk at the source (existing junk is PR‑D's cleanup). **Recommended one‑line follow‑up:** order the review list by `rank` ASC instead of `signal_score` DESC — #327 made `rank` meaningful (RSS 1–7, newsletter 8–20), so it surfaces RSS first; or stop deriving newsletter `signal_score` from `extraction_confidence`.

## Verification appendix
- **New tests** — `extraction-quality.test.ts`, **30 tests**: B1 per‑charset decode (×5, incl. the `Semaforâ€™s` regression), B2 segmentation (1 recover + 1 glyph + 5 MUST_NOT_STRIP), B3 (9 MUST_REJECT with exact reasons + 7 MUST_KEEP), B4 (TLDR deny‑list + `?email=`/`utm_*` strip with non‑tracking params preserved). All green.
- **Full suite: 1142 → 1172** (+30). Typecheck **0**. Lint clean. **No migration.**
- **B1 decode location:** `email-content.ts` `decodeQuotedPrintableToBytes` + `decodeBytesWithCharset` + `decodePartBody(body, transferEncoding, charset)`.
- **B3 chrome predicates:** `subscribe_cta` (phrase list), `masthead` (` // `), `photo_credit` (`First Last/Agency$`), `section_header` (label `Set`) — plus the existing bare‑url / boilerplate / postal / tracking‑host / below‑min‑prose.
- **B4 tracking‑unwrap fn:** `normalizeUrl` (param strip) + `TRACKING_HOST_PATTERNS` (TLDR hosts). Full publisher‑resolution: **scoped down** (live‑follow required).
- **B5 findings:** offending path = `signals-editorial.ts:1305` + `compareEditorialHistoryPosts`; root = `promotion.ts:221`. Recommended follow‑up above.
- **Did NOT touch:** publish path, cockpit, render, `published_*`/`edited_*` columns, `final_slate_rank` assignment, validation logic. `#324` atomic insert untouched.

## Checkpoint 2 (your MCP verification, then merge)
After the next clean tick: ranks 1–7 carry **real, well‑formed** titles and the candidate pool is free of mojibake / tracking‑redirect / masthead rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
